### PR TITLE
Improve skill-eval report UX with Rich tables and default run selection

### DIFF
--- a/evals/pyproject.toml
+++ b/evals/pyproject.toml
@@ -15,6 +15,7 @@ skill-eval = "skill_eval.cli:app"
 
 [tool.uv]
 package = true
+default-groups = ["dev"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -24,3 +25,6 @@ dev = [
     "pytest>=8.0",
     "ty>=0.0.1a6",
 ]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]

--- a/evals/src/skill_eval/reporter.py
+++ b/evals/src/skill_eval/reporter.py
@@ -1,8 +1,182 @@
 """Report generation for skill evaluation."""
 
+from collections import Counter, defaultdict
 from pathlib import Path
 
+from rich.console import Console
+from rich.table import Table
+
 from skill_eval.grader import load_grades
+
+
+def _compute_skill_set_stats(results: dict) -> dict[str, dict]:
+    """Compute aggregate statistics per skill set."""
+    # Flatten nested structure into (skill_set_name, data) pairs
+    all_entries = (
+        (skill_set_name, data)
+        for skill_sets in results.values()
+        for skill_set_name, data in skill_sets.items()
+    )
+
+    # Use defaultdict to auto-initialize
+    stats: dict[str, dict] = defaultdict(lambda: {
+        "passed": 0,
+        "total": 0,
+        "scores": [],
+        "tool_usage": Counter(),
+        "skill_usage": [],
+    })
+
+    for skill_set_name, data in all_entries:
+        s = stats[skill_set_name]
+        s["total"] += 1
+        s["passed"] += bool(data.get("success"))
+        if (score := data.get("score")) is not None:
+            s["scores"].append(score)
+        if tool_usage := (data.get("tool_usage") or "").lower():
+            s["tool_usage"][tool_usage] += 1
+        if skills_available := data.get("skills_available", []):
+            s["skill_usage"].append((len(data.get("skills_invoked", [])), len(skills_available)))
+
+    return dict(stats)
+
+
+def print_rich_report(run_dir: Path, console: Console | None = None) -> None:
+    """Print a rich-formatted report to the terminal."""
+    if console is None:
+        console = Console()
+
+    grades = load_grades(run_dir)
+    if not grades or not grades.get("results"):
+        console.print("[red]No grades found. Run `skill-eval grade` first.[/red]")
+        return
+
+    results = grades["results"]
+    run_id = run_dir.name
+
+    # Header
+    console.print()
+    console.print(f"[bold blue]Eval Report:[/bold blue] [cyan]{run_id}[/cyan]")
+    console.print(f"[dim]Graded: {grades.get('graded_at', 'Not yet')} | Grader: {grades.get('grader', 'unknown')}[/dim]")
+    console.print()
+
+    # Summary table
+    skill_set_stats = _compute_skill_set_stats(results)
+
+    summary_table = Table(title="Summary", title_style="bold", box=None, padding=(0, 2))
+    summary_table.add_column("Skill Set", style="cyan", no_wrap=True)
+    summary_table.add_column("Passed", justify="right")
+    summary_table.add_column("Avg Score", justify="right")
+    summary_table.add_column("Tool Usage", justify="center")
+    summary_table.add_column("Skill Usage", justify="right")
+
+    for skill_set_name, stats in sorted(skill_set_stats.items()):
+        passed = stats["passed"]
+        total = stats["total"]
+        pct = (passed / total * 100) if total > 0 else 0
+        scores = stats["scores"]
+        avg_score = sum(scores) / len(scores) if scores else 0
+
+        # Color the pass rate
+        if pct == 100:
+            passed_str = f"[green]{passed}/{total} ({pct:.0f}%)[/green]"
+        elif pct >= 50:
+            passed_str = f"[yellow]{passed}/{total} ({pct:.0f}%)[/yellow]"
+        else:
+            passed_str = f"[red]{passed}/{total} ({pct:.0f}%)[/red]"
+
+        # Color the score (scale is 1-5)
+        if avg_score >= 4:
+            score_str = f"[green]{avg_score:.1f}/5[/green]"
+        elif avg_score >= 3:
+            score_str = f"[yellow]{avg_score:.1f}/5[/yellow]"
+        else:
+            score_str = f"[red]{avg_score:.1f}/5[/red]"
+
+        # Tool usage with colors
+        tool_stats = stats["tool_usage"]
+        tool_str = f"[green]{tool_stats['appropriate']}✓[/green] [yellow]{tool_stats['partial']}~[/yellow] [red]{tool_stats['inappropriate']}✗[/red]"
+
+        # Skill usage
+        skill_usage_data = stats["skill_usage"]
+        if skill_usage_data:
+            total_invoked = sum(x[0] for x in skill_usage_data)
+            total_available = sum(x[1] for x in skill_usage_data)
+            skill_pct = (total_invoked / total_available * 100) if total_available else 0
+            if skill_pct == 100:
+                skill_str = f"[green]{skill_pct:.0f}% ({total_invoked}/{total_available})[/green]"
+            elif skill_pct >= 50:
+                skill_str = f"[yellow]{skill_pct:.0f}% ({total_invoked}/{total_available})[/yellow]"
+            else:
+                skill_str = f"[red]{skill_pct:.0f}% ({total_invoked}/{total_available})[/red]"
+        else:
+            skill_str = "[dim]-[/dim]"
+
+        summary_table.add_row(skill_set_name, passed_str, score_str, tool_str, skill_str)
+
+    console.print(summary_table)
+    console.print()
+
+    # Detailed results by scenario
+    console.print("[bold]By Scenario[/bold]")
+    console.print()
+
+    for scenario_name, skill_sets in sorted(results.items()):
+        console.print(f"  [bold cyan]{scenario_name}[/bold cyan]")
+
+        for skill_set_name, data in sorted(skill_sets.items()):
+            success = data.get("success")
+            score = data.get("score")
+            tool_usage = data.get("tool_usage", "")
+            notes = data.get("notes", "")
+            skills_available = data.get("skills_available", [])
+            skills_invoked = data.get("skills_invoked", [])
+
+            # Status icon and color
+            if success:
+                icon = "[green]✓[/green]"
+            elif success is False:
+                icon = "[red]✗[/red]"
+            else:
+                icon = "[yellow]?[/yellow]"
+
+            # Score with color (scale is 1-5)
+            if score is not None:
+                if score >= 4:
+                    score_str = f"[green]({score}/5)[/green]"
+                elif score >= 3:
+                    score_str = f"[yellow]({score}/5)[/yellow]"
+                else:
+                    score_str = f"[red]({score}/5)[/red]"
+            else:
+                score_str = ""
+
+            # Tool usage
+            tool_str = f" [dim][tools: {tool_usage}][/dim]" if tool_usage else ""
+
+            # Skill usage
+            if skills_available:
+                skill_pct = (len(skills_invoked) / len(skills_available) * 100)
+                skill_str = f" [dim][skills: {skill_pct:.0f}%][/dim]"
+            else:
+                skill_str = ""
+
+            console.print(f"    {icon} [bold]{skill_set_name}[/bold] {score_str}{tool_str}{skill_str}")
+
+            # Notes (truncated to 500 chars for terminal)
+            if notes:
+                truncated = notes[:500] + "..." if len(notes) > 500 else notes
+                console.print(f"      [dim]{truncated}[/dim]")
+
+            # Skills detail (extra indentation to distinguish from skill set)
+            if skills_available:
+                for skill in skills_available:
+                    if skill in skills_invoked:
+                        console.print(f"          [green]✓[/green] [dim]{skill}[/dim]")
+                    else:
+                        console.print(f"          [red]✗[/red] [dim]{skill} (not invoked)[/dim]")
+
+        console.print()
 
 
 def generate_report(run_dir: Path) -> str:
@@ -24,28 +198,10 @@ def generate_report(run_dir: Path) -> str:
         "",
     ]
 
-    skill_set_stats: dict[str, dict] = {}
-    for scenario_name, skill_sets in results.items():
-        for skill_set_name, data in skill_sets.items():
-            if skill_set_name not in skill_set_stats:
-                skill_set_stats[skill_set_name] = {
-                    "passed": 0,
-                    "total": 0,
-                    "scores": [],
-                    "tool_usage": {"appropriate": 0, "partial": 0, "inappropriate": 0},
-                }
+    skill_set_stats = _compute_skill_set_stats(results)
 
-            skill_set_stats[skill_set_name]["total"] += 1
-            if data.get("success"):
-                skill_set_stats[skill_set_name]["passed"] += 1
-            if data.get("score") is not None:
-                skill_set_stats[skill_set_name]["scores"].append(data["score"])
-            tool_usage = data.get("tool_usage", "").lower()
-            if tool_usage in skill_set_stats[skill_set_name]["tool_usage"]:
-                skill_set_stats[skill_set_name]["tool_usage"][tool_usage] += 1
-
-    lines.append("| Skill Set | Passed | Avg Score | Tool Usage |")
-    lines.append("|-----------|--------|-----------|------------|")
+    lines.append("| Skill Set | Passed | Avg Score | Tool Usage | Skill Usage |")
+    lines.append("|-----------|--------|-----------|------------|-------------|")
 
     for skill_set_name, stats in sorted(skill_set_stats.items()):
         passed = stats["passed"]
@@ -55,7 +211,16 @@ def generate_report(run_dir: Path) -> str:
         avg_score = sum(scores) / len(scores) if scores else 0
         tool_stats = stats["tool_usage"]
         tool_str = f"{tool_stats['appropriate']}✓ {tool_stats['partial']}~ {tool_stats['inappropriate']}✗"
-        lines.append(f"| {skill_set_name} | {passed}/{total} ({pct:.0f}%) | {avg_score:.1f} | {tool_str} |")
+        # Compute skill usage summary
+        skill_usage_data = stats["skill_usage"]
+        if skill_usage_data:
+            total_invoked = sum(x[0] for x in skill_usage_data)
+            total_available = sum(x[1] for x in skill_usage_data)
+            skill_pct = (total_invoked / total_available * 100) if total_available else 0
+            skill_str = f"{skill_pct:.0f}% ({total_invoked}/{total_available})"
+        else:
+            skill_str = "-"
+        lines.append(f"| {skill_set_name} | {passed}/{total} ({pct:.0f}%) | {avg_score:.1f}/5 | {tool_str} | {skill_str} |")
 
     lines.append("")
     lines.append("## By Scenario")
@@ -69,13 +234,31 @@ def generate_report(run_dir: Path) -> str:
             score = data.get("score")
             tool_usage = data.get("tool_usage", "")
             notes = data.get("notes", "")
+            skills_available = data.get("skills_available", [])
+            skills_invoked = data.get("skills_invoked", [])
 
             icon = "✓" if success else "❌" if success is False else "?"
-            score_str = f"({score})" if score is not None else ""
+            score_str = f"({score}/5)" if score is not None else ""
             tool_str = f" [tools: {tool_usage}]" if tool_usage else ""
+
+            # Skill usage string
+            if skills_available:
+                skill_pct = (len(skills_invoked) / len(skills_available) * 100) if skills_available else 0
+                skill_str = f" [skills: {skill_pct:.0f}% ({len(skills_invoked)}/{len(skills_available)})]"
+            else:
+                skill_str = ""
+
             notes_str = f" - {notes}" if notes else ""
 
-            lines.append(f"- **{skill_set_name}**: {icon} {score_str}{tool_str}{notes_str}")
+            lines.append(f"- **{skill_set_name}**: {icon} {score_str}{tool_str}{skill_str}{notes_str}")
+
+            # List individual skills with status
+            if skills_available:
+                for skill in skills_available:
+                    if skill in skills_invoked:
+                        lines.append(f"  - ✓ {skill}")
+                    else:
+                        lines.append(f"  - ✗ {skill} (not invoked)")
         lines.append("")
 
     return "\n".join(lines)

--- a/evals/tests/test_cli.py
+++ b/evals/tests/test_cli.py
@@ -1,0 +1,107 @@
+"""Tests for skill_eval CLI."""
+
+from pathlib import Path
+
+import pytest
+from click.exceptions import Exit
+
+from skill_eval.cli import find_run, get_latest_run
+
+
+def test_get_latest_run_returns_most_recent(tmp_path: Path) -> None:
+    """get_latest_run returns the most recently named run directory."""
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "2024-01-01-100000").mkdir()
+    (runs_dir / "2024-01-02-100000").mkdir()
+    (runs_dir / "2024-01-01-150000").mkdir()
+
+    result = get_latest_run(runs_dir)
+
+    assert result.name == "2024-01-02-100000"
+
+
+def test_get_latest_run_ignores_hidden_dirs(tmp_path: Path) -> None:
+    """get_latest_run ignores hidden directories."""
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / ".DS_Store").mkdir()
+    (runs_dir / "2024-01-01-100000").mkdir()
+
+    result = get_latest_run(runs_dir)
+
+    assert result.name == "2024-01-01-100000"
+
+
+def test_get_latest_run_exits_when_no_runs(tmp_path: Path) -> None:
+    """get_latest_run exits with error when no runs exist."""
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+
+    with pytest.raises(Exit):
+        get_latest_run(runs_dir)
+
+
+def test_get_latest_run_exits_when_dir_missing(tmp_path: Path) -> None:
+    """get_latest_run exits with error when runs dir doesn't exist."""
+    runs_dir = tmp_path / "runs"  # Not created
+
+    with pytest.raises(Exit):
+        get_latest_run(runs_dir)
+
+
+def test_find_run_returns_latest_when_none(tmp_path: Path) -> None:
+    """find_run returns latest run when run_id is None."""
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "2024-01-01-100000").mkdir()
+    (runs_dir / "2024-01-02-100000").mkdir()
+
+    result = find_run(runs_dir, None)
+
+    assert result.name == "2024-01-02-100000"
+
+
+def test_find_run_exact_match(tmp_path: Path) -> None:
+    """find_run returns exact match when provided."""
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "2024-01-01-100000").mkdir()
+    (runs_dir / "2024-01-02-100000").mkdir()
+
+    result = find_run(runs_dir, "2024-01-01-100000")
+
+    assert result.name == "2024-01-01-100000"
+
+
+def test_find_run_partial_match(tmp_path: Path) -> None:
+    """find_run returns partial match when unique."""
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "2024-01-01-100000").mkdir()
+    (runs_dir / "2024-02-01-100000").mkdir()
+
+    result = find_run(runs_dir, "01-01")
+
+    assert result.name == "2024-01-01-100000"
+
+
+def test_find_run_exits_on_ambiguous_match(tmp_path: Path) -> None:
+    """find_run exits with error when multiple runs match."""
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "2024-01-01-100000").mkdir()
+    (runs_dir / "2024-01-01-150000").mkdir()
+
+    with pytest.raises(Exit):
+        find_run(runs_dir, "01-01")
+
+
+def test_find_run_exits_on_no_match(tmp_path: Path) -> None:
+    """find_run exits with error when no runs match."""
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "2024-01-01-100000").mkdir()
+
+    with pytest.raises(Exit):
+        find_run(runs_dir, "nonexistent")

--- a/evals/tests/test_reporter.py
+++ b/evals/tests/test_reporter.py
@@ -1,0 +1,90 @@
+"""Tests for skill_eval reporter."""
+
+from skill_eval.reporter import _compute_skill_set_stats
+
+
+def test_compute_skill_set_stats_aggregates_across_scenarios() -> None:
+    """Stats are aggregated per skill set across all scenarios."""
+    results = {
+        "scenario-a": {
+            "set-1": {"success": True, "score": 5, "tool_usage": "appropriate"},
+            "set-2": {"success": False, "score": 2, "tool_usage": "partial"},
+        },
+        "scenario-b": {
+            "set-1": {"success": True, "score": 4, "tool_usage": "appropriate"},
+        },
+    }
+
+    stats = _compute_skill_set_stats(results)
+
+    assert stats["set-1"]["total"] == 2
+    assert stats["set-1"]["passed"] == 2
+    assert stats["set-1"]["scores"] == [5, 4]
+    assert stats["set-2"]["total"] == 1
+    assert stats["set-2"]["passed"] == 0
+
+
+def test_compute_skill_set_stats_counts_tool_usage() -> None:
+    """Tool usage is counted correctly."""
+    results = {
+        "scenario-a": {
+            "set-1": {"tool_usage": "appropriate"},
+        },
+        "scenario-b": {
+            "set-1": {"tool_usage": "appropriate"},
+        },
+        "scenario-c": {
+            "set-1": {"tool_usage": "partial"},
+        },
+    }
+
+    stats = _compute_skill_set_stats(results)
+
+    assert stats["set-1"]["tool_usage"]["appropriate"] == 2
+    assert stats["set-1"]["tool_usage"]["partial"] == 1
+    assert stats["set-1"]["tool_usage"]["inappropriate"] == 0
+
+
+def test_compute_skill_set_stats_tracks_skill_usage() -> None:
+    """Skill usage is tracked as (invoked, available) tuples."""
+    results = {
+        "scenario-a": {
+            "set-1": {
+                "skills_available": ["skill-a", "skill-b"],
+                "skills_invoked": ["skill-a"],
+            },
+        },
+        "scenario-b": {
+            "set-1": {
+                "skills_available": ["skill-a"],
+                "skills_invoked": ["skill-a"],
+            },
+        },
+    }
+
+    stats = _compute_skill_set_stats(results)
+
+    assert stats["set-1"]["skill_usage"] == [(1, 2), (1, 1)]
+
+
+def test_compute_skill_set_stats_handles_missing_fields() -> None:
+    """Missing fields are handled gracefully."""
+    results = {
+        "scenario-a": {
+            "set-1": {},  # No fields at all
+        },
+    }
+
+    stats = _compute_skill_set_stats(results)
+
+    assert stats["set-1"]["total"] == 1
+    assert stats["set-1"]["passed"] == 0
+    assert stats["set-1"]["scores"] == []
+    assert stats["set-1"]["skill_usage"] == []
+
+
+def test_compute_skill_set_stats_handles_empty_results() -> None:
+    """Empty results return empty stats."""
+    stats = _compute_skill_set_stats({})
+
+    assert stats == {}


### PR DESCRIPTION
## Summary

- Add Rich-formatted terminal output for reports with colored tables and proper alignment
- Make `run_id` optional for `grade` and `report` commands (defaults to latest run)
- Show scores with `/5` scale for clarity (e.g., `4.0/5` instead of `4.0`)
- Add skill usage tracking to report output
- Refactor `find_run` helper to handle optional run_id