### PR TITLE
docs: clarify version requirements for new semantic layer spec

### DIFF
--- a/skills/building-dbt-semantic-layer/SKILL.md
+++ b/skills/building-dbt-semantic-layer/SKILL.md
@@ -21,7 +21,7 @@ This skill guides the creation and modification of dbt Semantic Layer components
 - [Best Practices](references/best-practices.md) - Design patterns and recommendations for semantic models and metrics
 
 > [!NOTE]
-This skill contains guidance for the new dbt semantic layer YAML spec, valid for dbt 1.12.0 and above. If the user is using a different version of dbt, you can use the [migration guide](https://docs.getdbt.com/docs/build/latest-metrics-spec) to help them migrate to the new spec and add new components to their semantic layer. Ask the user if they want to migrate to the new spec before proceeding.
+> This skill contains guidance for the new dbt semantic layer YAML spec, which requires either **dbt 1.12+** or the **dbt Fusion engine**. If the user is using a different version of dbt, you can use the [migration guide](https://docs.getdbt.com/docs/build/latest-metrics-spec) to help them migrate to the new spec and add new components to their semantic layer. Ask the user if they want to migrate to the new spec before proceeding.
 
 ## Entry Points
 


### PR DESCRIPTION
## Summary
- Clarified that the new semantic layer YAML spec requires either **dbt 1.12+** or the **dbt Fusion engine**

## Test plan
- [ ] Verify the NOTE renders correctly in markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)