### PR TITLE
Add logging, timeout handling, and TUI improvements to skill-eval

### DIFF
--- a/evals/AGENTS.md
+++ b/evals/AGENTS.md
@@ -10,7 +10,9 @@ src/skill_eval/
 ├── models.py    # Data models: Scenario, SkillSet, load_scenario()
 ├── runner.py    # Execution: Runner class, RunResult, RunTask
 ├── grader.py    # Auto-grading with Claude CLI
-└── reporter.py  # Report generation from grades
+├── reporter.py  # Report generation from grades
+├── selector.py  # Interactive TUI selectors for runs/scenarios
+└── logging.py   # Loguru configuration with context support
 ```
 
 **Data flow:** `cli.py` loads scenarios via `models.py`, executes via `runner.py`, grades via `grader.py`, and reports via `reporter.py`.
@@ -19,18 +21,31 @@ src/skill_eval/
 
 We use [Typer](https://typer.tiangolo.com/) for the CLI.
 
-### Output with typer.echo()
+### Output
 
-Always use `typer.echo()` for user-facing output, never `print()`:
+Use the appropriate output method based on context:
 
+**User-facing CLI output** (command results, prompts): Use `typer.echo()`
 ```python
-# Good
-typer.echo(f"Running scenario: {name}")
+typer.echo(f"Run directory: {run_dir}")
 typer.echo("Error: file not found", err=True)
-
-# Bad
-print(f"Running scenario: {name}")
 ```
+
+**Progress logging** (during execution): Use `logger` from `logging.py`
+```python
+from skill_eval.logging import logger
+
+logger.info("Starting scenario")
+logger.debug("Tool called: Read")
+logger.warning("Timeout reached")
+logger.success("Completed")
+
+# With context (for parallel runs)
+ctx_logger = logger.bind(scenario="my-scenario", skill_set="with-skill")
+ctx_logger.info("Starting")  # Shows: [T0/my-scenario/with-skill] Starting
+```
+
+Never use `print()` for output.
 
 ### Adding Commands
 
@@ -157,6 +172,8 @@ Key dependencies in `pyproject.toml`:
 - `typer` - CLI framework
 - `pyyaml` - YAML parsing
 - `claude-code-transcripts` - HTML transcript generation
+- `loguru` - Logging with context support
+- `textual` - TUI for interactive selection
 
 Dev dependencies:
 - `pytest` - testing

--- a/evals/CLAUDE.md
+++ b/evals/CLAUDE.md
@@ -3,7 +3,7 @@
 See [AGENTS.md](AGENTS.md) for development conventions.
 
 Quick reference:
-- Use `typer.echo()` not `print()`
+- Use `typer.echo()` for CLI output, `logger` from `logging.py` for progress
 - Run `uv run ty check src/` before committing
 - Add tests for new features
 - Check dataclasses in `models.py` and `runner.py` when modifying commands

--- a/evals/README.md
+++ b/evals/README.md
@@ -23,6 +23,9 @@ uv run skill-eval run <scenario-name> --parallel      # single scenario, paralle
 uv run skill-eval run --all --parallel                # all scenarios, all skill-sets in parallel
 uv run skill-eval run --all --parallel --workers 8    # custom worker count (default: 4)
 
+# Verbose mode (shows tool calls and skill invocations)
+uv run skill-eval run <scenario-name> --verbose       # or -v
+
 # Review transcripts in browser (opens HTML files)
 uv run skill-eval review              # latest run
 uv run skill-eval review <run-id>     # specific run
@@ -55,7 +58,7 @@ evals/
 │               ├── output.md       # Full conversation text
 │               ├── metadata.yaml   # Run metrics and tool usage
 │               ├── raw.jsonl       # Complete NDJSON stream
-│               ├── context/        # Modified files after run
+│               ├── changes/        # Files modified during the run
 │               └── transcript/     # HTML conversation viewer
 ├── reports/                # Generated comparison reports
 └── src/skill_eval/         # CLI source code
@@ -260,9 +263,9 @@ input_tokens: 125241
 output_tokens: 1177
 ```
 
-### context/
+### changes/
 
-The modified working directory after the run (excluding `.claude/`). Useful for verifying what changes Claude made to files.
+Files that were modified or created during the run. Only includes files that differ from the original context (excluding `.claude/`). Useful for verifying what changes Claude made.
 
 ### raw.jsonl
 
@@ -271,6 +274,15 @@ Complete NDJSON (newline-delimited JSON) stream from Claude for debugging.
 ### transcript/
 
 HTML files for viewing the conversation in a browser. Open `index.html` to view, with paginated content in `page-XXX.html` files. In VS Code, you can use the [Live Preview](https://marketplace.visualstudio.com/items?itemName=ms-vscode.live-server) extension to view these directly in the editor.
+
+## Timeouts and Stall Detection
+
+Each run has built-in safeguards:
+
+- **Total timeout**: 10 minutes maximum per skill-set run
+- **Stall detection**: Kills the run if no output for 60 seconds (e.g., waiting for permission approval)
+
+Stall detection helps catch runs that get stuck waiting for tool approval when using `allowed_tools` restrictions.
 
 ## Workflow
 
@@ -300,7 +312,7 @@ The grader receives:
 - Grading criteria (`scenario.md`)
 - Assistant's response (`output.md`)
 - Tools used, skills available/invoked, MCP servers (`metadata.yaml`)
-- Modified files (`context/`)
+- Modified files (`changes/`)
 
 Output grades include:
 - `success`: true/false

--- a/evals/pyproject.toml
+++ b/evals/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "typer>=0.9.0",
     "claude-code-transcripts>=0.5.0",
     "textual>=0.47.0",
+    "loguru>=0.7.0",
 ]
 
 [project.scripts]

--- a/evals/src/skill_eval/logging.py
+++ b/evals/src/skill_eval/logging.py
@@ -1,0 +1,63 @@
+"""Logging configuration for skill-eval."""
+
+import sys
+import threading
+from typing import Any
+
+from loguru import logger
+
+# Custom format function to include context when available
+def _format_record(record: Any) -> str:
+    """Format log record with optional context (scenario, skill_set, thread)."""
+    extra = record.get("extra", {})
+
+    # Build context prefix
+    context_parts = []
+    if "scenario" in extra:
+        context_parts.append(extra["scenario"])
+    if "skill_set" in extra:
+        context_parts.append(extra["skill_set"])
+
+    # Add thread number for parallel runs
+    thread_id = threading.current_thread().name
+    if thread_id != "MainThread":
+        # Extract thread number from ThreadPoolExecutor naming (e.g., "ThreadPoolExecutor-0_1")
+        if "_" in thread_id:
+            thread_num = thread_id.split("_")[-1]
+            context_parts.insert(0, f"T{thread_num}")
+
+    context = "/".join(context_parts)
+    context_str = f"<cyan>[{context}]</cyan> " if context else ""
+
+    return (
+        "<dim>{time:HH:mm:ss}</dim> | "
+        "<level>{level: <7}</level> | "
+        f"{context_str}"
+        "{message}\n"
+    )
+
+
+# Remove default handler
+logger.remove()
+
+# Add custom handler
+logger.add(
+    sys.stderr,
+    format=_format_record,
+    level="INFO",
+    colorize=True,
+)
+
+
+def set_level(level: str) -> None:
+    """Set the logging level."""
+    logger.remove()
+    logger.add(
+        sys.stderr,
+        format=_format_record,
+        level=level.upper(),
+        colorize=True,
+    )
+
+
+__all__ = ["logger", "set_level"]

--- a/evals/tests/test_selector.py
+++ b/evals/tests/test_selector.py
@@ -21,14 +21,17 @@ class TestRunInfo:
         """RunInfo.from_path creates info from a run directory."""
         run_dir = tmp_path / "2024-01-15-120000"
         run_dir.mkdir()
-        (run_dir / "scenario1").mkdir()
-        (run_dir / "scenario2").mkdir()
+        # Create scenarios with skill sets inside
+        (run_dir / "scenario1" / "set-a").mkdir(parents=True)
+        (run_dir / "scenario1" / "set-b").mkdir(parents=True)
+        (run_dir / "scenario2" / "set-a").mkdir(parents=True)
 
         info = RunInfo.from_path(run_dir)
 
         assert info.path == run_dir
         assert info.name == "2024-01-15-120000"
         assert info.scenario_count == 2
+        assert info.skill_set_count == 3
         assert info.graded is False
 
     def test_from_path_with_grades(self, tmp_path: Path) -> None:
@@ -46,24 +49,26 @@ class TestRunInfo:
         run_dir = tmp_path / "2024-01-15-120000"
         run_dir.mkdir()
         (run_dir / ".hidden").mkdir()
-        (run_dir / "scenario1").mkdir()
+        (run_dir / "scenario1" / "set-a").mkdir(parents=True)
 
         info = RunInfo.from_path(run_dir)
 
         assert info.scenario_count == 1
+        assert info.skill_set_count == 1
 
     def test_display_text_all_fields(self, tmp_path: Path) -> None:
         """display_text shows all available information."""
         run_dir = tmp_path / "2024-01-15-120000"
         run_dir.mkdir()
-        (run_dir / "scenario1").mkdir()
+        (run_dir / "scenario1" / "set-a").mkdir(parents=True)
         (run_dir / "grades.yaml").write_text("graded_at: 2024-01-15")
 
         info = RunInfo.from_path(run_dir)
         display = info.display_text()
 
         assert "2024-01-15-120000" in display
-        assert "1 scenario(s)" in display
+        assert "1 scenarios" in display
+        assert "1 sets" in display
         assert "graded" in display
 
     def test_display_text_minimal(self, tmp_path: Path) -> None:
@@ -75,9 +80,9 @@ class TestRunInfo:
         display = info.display_text()
 
         assert "2024-01-15-120000" in display
-        assert "0 scenario(s)" in display
+        assert "0 scenarios" in display
+        assert "0 sets" in display
         assert "graded" not in display
-        assert "$" not in display
 
 
 class TestScenarioInfo:

--- a/evals/uv.lock
+++ b/evals/uv.lock
@@ -246,6 +246,19 @@ wheels = [
 ]
 
 [[package]]
+name = "loguru"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
+]
+
+[[package]]
 name = "markdown"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -539,6 +552,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "claude-code-transcripts" },
+    { name = "loguru" },
     { name = "pyyaml" },
     { name = "textual" },
     { name = "typer" },
@@ -554,6 +568,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "claude-code-transcripts", specifier = ">=0.5.0" },
+    { name = "loguru", specifier = ">=0.7.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "textual", specifier = ">=0.47.0" },
     { name = "typer", specifier = ">=0.9.0" },
@@ -701,4 +716,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/30/6b0809f4510673dc723187aeaf24c7f5459922d01e2f794277a3dfb90345/wcwidth-0.2.14.tar.gz", hash = "sha256:4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605", size = 102293, upload-time = "2025-09-22T16:29:53.023Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/b5/123f13c975e9f27ab9c0770f514345bd406d0e8d3b7a0723af9d43f710af/wcwidth-0.2.14-py2.py3-none-any.whl", hash = "sha256:a7bb560c8aee30f9957e5f9895805edd20602f2d7f720186dfd906e82b4982e1", size = 37286, upload-time = "2025-09-22T16:29:51.641Z" },
+]
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
 ]


### PR DESCRIPTION
## Summary

- Add loguru-based logging with context support (thread number, scenario, skill_set)
- Add `--verbose` flag for detailed progress output (tool calls, skill invocations)
- Add 10-minute timeout and 60-second stall detection to catch stuck runs
- Improve TUI run picker to show scenario names and skill-set counts
- Fix TUI scenario selector so Enter confirms selection
- Capture transcript library output into debug logs
- Update documentation (README, AGENTS.md, CLAUDE.md) to reflect current state

## Test plan

- [x] All 115 tests pass
- [x] Type checking passes (`uv run ty check src/`)
- [x] Manual test: `uv run skill-eval run --all --verbose` shows tool calls
- [x] Manual test: Run picker shows scenario details