### PR TITLE
Change aggregation function name from 'avg' to 'average'

### DIFF
--- a/skills/building-dbt-semantic-layer/SKILL.md
+++ b/skills/building-dbt-semantic-layer/SKILL.md
@@ -173,7 +173,7 @@ models:
 
       - name: average_order_value
         type: simple
-        agg: avg
+        agg: average
         expr: amount
 ```
 


### PR DESCRIPTION
According to dbt docs, the supported agg type should be average, not avg. https://docs.getdbt.com/docs/build/semantic-models#measures

When using the existing skill, the agent produced a metrics with agg: avg which causes an error: 

```
error: dbt1013: YAML error: unknown variant `avg`, expected one of `sum`, `min`, `max`, `count_distinct`, `sum_boolean`, `average`, `percentile`, `median`, `count`
  --> models/marts/_schema.yml:242:14
```

resolves #41 

### Description

Update the example to include the valid `agg: average` value

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-oss-template/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-oss-template/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
