### PR TITLE
Update SL skill to include old spec too

### DIFF
--- a/skills/building-dbt-semantic-layer/references/best-practices.md
+++ b/skills/building-dbt-semantic-layer/references/best-practices.md
@@ -56,12 +56,12 @@ Every metric needs: `name`, `description`, `label`, and `type`
 dbt parse
 
 # List available dimensions for a metric
-dbt sl list dimensions --metrics <metric_name>   # dbt Cloud CLI
+dbt sl list dimensions --metrics <metric_name>   # dbt Cloud CLI / Fusion CLI when using the dbt platform
 mf list dimensions --metrics <metric_name>       # MetricFlow CLI
 
 # Test metric queries
-dbt sl query --metrics <metric_name> --group-by <dimension>   # dbt Cloud CLI
-mf query --metrics <metric_name> --group-by <dimension>       # MetricFlow CLI
+dbt sl query --metrics <metric_name> --group-by <dimension>
+mf query --metrics <metric_name> --group-by <dimension>
 ```
 
 ## What to Avoid

--- a/skills/building-dbt-semantic-layer/references/latest-spec.md
+++ b/skills/building-dbt-semantic-layer/references/latest-spec.md
@@ -4,6 +4,16 @@ This is the authoring guide for the **latest** dbt Semantic Layer YAML spec, sup
 
 In the latest spec, semantic models are configured as metadata annotations on your dbt models rather than as separate top-level resources. Measures are replaced by simple metrics defined directly within models.
 
+## Contents
+
+- Implementation Workflow (Steps 1-4: enable semantic model, entities, dimensions, metrics)
+- YAML Format Reference (derived semantics, simple metric options, advanced metrics)
+- Advanced Metrics (derived, cumulative, ratio, conversion)
+- Cross-Model (Top-Level) Metrics
+- SCD Type II Dimensions
+- Key Formatting Rules
+- Common Pitfalls
+
 ## Implementation Workflow
 
 ### Step 1: Enable Semantic Model

--- a/skills/building-dbt-semantic-layer/references/legacy-spec.md
+++ b/skills/building-dbt-semantic-layer/references/legacy-spec.md
@@ -4,6 +4,15 @@ This is the authoring guide for the **legacy** dbt Semantic Layer YAML spec, sup
 
 In the legacy spec, semantic models are defined as top-level resources separate from dbt model definitions. Measures are a core concept used as building blocks for metrics.
 
+## Contents
+
+- Implementation Workflow (Steps 1-4: semantic model, entities, dimensions, measures/metrics)
+- YAML Format Reference (complete spec, measure properties, percentile, non-additive dimensions)
+- Metrics (simple, derived, cumulative, ratio, conversion)
+- SCD Type II Dimensions
+- Key Formatting Rules
+- Common Pitfalls
+
 ## Implementation Workflow
 
 ### Step 1: Define Semantic Model

--- a/skills/building-dbt-semantic-layer/references/time-spine.md
+++ b/skills/building-dbt-semantic-layer/references/time-spine.md
@@ -15,7 +15,9 @@ A time spine is essential for time-based joins and aggregations in MetricFlow. I
 
 ### 1. Create the Time Spine Model
 
-Create `models/marts/time_spine_daily.sql`:
+Create `models/marts/time_spine_daily.sql`.
+
+**Using `dbt.date_spine` macro** (when supported by your adapter):
 
 ```sql
 {{
@@ -47,6 +49,8 @@ from final
 where date_day > dateadd(year, -5, current_date())
   and date_day < dateadd(day, 30, current_date())
 ```
+
+> **Note**: `dbt.date_spine()` is not available for all adapters. If the macro isn't supported, use raw SQL with `generate_series` or your warehouse's equivalent date generation function instead.
 
 ### 2. Configure YAML for MetricFlow
 


### PR DESCRIPTION
### Description
Restructures the skill to handle the old spec (dbt Core v1.6 through v1.11), and the new one (Fusion and the forthcoming 1.12):
- entry point includes guidance on which version of the spec to use
- The main skill file no longer contains any example code, it points to a spec file for the correct one
- update the best practice guide to be generic across the two (Docs team has not yet updated the "how we do SL" guide for the new spec)

Things I'm not clear on: 
1. **Validation commands**: Are `dbt sl validate` and `mf validate-configs` correct for both specs? Specifically, does Fusion expose validation via `dbt sl validate`? (I don't think it does)
2. **Jinja filter template format**: Is the `{{ Dimension('entity__dim') }}`, `{{ Entity('...') }}`, `{{ TimeDimension('...', '...') }}`, `{{ Metric('...') }}` syntax identical across both specs?

Discrepancies claude found in the docs:
1. **Non-additive dimensions in latest spec**: The dbt docs don't show a `non_additive_dimension` example for the latest spec. The simple metric parameter table lists it. Need to confirm the syntax.
2. **Percentile in latest spec**: The simple metric parameter table shows `percentile` and `percentile_type` as direct keys. Need to confirm no `agg_params` wrapper is needed.