### PR TITLE
Add top-level Additional Resources sections to skills

### DIFF
--- a/skills/adding-dbt-unit-test/SKILL.md
+++ b/skills/adding-dbt-unit-test/SKILL.md
@@ -8,6 +8,22 @@ metadata:
 
 # Add unit test for a dbt model
 
+## Additional Resources
+
+- [Spec Reference](references/spec.md) - All required and optional YAML keys for unit tests
+- [Examples](references/examples.md) - Unit test examples across formats (dict, csv, sql)
+- [Incremental Models](references/special-cases-incremental-model.md) - Unit testing incremental models
+- [Ephemeral Dependencies](references/special-cases-ephemeral-dependency.md) - Unit testing models depending on ephemeral models
+- [Special Case Overrides](references/special-cases-special-case-overrides.md) - Introspective macros, project variables, environment variables
+- [Versioned Models](references/special-cases-versioned-model.md) - Unit testing versioned SQL models
+- [BigQuery Caveats](references/warehouse-bigquery-caveats.md) - BigQuery-specific caveats
+- [BigQuery Data Types](references/warehouse-bigquery-data-types.md) - BigQuery data type handling
+- [Postgres Data Types](references/warehouse-postgres-data-types.md) - Postgres data type handling
+- [Redshift Caveats](references/warehouse-redshift-caveats.md) - Redshift-specific caveats
+- [Redshift Data Types](references/warehouse-redshift-data-types.md) - Redshift data type handling
+- [Snowflake Data Types](references/warehouse-snowflake-data-types.md) - Snowflake data type handling
+- [Spark Data Types](references/warehouse-spark-data-types.md) - Spark data type handling
+
 ## What are unit tests in dbt
 
 In software programming, unit tests validate small portions of your functional code, and they work much the same way in dbt. dbt unit tests allow you to validate your SQL modeling logic on a small set of static inputs _before_ you materialize your full model in production. dbt unit tests enable test-driven development, benefiting developer efficiency and code reliability.

--- a/skills/migrating-dbt-core-to-fusion/SKILL.md
+++ b/skills/migrating-dbt-core-to-fusion/SKILL.md
@@ -12,6 +12,12 @@ dbt Fusion is dbt Labs' next-generation engine for parsing, compiling, and runni
 
 **Success criteria**: Migration is complete when `dbtf compile` finishes with 0 errors.
 
+## Additional Resources
+
+- [Custom Configuration](references/custom_configuration.md) - Moving custom config keys to `meta` block
+- [Dynamic SQL Patterns](references/dynamic_sql.md) - Resolving dynamic SQL compatibility issues
+- [Misspelled Config Keys](references/misspelled_config_keys.md) - Fixing misspelled config keys
+
 ## Migration Workflow
 
 ### Progress Checklist


### PR DESCRIPTION
## Summary
- Adds an "Additional Resources" section near the top of `adding-dbt-unit-test` and `migrating-dbt-core-to-fusion` skills
- Follows [agent skills best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) for progressive disclosure — all reference files are now discoverable upfront without reading through the entire skill
- Inline links deeper in each skill are preserved as contextual pointers