### PR TITLE
Fix CODEOWNERS check: use ubuntu-latest runner

### DIFF
--- a/.github/workflows/codeowners-check.yml
+++ b/.github/workflows/codeowners-check.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   validate-codeowners:
     if: github.actor != 'dependabot[bot]'
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6
       - uses: mszostok/codeowners-validator@7f3f5e28c6d7b8dfae5731e54ce2272ca384592f #v0.7.4


### PR DESCRIPTION
## Summary
- Switches `runs-on` from `depot-ubuntu-24.04` to `ubuntu-latest` in the CODEOWNERS validation workflow
- The Depot runner is not provisioned for this repo, causing every run to time out after 24h waiting for a runner
- All recent runs are stuck in `queued`: https://github.com/dbt-labs/dbt-agent-skills/actions/workflows/codeowners-check.yml

## Test plan
- [ ] Verify this PR's own CODEOWNERS check passes on `ubuntu-latest`