### PR TITLE
fix: correct tile publish action

### DIFF
--- a/.changes/unreleased/Under the Hood-20260220-103318.yaml
+++ b/.changes/unreleased/Under the Hood-20260220-103318.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Publish Tiles only on merge / push to main
+time: 2026-02-20T10:33:18.631512Z
+custom:
+    Author: robcresswell
+    Issue: "75"

--- a/.github/workflows/publish-tile.yml
+++ b/.github/workflows/publish-tile.yml
@@ -1,11 +1,10 @@
 name: Publish Tessl Tile
 
 permissions:
-  id-token: write  # Required for OIDC token
-  contents: read  # Required to checkout the repository
+  id-token: write # Required for OIDC token
+  contents: read # Required to checkout the repository
 
 on:
-  pull_request:
   push:
     branches:
       - main
@@ -14,7 +13,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: tesslio/publish@a85d5126aedcc671a042364ffe48d60593365f7a  # latest commit as-of 2026-02-18
+      - uses: actions/checkout@v6
+      - uses: tesslio/publish@3ebebcd042bd9d3851b6940ebec376fd6d5dee84 # latest commit as of 2026-02-20
         with:
           token: ${{ secrets.TESSL_API_TOKEN }}


### PR DESCRIPTION
The action example in https://github.com/tesslio/publish listed `pull_request`; I'd intended this to be a placeholder and hadn't cleaned it up. This will cause a publish on every PR I believe, when what you probably want is on push / merge to `main`. I've fixed the example, and this patch fixes it here too.

I've also bumped `checkout` to align with the latest version, and updated the publish SHA to latest (although the only changes are minor `README` updates)

resolves #75

 
