### PR TITLE
Improve skills: unit tests, semantic layer, commands, mesh, migration, mermaid DAG

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,9 @@ description: Brief one-sentence description starting with "Use when..."
 **Critical Rules**:
 - `name` MUST be lowercase with hyphens only (letters, digits, hyphens)
 - `name` MUST match the directory name exactly
-- Only allowed fields: `name`, `description`, `allowed-tools`, `compatibility`, `license`, `metadata`
+- Only allowed fields: `name`, `description`, `allowed-tools`, `compatibility`, `license`, `metadata`, `user-invocable`
 - NO `version`, `author`, or `tags` fields (these will cause validation errors if not put inside `metadata:`
+- `user-invocable: false` must be at the **top level**, not nested inside `metadata:`
 
 ## Common Validation Errors
 

--- a/skills/dbt-extras/.claude-plugin/plugin.json
+++ b/skills/dbt-extras/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dbt-extras",
   "description": "Miscellaneous skills for dbt.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "dbt Labs"
   },

--- a/skills/dbt-extras/skills/creating-mermaid-dbt-dag/SKILL.md
+++ b/skills/dbt-extras/skills/creating-mermaid-dbt-dag/SKILL.md
@@ -2,7 +2,7 @@
 name: creating-mermaid-dbt-dag
 description: Generates a Mermaid flowchart diagram of dbt model lineage using MCP tools, manifest.json, or direct code parsing as fallbacks. Use when visualizing dbt model lineage and dependencies as a Mermaid diagram in markdown format.
 user-invocable: false
-allowed-tools: "mcp__dbt__get_lineage_dev, mcp__dbt__get_lineage"
+allowed-tools: "mcp__dbt__get_lineage_dev, mcp__dbt__get_lineage, Read, Glob, Grep, Bash(jq *)"
 metadata:
   author: dbt-labs
 ---
@@ -54,16 +54,17 @@ Follow this hierarchy. Use the first available method:
 ## Formatting Guidelines
 
 - Use the `graph LR` directive to define a left-to-right graph.
-- Color nodes as follows:
-  - selected node: Purple
+- Color nodes by **resource type first**, with "selected node" meaning the focal model the user requested lineage for:
   - source nodes: Blue
-  - staging nodes: Bronze
-  - intermediate nodes: Silver
-  - mart nodes: Gold
+  - staging nodes (stg_*): Bronze
+  - intermediate nodes (int_*): Silver
+  - mart / fact / dimension nodes: Gold
   - seeds: Green
   - exposures: Orange
   - tests: Yellow
+  - selected/focal node (the specific model whose lineage was requested): Purple — only use this when a specific model was identified as the focal point by an MCP tool
   - undefined nodes: Grey
+- **Important**: When generating a diagram from a user's description (not via MCP tools), color nodes by resource type only — do not designate any node as "selected" unless an MCP tool explicitly identified it as such.
 - Represent each model as a node in the graph.
 - Include a legend explaining the color coding used in the diagram.
 - Make sure the text contrasts well with the background colors for readability.

--- a/skills/dbt-migration/.claude-plugin/plugin.json
+++ b/skills/dbt-migration/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dbt-migration",
   "description": "Skills for migrating dbt projects — moving from dbt Core to the Fusion engine or across data platforms.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "author": {
     "name": "dbt Labs"
   },

--- a/skills/dbt-migration/skills/migrating-dbt-core-to-fusion/SKILL.md
+++ b/skills/dbt-migration/skills/migrating-dbt-core-to-fusion/SKILL.md
@@ -128,6 +128,7 @@ Use the 4-category framework to triage errors. For the full pattern catalog see 
 **Can fix automatically with HIGH confidence**
 
 - Quote nesting in config (dbt1000) — use single quotes outside: `warn_if='{{ "text" }}'`
+- Static analysis errors in `analyses/` files (dbt0209, dbt0404, or other codes < 1000) — analyses are optional query files, not production models. The correct fix is to add `{{ config(static_analysis='off') }}` at the top of the analysis SQL file. Do **not** rewrite the SQL or remove content — just disable static analysis for that file.
 
 ### Category B: Guided Fixes (Need Approval)
 **Can fix with user approval — show diffs first**
@@ -163,7 +164,7 @@ When an error is Category D:
 
 Category D signals:
 - Fusion engine gaps — MiniJinja differences, parser gaps, missing implementations, wrong materialization dispatch
-- Known GitHub issues — check `github.com/dbt-labs/dbt-fusion/issues`
+- Known GitHub issues — **always search proactively**: use `WebFetch` with URL `https://api.github.com/search/issues?q=repo:dbt-labs/dbt-fusion+<error_code>+<keywords>&type=issues` to find existing issues. Don't tell the user to search manually — do it yourself.
 - Engine crashes — `panic!`, `internal error`, `RUST_BACKTRACE`
 - Adapter methods not implemented — `not yet implemented: Adapter::method`
 

--- a/skills/dbt-migration/skills/migrating-dbt-project-across-platforms/SKILL.md
+++ b/skills/dbt-migration/skills/migrating-dbt-project-across-platforms/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: migrating-dbt-project-across-platforms
 description: Use when migrating a dbt project from one data platform or data warehouse to another (e.g., Snowflake to Databricks, Databricks to Snowflake) using dbt Fusion's real-time compilation to identify and fix SQL dialect differences.
+user-invocable: false
 metadata:
   author: dbt-labs
 ---

--- a/skills/dbt/.claude-plugin/plugin.json
+++ b/skills/dbt/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dbt",
   "description": "Skills for analytics engineering with dbt — building models, writing tests, querying the semantic layer, troubleshooting jobs, and more.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "dbt Labs"
   },

--- a/skills/dbt/.cursor-plugin/plugin.json
+++ b/skills/dbt/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "dbt",
   "displayName": "dbt",
   "description": "Agent skills for dbt: data modeling, analytics engineering, semantic layer metrics, unit testing, job troubleshooting, and dbt MCP server setup. Covers dbt Core and dbt Cloud workflows.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "dbt Labs"
   },

--- a/skills/dbt/skills/adding-dbt-unit-test/SKILL.md
+++ b/skills/dbt/skills/adding-dbt-unit-test/SKILL.md
@@ -90,6 +90,28 @@ dbt show --select upstream_model --limit 5
   - See the "Data `format`s for unit tests" section below to determine which `format` to use.
 - The mock data only needs include the subset of columns used within this test case.
 
+### 4. Ensure upstream models exist before running
+
+**Unit tests require direct parent models to exist in the warehouse.** Before running unit tests standalone (`dbt test`), verify that upstream models already exist first:
+
+```bash
+# Check if upstream models exist in the warehouse
+dbt list --select +my_model --exclude my_model --resource-type model
+# Then verify the tables/views actually exist in the warehouse via dbt show or your SQL client
+dbt show --select upstream_model --limit 1
+```
+
+If upstream models **do not exist**, or **exist but have been modified and not yet refreshed**, build them using `--empty` to create schema-only versions:
+
+```bash
+# Build upstream models cheaply (schema only, no data read)
+dbt run --select +my_model --exclude my_model --empty
+```
+
+> **Warning:** `--empty` overwrites existing models with schema-only (zero-row) versions. Only use it when models don't exist yet, or when schema changes need to be applied. Do not use it if upstream models contain data you want to preserve — it will wipe that data.
+
+Skip this step if using `dbt build --select my_model` (recommended) — it handles the full pipeline including unit tests.
+
 ## Minimal unit test
 
 Suppose you have this model:
@@ -252,6 +274,31 @@ unit_tests:
 
 # Data `format`s for unit tests
 
+## **`dict` is the default format** — always start here
+
+Unless you have a specific reason to use another format, use `dict` (inline YAML). It is the default when `format:` is omitted.
+
+```yaml
+given:
+  - input: ref('orders')
+    # no format: key needed — dict is the default
+    rows:
+      - {order_id: 1, status: completed, amount: 100}
+      - {order_id: 2, status: pending, amount: 50}
+```
+
+## How to choose the `format`
+
+| Use `dict` (default) | Use `sql` | Use `csv` |
+|---------------------|-----------|-----------|
+| Everything else — this is the starting point | Model depends on an **ephemeral** model | Using an external fixture file |
+| | Column data type not supported by dict/csv | Column data type not supported by dict |
+| | External fixture file with unsupported types | |
+
+**Critical `sql` note**: `sql` format requires specifying **ALL columns** in the mock data. `dict` and `csv` only require the columns relevant to the test — much more concise.
+
+**Critical `sql` requirement**: If any of your model's `ref()` or `source()` inputs are ephemeral models, you **must** use `sql` format for those inputs. `dict` and `csv` will fail.
+
 dbt supports three formats for mock data within unit tests:
 
 1. `dict` (default): Inline YAML dictionary values.
@@ -259,14 +306,6 @@ dbt supports three formats for mock data within unit tests:
 3. `sql`: Inline SQL query or a SQL file.
 
 To see examples of each of the formats, see [references/examples.md](references/examples.md)
-
-## How to choose the `format`
-
-- Use the `dict` format by default, but fall back to another format as-needed.
-- Use the `sql` format when testing a model that depends on an `ephemeral` model
-- Use the `sql` format when unit testing a column whose data type is not supported by the `dict` or `csv` formats.
-- Use the `csv` or `sql` formats when using a fixture file. Default to `csv`, but fallback to `sql` if any of the column data types are not supported by the `csv` format.
-- The `sql` format is the least readable and requires suppling mock data for _all_ columns, so prefer other formats when possible. But it is also the most flexible, and should be used as the fallback in scenarios where `dict` or `csv` won't work.
 
 Notes:
 - For the `sql` format you must supply mock data for _all columns_ whereas `dict` and `csv` may supply only a subset.

--- a/skills/dbt/skills/building-dbt-semantic-layer/SKILL.md
+++ b/skills/dbt/skills/building-dbt-semantic-layer/SKILL.md
@@ -55,6 +55,69 @@ Look for existing semantic layer configuration in the project:
 
 Once you know which spec to use, follow the corresponding guide's implementation workflow (Steps 1-4) for all YAML authoring. The guides are self-contained with full examples.
 
+**Minimal latest spec example** (dbt Core 1.12+ / Fusion) — use this as your starting point to avoid guessing the structure:
+
+```yaml
+# models/fct_orders.yml
+models:
+  - name: fct_orders
+    semantic_model:
+      agg_time_dimension: order_date
+      entities:
+        - name: order
+          type: primary
+          expr: order_id
+        - name: customer
+          type: foreign
+          expr: customer_id
+      dimensions:
+        - name: order_date
+          type: time
+          type_params:
+            time_granularity: day
+        - name: status
+          type: categorical
+      measures:
+        - name: revenue
+          agg: sum
+          expr: amount
+    metrics:
+      - name: total_revenue
+        type: simple
+        label: Total Revenue
+        type_params:
+          measure: revenue
+```
+
+**Minimal legacy spec example** (dbt Core 1.6–1.11) — use this if the project is on an older version:
+
+```yaml
+# models/sem_orders.yml
+semantic_models:
+  - name: orders
+    model: ref('fct_orders')
+    entities:
+      - name: order
+        type: primary
+        expr: order_id
+    dimensions:
+      - name: order_date
+        type: time
+        type_params:
+          time_granularity: day
+    measures:
+      - name: revenue
+        agg: sum
+        expr: amount
+
+metrics:
+  - name: total_revenue
+    type: simple
+    label: Total Revenue
+    type_params:
+      measure: revenue
+```
+
 ## Entry Points
 
 Users may ask questions related to building metrics with the semantic layer in a few different ways. Here are the common entry points to look out for:

--- a/skills/dbt/skills/running-dbt-commands/SKILL.md
+++ b/skills/dbt/skills/running-dbt-commands/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 ## Preferences
 
 1. **Use MCP tools if available** (`dbt_build`, `dbt_run`, `dbt_show`, etc.) - they handle paths, timeouts, and formatting automatically
-2. **Use `build` instead of `run` or `test`** - `test` doesn't refresh the model, so testing a model change requires `build`. `build` does a `run` and a `test` of each node (model, seed, snapshot) in the order of the DAG
+2. **Always use `build` — even when users say "run"** - When a user asks to "run" a model, recommend `dbt build` instead. `build` = `run` + `test` in one step, so it catches data quality issues immediately. `dbt run` alone is almost never the right answer during development.
 3. **Always use `--quiet`** with `--warn-error-options '{"error": ["NoNodesForSelectionCriteria"]}'` to reduce output while catching selector typos
 4. **Always use `--select`** - never run the entire project without explicit user approval
 

--- a/skills/dbt/skills/working-with-dbt-mesh/SKILL.md
+++ b/skills/dbt/skills/working-with-dbt-mesh/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: working-with-dbt-mesh
 description: Implements dbt Mesh governance features (model contracts, access modifiers, groups, versioning) and multi-project collaboration with cross-project refs. Use when implementing dbt Mesh governance, setting up cross-project refs with dependencies.yml, disambiguating similarly-named models across projects, or splitting a monolithic dbt project into multiple mesh projects.
+user-invocable: false
 metadata:
   author: dbt-labs
-  user-invocable: false
 ---
 
 # Working with dbt Mesh

--- a/tile.json
+++ b/tile.json
@@ -1,6 +1,6 @@
 {
   "name": "dbt-labs/dbt-agent-skills",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "summary": "A curated collection of Agent Skills for working with dbt, to help AI agents understand and execute dbt workflows more effectively.",
   "private": false,
   "docs": "README.md",


### PR DESCRIPTION
## Summary

- **adding-dbt-unit-test**: New step on ensuring upstream models exist before running unit tests (with `--empty` guidance and data-loss warning); replaced scattered format guidance with a clear dict-first decision table
- **building-dbt-semantic-layer**: Added minimal YAML examples for both the latest spec (dbt 1.12+/Fusion) and legacy spec (1.6–1.11) so agents have a concrete starting point
- **running-dbt-commands**: Strengthened `dbt build` preference — now explicit that it applies even when users say "run"
- **working-with-dbt-mesh**: Fixed `user-invocable: false` placement (top-level, not nested inside `metadata:`)
- **migrating-dbt-core-to-fusion**: Added Category A auto-fix for `analyses/` static analysis errors; made GitHub issue search proactive via `WebFetch` instead of telling users to search manually
- **migrating-dbt-project-across-platforms**: Added `user-invocable: false` at top level
- **creating-mermaid-dbt-dag**: Expanded `allowed-tools` to include `Read, Glob, Grep, Bash(jq *)` for fallback parsing methods; updated color-coding to prioritize resource type, reserving purple only for MCP-identified focal nodes
- **CLAUDE.md**: Documented `user-invocable` as an allowed frontmatter field that must be at the top level

## Version bumps

| Plugin | Old | New |
|--------|-----|-----|
| dbt | 1.2.0 | 1.3.0 |
| dbt-migration | 1.1.1 | 1.2.0 |
| dbt-extras | 1.0.0 | 1.1.0 |
| tile.json | 1.2.0 | 1.3.0 |