### PR TITLE
feat(using-dbt-index): update skill to match community enablement doc

### DIFF
--- a/skills/dbt-extras/skills/using-dbt-index/SKILL.md
+++ b/skills/dbt-extras/skills/using-dbt-index/SKILL.md
@@ -106,8 +106,8 @@ Always run `dbt-index status` first to understand the project shape (node counts
 
 | User intent | Command | Key flags |
 |---|---|---|
-| Compare local index vs dbt Cloud production | `diff` | `--only added|removed|modified`, `--type model|source|test|...` |
-| Sync production artifacts from dbt Cloud | `cloud-sync` | |
+| Sync production artifacts from dbt Cloud | `cloud-sync` | Run this first before `diff` |
+| Compare local index vs dbt Cloud production | `diff` | `--only added|removed|modified`, `--type model|source|test|...`. Requires `cloud-sync` first |
 | Build performance analysis | `timings` | Subcommands: `summary`, `slowest`, `bottlenecks`, `phases`, `queries`, `export-html` |
 | Refresh the index after a new dbt run (Core path) | `ingest` | `--full-refresh` to force re-read; `--auto-reingest` on query commands to auto-refresh |
 | Start MCP server for AI assistants | `serve` | `--db /path/to/index` |

--- a/skills/dbt-extras/skills/using-dbt-index/SKILL.md
+++ b/skills/dbt-extras/skills/using-dbt-index/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: using-dbt-index
-description: Use when querying dbt project metadata via the dbt-index CLI tool, including installing dbt-index, creating the index from dbt artifacts, and running commands like search, node, lineage, impact, and query to answer questions about a dbt project.
+description: Use when querying dbt project metadata via the dbt-index CLI tool, including installing dbt-index, creating the index from dbt artifacts, and running commands like search, describe, lineage, impact, metrics, warehouse, and metadata to answer questions about a dbt project.
 metadata:
   author: dbt-labs
 ---
 
 # Using dbt-index
 
-`dbt-index` is a queryable DuckDB index over dbt artifacts. It ingests the JSON files dbt produces (manifest.json, catalog.json, run_results.json, sources.json, semantic_manifest.json) and normalizes them into relational tables. Everything in your dbt project is queryable as SQL, locally, with no warehouse connection.
+`dbt-index` turns dbt artifacts into a local, queryable database. It reads the JSON files dbt produces (manifest.json, catalog.json, run_results.json, sources.json, semantic_manifest.json), normalizes them into 34 relational tables + 5 analytical views in DuckDB, and gives you a CLI and MCP server to query them. No warehouse connection needed for metadata queries. Everything runs locally, in milliseconds.
+
+Works with **dbt Core** and **dbt Fusion**.
 
 ## How to use this skill
 
@@ -20,7 +22,7 @@ Ensure `dbt-index` is installed, up-to-date, the dbt flavor is known, and an ind
 #### Step 1 — Install and update `dbt-index`
 
 1. Run `dbt-index --version`
-2. If not found: install via `curl -fsSL https://public.staging.cdn.getdbt.com/fs/install/install-index.sh | sh`
+2. If not found: install via `curl -fsSL https://public.cdn.getdbt.com/fs/install/install-index.sh | sh`
 3. If found (or after install): run `dbt-index system update` to ensure it's up-to-date
 4. Verify with `dbt-index --version`
 
@@ -43,48 +45,87 @@ Ensure `dbt-index` is installed, up-to-date, the dbt flavor is known, and an ind
 
 ### Phase 2: Command Selection
 
-After prerequisites are met, use this decision tree to pick the right command.
+After prerequisites are met, use this decision tree to pick the right command. There are 17 commands total. Default output is compact YAML+TSV, token-efficient for LLMs. All commands support `--format json|csv|table|ndjson|tree`.
 
 #### Orient first
 
-Always run `dbt-index status` first to understand the project shape (node counts, coverage, last run info). Use `--detail` for per-package breakdown.
+Always run `dbt-index status` first to understand the project shape (node counts, coverage, last run info).
 
 #### Match intent to command
 
+**Explore & understand:**
+
 | User intent | Command | Key flags |
 |---|---|---|
-| Find a model/source/node by name or keyword | `search` | `--type`, `--tag`, `--where` to narrow |
-| Deep-dive into a specific node (columns, SQL, tests) | `node` | `-D` for full detail, or `--sql`, `--columns`, `--tests`, `--lineage` individually |
-| Trace upstream/downstream dependencies | `lineage` | `--upstream`, `--downstream`, `--depth`, `--column` for column-level |
-| Assess blast radius before changing a model | `impact` | `--depth` to control hops |
-| Discover what tables/columns exist in the index | `schema` | Pass a table name for column details, `--tables-only` for just table list |
-| Compare dev vs prod | `diff` | `--base <prod-index>`, `--only added\|removed\|modified`, `--type model\|source\|test\|...` to filter |
-| Export tables as parquet | `export` | `--table` to select specific tables |
-| Check index integrity and completeness | `doctor` | `--name <check>` to run a specific check |
-| Refresh the index after a new dbt run (Core path) | `ingest` | `--full-refresh` to bypass content hashing and force a full re-read of all artifacts |
+| Find a model/source/node by name or keyword | `search` | `--type`, `--tag`, `--package`, `--materialized` to narrow |
+| Deep-dive into a specific node (columns, SQL, tests) | `describe` | `--detail` for everything, or `--sql`, `--columns`, `--tests` individually |
+| Trace upstream/downstream dependencies | `lineage` | `--upstream`, `--downstream`, `--depth N`, `--column` for column-level |
+| Assess blast radius before changing a model | `impact` | `--column` for column-level impact |
+
+**Query metadata and warehouse:**
+
+| User intent | Command | Key flags |
+|---|---|---|
+| List all tables in the index | `metadata list` | |
+| Show columns of an index table | `metadata describe <table>` | e.g. `metadata describe dbt.nodes` |
+| Raw SQL against the index | `metadata run "<SQL>"` | DuckDB SQL, SELECT-only by default |
+| Execute SQL against the remote warehouse | `warehouse run "<SQL>"` | Uses profile's dialect (Snowflake, BigQuery, Redshift, Databricks, etc.) |
+
+**Semantic layer (metrics):**
+
+| User intent | Command | Key flags |
+|---|---|---|
+| List metrics, dimensions, entities, or saved queries | `metrics list` | |
+| Show valid group-by, where, and order-by syntax | `metrics describe --metrics <M>` | |
+| Compile and execute a metric query | `metrics run --metrics <M> --group-by <D>` | `--dry-run` to get SQL without executing |
+
+**Operations:**
+
+| User intent | Command | Key flags |
+|---|---|---|
+| Compare local index vs dbt Cloud production | `diff` | `--only added|removed|modified`, `--type model|source|test|...` |
+| Sync production artifacts from dbt Cloud | `cloud-sync` | |
+| Build performance analysis | `timings` | Subcommands: `summary`, `slowest`, `bottlenecks`, `phases`, `queries`, `export-html` |
+| Refresh the index after a new dbt run (Core path) | `ingest` | `--full-refresh` to force re-read; `--auto-reingest` on query commands to auto-refresh |
+| Start MCP server for AI assistants | `serve` | `--db /path/to/index` |
 | Update or uninstall dbt-index itself | `system` | `update`, `uninstall` |
-| Anything the above can't answer | `query` | Raw SQL escape hatch; SELECT-only by default; use `schema` first to discover table structure |
+
+Also: `doctor` (integrity checks), `export` (parquet export), `hydrate` (fetch column types from warehouse).
 
 #### Global flags
 
 - `--db <path>` — index location (default: `target/index`; env: `DBT_INDEX_DB`). Only needed if using a non-default location.
-- Default `compact` format — do not change (it is token-efficient)
+- `--format` — output format: `compact` (default, token-efficient), `json`, `csv`, `table`, `ndjson`, `tree`
 - `--limit` to control row limits when expecting large results
 
 #### Command chaining
 
-For multi-step investigations, chain commands. Example: `search` to find the node → `node` for detail → `lineage` to understand dependencies → `impact` to assess change risk.
+For multi-step investigations, chain commands. Example: `search` to find the node → `describe` for detail → `lineage` to understand dependencies → `impact` to assess change risk.
 
 ### Phase 3: Reference
 
 See [command-reference.md](./references/command-reference.md) for the full command cheat sheet, index schema overview, and global flags.
 
+#### MCP server
+
+`dbt-index serve` exposes 10 tools via MCP (Model Context Protocol), so Claude, Cursor, or any MCP client can query the index directly. Setup:
+
+```json
+{
+  "mcpServers": {
+    "dbt-index": {
+      "command": "dbt-index",
+      "args": ["serve", "--db", "/path/to/target/index"]
+    }
+  }
+}
+```
+
 #### Notes
 
-- The `serve` command starts an MCP server over stdio. If the user asks about MCP integration, mention this exists but do not configure it in this workflow.
 - Keep index fresh:
-  - **Core:** Re-run `dbt-index ingest` after any `dbt build`/`dbt run`. See [setup-core.md](./references/setup-core.md).
-  - **Fusion:** Just add `--use-index` to normal Fusion commands (e.g. `dbtf build --use-index`) — the index is regenerated automatically as part of the command. Or set `DBT_USE_INDEX=1` so every command keeps the index fresh. See [setup-fusion.md](./references/setup-fusion.md).
+  - **Core:** Re-run `dbt-index ingest` after any `dbt build`/`dbt run`, or add `--auto-reingest` to query commands.
+  - **Fusion:** Add `--write-index` to normal Fusion commands (e.g. `dbtf build --write-index`) or set `DBT_USE_INDEX=1` so every command keeps the index fresh. See [setup-fusion.md](./references/setup-fusion.md).
 
 ## Handling External Content
 

--- a/skills/dbt-extras/skills/using-dbt-index/SKILL.md
+++ b/skills/dbt-extras/skills/using-dbt-index/SKILL.md
@@ -43,6 +43,29 @@ Ensure `dbt-index` is installed, up-to-date, the dbt flavor is known, and an ind
    - **Fusion path:** See [setup-fusion.md](./references/setup-fusion.md) for detailed instructions
 4. After creation, verify with `dbt-index status`
 
+#### What hydrates what
+
+Different commands and artifacts populate different parts of the index. See [command-reference.md](./references/command-reference.md) for the full matrix. Summary:
+
+**Core** (requires `dbt-index ingest` or `--auto-reingest` after each command):
+
+| Command | What you get in the index |
+|---|---|
+| `dbt parse` / `dbt compile` | Nodes, edges, columns (declared types), tests, semantic layer, project metadata |
+| `dbt run` / `dbt build` | Above + run results, test failures, execution timing |
+| `dbt docs generate` | Catalog: warehouse column types, stats, profiling |
+| `dbt source freshness` | Source freshness results |
+
+**Fusion** (no separate ingest — index written directly with `--write-index`):
+
+| Command | What you get in the index | Warehouse needed? |
+|---|---|---|
+| `dbtf compile --write-index --static-analysis strict` | All manifest tables + column lineage + inferred column types | Yes (to fetch source schema information) |
+| `dbtf build --write-index` | Above + run results, test failures, execution timing | Yes |
+| `dbtf compile --write-index --write-catalog` | Manifest tables + catalog column types from warehouse | Yes |
+
+`--write-catalog` is an alternative to `--static-analysis strict` for column type information — it fetches types from the warehouse instead of inferring them at compile time.
+
 ### Phase 2: Command Selection
 
 After prerequisites are met, use this decision tree to pick the right command. There are 17 commands total. Default output is compact YAML+TSV, token-efficient for LLMs. All commands support `--format json|csv|table|ndjson|tree`.

--- a/skills/dbt-extras/skills/using-dbt-index/references/command-reference.md
+++ b/skills/dbt-extras/skills/using-dbt-index/references/command-reference.md
@@ -54,6 +54,32 @@ dbt-index ingest
 dbt-index export --table dbt.nodes
 ```
 
+## What hydrates what
+
+Different dbt commands produce different artifacts, and each artifact populates different parts of the index. Use this matrix to know what to run to get the data you need.
+
+### Core: artifact → index tables
+
+| Artifact | Produced by | Index tables populated |
+|---|---|---|
+| `manifest.json` | `dbt parse`, `dbt compile`, `dbt run`, `dbt build` | `nodes`, `edges`, `node_columns` (declared types only), `test_metadata`, `semantic_models`, `metrics`, `macros`, `exposures`, `groups`, `docs`, `project`, `packages` |
+| `catalog.json` | `dbt docs generate` | `catalog_tables`, `catalog_stats`, `column_stats`, `node_columns.catalog_type` |
+| `run_results.json` | `dbt run`, `dbt build`, `dbt test` | `invocations`, `run_results`, `test_failures`, `adapter_queries` |
+| `sources.json` | `dbt source freshness` | `source_freshness` |
+| `semantic_manifest.json` | `dbt parse`, `dbt compile` (with semantic layer configured) | `semantic_entities`, `semantic_measures`, `semantic_dimensions`, `saved_queries`, `time_spines` |
+
+After producing artifacts, run `dbt-index ingest` (or use `--auto-reingest`) to populate the index.
+
+### Fusion: command → index tables
+
+| Command | What it populates | Warehouse needed? |
+|---|---|---|
+| `dbtf compile --write-index --static-analysis strict` | All manifest tables + `column_lineage` + inferred column types (`node_columns.inferred_type`) | Yes (to fetch source schema information) |
+| `dbtf build --write-index` | All of the above + `invocations`, `run_results`, `test_failures`, `adapter_queries` | Yes (executes models) |
+| `dbtf compile --write-index --write-catalog` | All manifest tables + `catalog_tables`, `catalog_stats`, `column_stats`, `node_columns.catalog_type` | Yes (fetches column types from warehouse) |
+
+`--write-catalog` is an alternative to `--static-analysis strict` for getting column type information — it fetches types from the warehouse rather than inferring them at compile time. Users who don't run `dbtf compile --write-index --static-analysis strict` can use `--write-catalog` to get column information instead.
+
 ## Index schema overview
 
 Two schemas. The `unique_id` column is the primary join key across most tables.

--- a/skills/dbt-extras/skills/using-dbt-index/references/command-reference.md
+++ b/skills/dbt-extras/skills/using-dbt-index/references/command-reference.md
@@ -5,35 +5,46 @@
 ```bash
 # Orient: get project summary (node counts, coverage, last run)
 dbt-index status
-dbt-index status --detail  # per-package breakdown
 
 # Find: full-text search across node names, descriptions, and unique_ids
 dbt-index search "revenue"
-dbt-index search --type model --tag pii  # narrow by resource type and tag
-dbt-index search --tag pii --columns unique_id,name,description,tags  # select specific output columns (see `dbt-index schema dbt.nodes` for options)
+dbt-index search --type model --tag pii
 
-# Deep-dive: inspect a specific node (columns, SQL, tests, lineage)
-dbt-index node customers --detail
-dbt-index node model.my_project.fct_orders --sql --columns
+# Inspect: deep-dive into a specific node (columns, SQL, tests, lineage)
+dbt-index describe customers --detail
+dbt-index describe customers --sql --columns --tests
 
-# DAG traversal: walk the dependency graph up to 5 layers upstream of `customers`
+# DAG traversal: walk the dependency graph
 dbt-index lineage customers --upstream --depth 5
-dbt-index lineage customers --column customer_id  # column-level lineage
+dbt-index lineage customers --column customer_id
 
-# Blast radius: list all nodes downstream of `stg_customers` (change impact)
-dbt-index impact stg_customers --depth 5
+# Impact analysis before a change
+dbt-index impact stg_orders
+dbt-index impact stg_orders --column order_id
 
-# Raw SQL: escape hatch for anything the structured commands can't answer
-dbt-index query "SELECT n.name, unnest(n.tags) AS tag FROM dbt.nodes n WHERE n.resource_type = 'model'"
+# Metadata: list tables, describe columns, run raw SQL on the index
+dbt-index metadata list
+dbt-index metadata describe dbt.nodes
+dbt-index metadata run "SELECT name, materialized FROM dbt.nodes WHERE resource_type = 'model'"
 
-# Schema discovery: list all tables in the index, then inspect columns of a specific table (use before writing queries)
-dbt-index schema
-dbt-index schema dbt.nodes
+# Warehouse: execute SQL against the remote warehouse
+dbt-index warehouse run "SELECT * FROM orders LIMIT 10"
 
-# Compare environments: show nodes added in dev vs prod
-dbt-index diff --base prod.duckdb --only added
+# Metrics: discover, describe, and execute metric queries
+dbt-index metrics list
+dbt-index metrics describe --metrics revenue
+dbt-index metrics run --metrics revenue --group-by metric_time:day
+dbt-index metrics run --metrics revenue --group-by metric_time:day --dry-run
 
-# Doctor: check index integrity and completeness (errors = structural problems, warnings = incomplete enrichment)
+# Diff vs production
+dbt-index diff
+dbt-index diff --only added --type model
+
+# Build performance
+dbt-index timings slowest
+dbt-index timings export-html timeline.html
+
+# Doctor: check index integrity and completeness
 dbt-index doctor
 
 # Re-ingest: pick up new artifacts after a dbt run (Core path only)
@@ -45,84 +56,50 @@ dbt-index export --table dbt.nodes
 
 ## Index schema overview
 
-Two schemas with 39 tables/views total. The `unique_id` column is the primary join key across most tables.
+Two schemas. The `unique_id` column is the primary join key across most tables.
 
-Use `dbt-index schema` to list all tables. Use `dbt-index schema <table>` to see column details for a specific table.
+Use `dbt-index metadata list` to list all tables. Use `dbt-index metadata describe <table>` to see column details.
 
-### `dbt.*` — Project metadata (30 tables + 2 views)
+### `dbt.*` — Project metadata (28 tables)
 
-#### Core node tables
+| Table | What it stores |
+|---|---|
+| `nodes` | Every resource (model, source, test, seed, snapshot) with compiled SQL, config, grain |
+| `node_columns` | Column definitions with type provenance and PK/unique markers |
+| `edges` | Node-level DAG (parent → child) |
+| `column_lineage` | Column-level lineage mappings |
+| `test_metadata` | Test definitions with unique/not_null/relationship details |
+| `metrics` | MetricFlow metric definitions (simple, derived, ratio, cumulative, conversion) |
+| `semantic_models` | Semantic model definitions with entities, measures, dimensions |
+| `catalog_tables` | Physical warehouse table metadata |
+| `exposures`, `groups`, `macros`, `docs` | Project structure |
+| `project`, `packages` | Reproducibility metadata |
 
-| Table | Description | Key columns | Joins to |
-|---|---|---|---|
-| `nodes` | Every resource (model, source, test, seed, snapshot) | `unique_id`, `name`, `resource_type`, `package_name`, `materialized`, `compiled_code`, `grain`, `table_role`, `access_level`, `group_name`, `tags`, `description` | Primary table — others join via `unique_id` |
-| `node_columns` | Column definitions per node | `unique_id`, `column_name`, `declared_type`, `inferred_type`, `catalog_type`, `description`, `tags`, `tests` | `nodes.unique_id` |
-| `edges` | Node-level DAG (parent → child) | `parent_unique_id`, `child_unique_id`, `edge_type` | `nodes.unique_id` on both columns |
-| `column_lineage` | Column-level lineage | `from_node_unique_id`, `from_column_name`, `to_node_unique_id`, `to_column_name`, `lineage_kind` | `nodes.unique_id` + `node_columns.column_name` |
-| `test_metadata` | Test configuration details | `unique_id`, `test_name`, `attached_node`, `column_name`, `severity`, `kwargs` | `nodes.unique_id` (for test nodes), `attached_node` → `nodes.unique_id` |
-| `node_input_files` | Files contributing to each node | `unique_id`, `file_path`, `file_hash`, `input_kind` | `nodes.unique_id` |
-| `sample_data` | Sample rows per node | `unique_id`, `sample_rows` (JSON) | `nodes.unique_id` |
-| `unit_tests` | Unit test definitions | `unique_id`, `name`, `model`, `given` (JSON), `expect` (JSON), `depends_on_nodes` | `model` → `nodes.unique_id` |
+### `dbt_rt.*` — Runtime execution data (6 tables)
 
-#### Enriched views
+| Table | What it stores |
+|---|---|
+| `invocations` | One row per `dbt run/test/build` |
+| `run_results` | Per-node execution: status, timing, rows affected |
+| `test_failures` | Failing rows as JSON for root-cause diagnosis |
+| `adapter_queries` | Actual SQL sent to the warehouse |
+| `diagnostics` | Warnings and errors from dbt runs |
 
-| View | Description | Key columns |
-|---|---|---|
-| `nodes_enriched` | Nodes joined with latest run status and catalog metadata | All `nodes` columns + `last_run_status`, `last_execution_time`, `catalog_table_type`, `catalog_owner` |
-| `tests_enriched` | Tests joined with metadata and latest results | `unique_id`, `test_name`, `test_type`, `attached_node`, `column_name`, `severity`, `last_run_status`, `last_run_failures`, `failure_rows` |
+### Analytical views (5)
 
-#### Semantic layer tables
+| View | What it provides |
+|---|---|
+| `run_results_latest` | Most recent result per node |
+| `node_status` | Staleness detection |
+| `dag_validity` | DAG integrity checks |
+| `nodes_enriched` | Nodes joined with latest run status and catalog metadata |
+| `tests_enriched` | Tests joined with metadata and latest results |
 
-| Table | Description | Key columns | Joins to |
-|---|---|---|---|
-| `semantic_models` | MetricFlow semantic model definitions | `unique_id`, `name`, `model`, `primary_entity`, `depends_on_nodes` | `model` → `nodes.unique_id` |
-| `semantic_entities` | Entities within semantic models | `unique_id`, `name`, `entity_type`, `entity_role`, `expr` | `unique_id` → `semantic_models.unique_id` |
-| `semantic_measures` | Measures within semantic models | `unique_id`, `name`, `agg`, `expr`, `agg_time_dimension` | `unique_id` → `semantic_models.unique_id` |
-| `semantic_dimensions` | Dimensions within semantic models | `unique_id`, `name`, `dimension_type`, `expr`, `time_granularity` | `unique_id` → `semantic_models.unique_id` |
-| `semantic_relationships` | Relationships between semantic models | `name`, `from_unique_id`, `to_unique_id`, `from_columns`, `to_columns`, `cardinality` | `from_unique_id`/`to_unique_id` → `semantic_models.unique_id` |
-| `metrics` | Metric definitions | `unique_id`, `name`, `metric_type`, `type_params` (JSON), `depends_on_nodes` | `depends_on_nodes` → `nodes.unique_id` |
-| `saved_queries` | Saved query definitions | `unique_id`, `name`, `query_params` (JSON), `exports` (JSON), `depends_on_nodes` | `depends_on_nodes` → `nodes.unique_id` |
-| `time_spines` | Time spine definitions | `unique_id`, `primary_column`, `primary_granularity` | `unique_id` → `nodes.unique_id` |
-
-#### Catalog tables
-
-| Table | Description | Key columns | Joins to |
-|---|---|---|---|
-| `catalog_tables` | Physical warehouse table metadata | `unique_id`, `table_type`, `database_name`, `schema_name`, `table_name`, `table_owner` | `nodes.unique_id` |
-| `catalog_stats` | Table-level statistics | `unique_id`, `stat_id`, `stat_label`, `stat_value` | `nodes.unique_id` |
-| `column_stats` | Column-level profiling statistics | `unique_id`, `column_name`, `row_count`, `distinct_count`, `null_pct`, `min_value`, `max_value` | `nodes.unique_id` + `node_columns.column_name` |
-
-#### Project metadata tables
-
-| Table | Description | Key columns |
-|---|---|---|
-| `project` | Project-level info | `project_name`, `dbt_version`, `adapter_type`, `git_sha`, `git_branch` |
-| `packages` | Installed packages | `package_name`, `package_source`, `version`, `git_url` |
-| `project_vars` | dbt_project.yml variables | `var_name`, `var_value` (JSON) |
-| `project_env_vars` | Environment variables referenced | `env_var_name`, `used_in` |
-| `docs` | Doc block definitions | `unique_id`, `name`, `block_contents` |
-| `groups` | Access groups | `unique_id`, `name`, `owner_name`, `owner_email` |
-| `macros` | Macro definitions | `unique_id`, `name`, `macro_sql`, `depends_on_macros` |
-| `exposures` | Exposure definitions | `unique_id`, `name`, `exposure_type`, `owner_name`, `depends_on_nodes` |
-| `source_freshness` | Source freshness results | `unique_id`, `status`, `max_loaded_at`, `snapshotted_at` |
-
-### `dbt_rt.*` — Runtime data (6 tables + 3 views)
-
-| Table/View | Type | Description | Key columns | Joins to |
-|---|---|---|---|---|
-| `invocations` | table | One row per dbt run/test/build | `invocation_id`, `command`, `dbt_version`, `generated_at`, `elapsed_time`, `args` (JSON) | Primary key: `invocation_id` |
-| `invocation_nodes` | table | Which nodes were part of each invocation | `invocation_id`, `unique_id` | `invocations.invocation_id` + `nodes.unique_id` |
-| `run_results` | table | Per-node execution results | `unique_id`, `invocation_id`, `status`, `execution_time`, `message`, `failures` | `nodes.unique_id` + `invocations.invocation_id` |
-| `test_failures` | table | Failing test rows as JSON | `unique_id`, `invocation_id`, `failure_rows` (JSON) | `nodes.unique_id` + `invocations.invocation_id` |
-| `adapter_queries` | table | Actual SQL sent to warehouse | `unique_id`, `invocation_id`, `query_sql`, `rows_affected`, `bytes_scanned` | `nodes.unique_id` + `invocations.invocation_id` |
-| `diagnostics` | table | Warnings and errors from dbt | `unique_id`, `invocation_id`, `severity`, `code`, `message` | `nodes.unique_id` + `invocations.invocation_id` |
-| `run_results_latest` | view | Latest execution result per node | Same as `run_results` | `nodes.unique_id` |
-| `dag_validity` | view | Whether parents were built before children | `unique_id`, `status`, `parent_unique_id`, `parent_is_fresh` | `nodes.unique_id` |
-| `node_status` | view | Lifecycle status per node (parsed → compiled → run) | `unique_id`, `name`, `resource_type`, `run_status`, `effective_phase`, `is_stale` | `nodes.unique_id` |
+Run `dbt-index metadata list` for the full listing. Run `dbt-index metadata describe dbt.nodes` to see columns.
 
 ## Global flags
 
 - `--db <path>` — index location (default: `target/index`; env: `DBT_INDEX_DB`). Only needed if using a non-default location.
-- `--format compact` — default output format: YAML envelope with metadata keys + embedded CSV `data` block, token-efficient for LLMs (do not change)
+- `--format` — output format: `compact` (default, YAML envelope with CSV data block, token-efficient for LLMs), `json`, `csv`, `table`, `ndjson`, `tree`
 - `--raw` — only meaningful with `compact`: strips the YAML envelope, leaving just the CSV `data` block
 - `--limit <n>` — max rows returned (default 100, use 0 for unlimited)

--- a/skills/dbt-extras/skills/using-dbt-index/references/command-reference.md
+++ b/skills/dbt-extras/skills/using-dbt-index/references/command-reference.md
@@ -36,7 +36,8 @@ dbt-index metrics describe --metrics revenue
 dbt-index metrics run --metrics revenue --group-by metric_time:day
 dbt-index metrics run --metrics revenue --group-by metric_time:day --dry-run
 
-# Diff vs production
+# Diff vs production (run cloud-sync first to fetch prod data)
+dbt-index cloud-sync
 dbt-index diff
 dbt-index diff --only added --type model
 

--- a/skills/dbt-extras/skills/using-dbt-index/references/command-reference.md
+++ b/skills/dbt-extras/skills/using-dbt-index/references/command-reference.md
@@ -36,7 +36,7 @@ dbt-index metrics describe --metrics revenue
 dbt-index metrics run --metrics revenue --group-by metric_time:day
 dbt-index metrics run --metrics revenue --group-by metric_time:day --dry-run
 
-# Diff vs production (run cloud-sync first to fetch prod data)
+# Diff vs production (run `cloud-sync` first to fetch prod state)
 dbt-index cloud-sync
 dbt-index diff
 dbt-index diff --only added --type model

--- a/skills/dbt-extras/skills/using-dbt-index/references/setup-core.md
+++ b/skills/dbt-extras/skills/using-dbt-index/references/setup-core.md
@@ -26,27 +26,33 @@ Different artifacts populate different parts of the index:
 ### Step 2 — Ingest
 
 ```bash
-dbt-index ingest
+dbt-index ingest --db /path/to/index
 ```
 
 By default, `ingest` reads from `target/`. Use `--target` to specify a different target directory:
 
 ```bash
-dbt-index ingest --target /path/to/target
+dbt-index ingest --db /path/to/index --target /path/to/target
 ```
 
 Use `--full-refresh` to bypass content hashing and re-ingest all rows. Forces a full re-read of all artifacts, ignoring the hash cache. Useful if the index gets into a bad state:
 
 ```bash
-dbt-index ingest --full-refresh
+dbt-index ingest --db /path/to/index --full-refresh
 ```
 
 ### Step 3 — Verify
 
 ```bash
-dbt-index status
+dbt-index status --db /path/to/index
 ```
 
 ## Keeping the index fresh
 
 After any `dbt build`, `dbt run`, `dbt test`, or `dbt docs generate`, re-run `dbt-index ingest` to pick up new artifacts. Content hashing skips unchanged rows, so re-ingestion is fast.
+
+Alternatively, add `--auto-reingest` to any query command to automatically re-ingest when artifacts change:
+
+```bash
+dbt-index status --db /path/to/index --auto-reingest
+```

--- a/skills/dbt-extras/skills/using-dbt-index/references/setup-fusion.md
+++ b/skills/dbt-extras/skills/using-dbt-index/references/setup-fusion.md
@@ -4,36 +4,39 @@ Use this when the project runs dbt Fusion.
 
 ## Key insight
 
-Adding `--use-index` (or setting `DBT_USE_INDEX=1`) to any Fusion command automatically generates the Parquet index as part of that command — there is no separate ingest step. The index is written after compilation, with ~2ms overhead.
+Adding `--write-index` to a Fusion parse command automatically generates the Parquet index — there is no separate ingest step. The index is written after compilation, with ~2ms overhead.
 
 ## Creating the index
 
-Just add `--use-index` to your normal Fusion commands:
+Run parse with `--write-index` and `--static-analysis strict` for the richest metadata:
 
 ```bash
-dbtf parse --use-index
-dbtf build --use-index
-dbtf run --use-index
-dbtf test --use-index
+dbtf parse --write-index --static-analysis strict
 ```
 
-Or set `DBT_USE_INDEX=1` once so every Fusion command keeps the index fresh automatically:
+The index is written to `target/index/` by default. Query immediately:
+
+```bash
+dbt-index status --db target/index
+```
+
+Or set `DBT_USE_INDEX=1` so every Fusion command keeps the index fresh automatically:
 
 ```bash
 export DBT_USE_INDEX=1
 ```
 
-The index is written to `target/index/` by default. Specifying a different location with `--index-dir` (or `DBT_INDEX_DIR`) is rarely needed — the default works in almost all cases:
+Specifying a different location with `--index-dir` (or `DBT_INDEX_DIR`) is rarely needed — the default works in almost all cases:
 
 ```bash
-dbtf parse --use-index --index-dir /path/to/index
+dbtf parse --write-index --static-analysis strict --index-dir /path/to/index
 ```
 
 ## Environment variables
 
 | Flag | Environment variable | Description |
 |---|---|---|
-| `--use-index` | `DBT_USE_INDEX=1` | Write parquet index alongside JSON artifacts |
+| `--write-index` | `DBT_USE_INDEX=1` | Write parquet index alongside JSON artifacts |
 | `--index-dir` | `DBT_INDEX_DIR=/path/to/index` | Directory for index output (default: `<target>/index/`) |
 
 ## Verify
@@ -44,11 +47,12 @@ dbt-index status
 
 ## Keeping the index fresh
 
-Since `--use-index` is additive to normal commands, the index stays fresh automatically as long as the flag (or env var) is set. Every `dbtf build`, `dbtf run`, etc. refreshes the index.
+Since `--write-index` is additive to normal commands, the index stays fresh automatically as long as the flag (or `DBT_USE_INDEX=1` env var) is set. Every `dbtf build`, `dbtf run`, etc. refreshes the index.
 
 ## Differences from Core path
 
 - No separate `dbt-index ingest` step needed — index is generated as part of the command
 - Faster write path (Arrow → Parquet directly, ~2ms vs ~100ms)
 - Column lineage: Fusion's compile-time static analysis populates `dbt.column_lineage` with richer data
+- Static analysis provides richer type inference and lineage signals
 - Everything else is identical — same commands, same schemas, same query surface


### PR DESCRIPTION
## Summary
- **Command renames**: `node` → `describe`, `schema` → `metadata list/describe/run`, `query` → `metadata run`
- **New commands**: `warehouse run`, `metrics list/describe/run`, `timings`, `cloud-sync`, `hydrate`
- **Setup changes**: install URL updated (staging → prod CDN), Fusion uses `--write-index --static-analysis strict`, Core adds `--auto-reingest` and `--db` flag
- **Schema updated**: 28 `dbt.*` tables + 6 `dbt_rt.*` tables + 5 analytical views
- **MCP server**: added setup instructions and 10 tool listing
- **Format options**: all commands now support `--format json|csv|table|ndjson|tree`

Source: [dbt-index Community Enablement](https://www.notion.so/dbtlabs/dbt-index-Community-Enablement-333bb38ebda78151b9dbcadc90c44099)

## Test plan
- [ ] Verify SKILL.md frontmatter passes validation (name matches directory, lowercase, allowed fields only)
- [ ] Confirm all `./references/*.md` cross-references resolve
- [ ] Spot-check command examples against actual `dbt-index --help` output
- [ ] Verify markdown tables render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)