### PR TITLE
improve(using-dbt-index): rewrite skill to Anthropic best practices

### DIFF
--- a/skills/dbt-extras/skills/using-dbt-index/SKILL.md
+++ b/skills/dbt-extras/skills/using-dbt-index/SKILL.md
@@ -61,7 +61,7 @@ Match the user's question to the right command. Chain commands for multi-step in
 
 | User question | Command |
 |---|---|
-| "Find a model / source named X" or "find models tagged Y" | `search "X"` or `search --type model --tag Y` |
+| "Find a model / source named X" or "find models tagged Y" | `search "X"` or `search --type model --tag Y`; use `--where` for SQL predicates on node fields |
 | "What does this model do? Show me its columns, SQL, tests" | `describe <node> --detail sql,columns,tests` |
 | "Search the business context, glossary, fiscal calendar, compliance docs" | `context "X"` |
 
@@ -80,7 +80,7 @@ Match the user's question to the right command. Chain commands for multi-step in
 
 | User question | Command |
 |---|---|
-| "Run SQL against the warehouse" | `warehouse run "<SQL>"` — describe columns first, never guess |
+| "Run SQL against the warehouse" | `warehouse run "<SQL>"` — describe columns first, never guess; `warehouse run` sends SQL verbatim (no Jinja) — use `dbt[f] compile --inline "<jinja-sql>"` to render refs/macros first |
 | "Show me metric X / query the semantic layer" | `metrics describe --metrics X` then `metrics run --metrics X --group-by <dim>` |
 | "Write a custom query against project metadata" | `metadata run "<SQL>"` — describe the table first, never guess column names |
 
@@ -92,6 +92,8 @@ Match the user's question to the right command. Chain commands for multi-step in
 | "Find slow models or build bottlenecks" | `timings slowest` or `timings bottlenecks` |
 | "How does my local project differ from production?" | `diff` (auto-syncs cloud state; use `--sync` to force refresh) |
 | "Is the index valid and complete?" | `doctor` |
+| "Export index data for use outside dbt-index" | `export --table <table>` e.g. `export --table dbt.nodes` |
+| "Force a full re-ingest (index in bad state)" | `ingest --full-refresh` (Core only — bypasses content hashing) |
 
 ## Critical rules
 
@@ -115,7 +117,11 @@ dbt-index describe <model> --detail columns   # add --auto-hydrate if columns ar
 
 ### Before `metadata run`
 
-Always inspect the table schema before writing SQL. The index does not follow assumed dbt naming conventions (e.g. join key in `dbt.node_columns` is `unique_id`; DAG edges use `parent_unique_id`/`child_unique_id`).
+Always inspect the table schema before writing SQL. The index does not follow assumed dbt naming conventions — common traps:
+- Join key in `dbt.node_columns` is `unique_id`, not `node_unique_id`
+- DAG edges use `parent_unique_id`/`child_unique_id`, not `from_unique_id`/`to_unique_id`
+
+If you haven't seen the schema for a table in the current session, always run `metadata describe` first.
 
 ```bash
 dbt-index metadata list                     # list all available tables

--- a/skills/dbt-extras/skills/using-dbt-index/SKILL.md
+++ b/skills/dbt-extras/skills/using-dbt-index/SKILL.md
@@ -81,7 +81,8 @@ Match the user's question to the right command. Chain commands for multi-step in
 | User question | Command |
 |---|---|
 | "Run SQL against the warehouse" | `warehouse run "<SQL>"` — describe columns first, never guess; `warehouse run` sends SQL verbatim (no Jinja) — use `dbt[f] compile --inline "<jinja-sql>"` to render refs/macros first |
-| "Show me metric X / query the semantic layer" | `metrics describe --metrics X` then `metrics run --metrics X --group-by <dim>` |
+| "Show me metric X / query the semantic layer" | `metrics list --search X`; `metrics describe --metrics X`; `metrics run --metrics X --group-by <dim>`; add `--dry-run` to preview SQL without executing |
+| "Run a saved query" | `metrics list --saved-queries` to list; `metrics run --saved-query <name>` to execute |
 | "Write a custom query against project metadata" | `metadata run "<SQL>"` — describe the table first, never guess column names |
 
 ### Operations and health

--- a/skills/dbt-extras/skills/using-dbt-index/SKILL.md
+++ b/skills/dbt-extras/skills/using-dbt-index/SKILL.md
@@ -1,162 +1,185 @@
 ---
 name: using-dbt-index
-description: Use when querying dbt project metadata via the dbt-index CLI tool, including installing dbt-index, creating the index from dbt artifacts, and running commands like search, describe, lineage, impact, metrics, warehouse, and metadata to answer questions about a dbt project.
+description: Queries dbt project metadata locally using the dbt-index CLI — no warehouse connection needed. Use when user asks about model or column lineage, blast radius of a change, test coverage, finding or describing dbt models or sources, build performance, semantic layer metrics, business context glossary, or comparing local vs production state.
 allowed-tools:
   - Bash(dbt-index*)
   - Bash(dbt --version*)
-  - Bash(which dbtf*)
+  - Bash(which dbtf)
 metadata:
   author: dbt-labs
 ---
 
 # Using dbt-index
 
-`dbt-index` turns dbt artifacts into a local, queryable database. It reads the JSON files dbt produces (manifest.json, catalog.json, run_results.json, sources.json, semantic_manifest.json), normalizes them into relational tables + analytical views in DuckDB, and gives you a CLI and MCP server to query them. No warehouse connection needed for metadata queries -- everything runs locally, in milliseconds.
+`dbt-index` turns dbt artifacts into a local, queryable DuckDB database. All metadata queries run in milliseconds — no warehouse connection needed.
 
 Works with **dbt Core** and **dbt Fusion**.
 
-## How to use this skill
+## Phase 1: Ensure the index is ready
 
-Follow the three phases in order. Phase 1 (Prerequisites) only needs to run once per session. Phase 2 (Command Selection) is the core loop for answering questions.
+Run once per session before answering any question.
 
-### Phase 1: Prerequisites
+### Install / update
 
-Ensure `dbt-index` is installed, up-to-date, the dbt flavor is known, and an index exists.
+```bash
+dbt-index --version          # if not found, install:
+curl -fsSL https://public.cdn.getdbt.com/fs/install/install-index.sh | sh
+dbt-index system update      # always update to latest
+```
 
-#### Step 1 — Install and update `dbt-index`
+### Detect dbt flavor
 
-1. Run `dbt-index --version`
-2. If not found: install via `curl -fsSL https://public.cdn.getdbt.com/fs/install/install-index.sh | sh`
-3. If found (or after install): run `dbt-index system update` to ensure it's up-to-date
-4. Verify with `dbt-index --version`
+```bash
+dbt --version && which dbtf
+```
 
-#### Step 2 — Detect dbt flavor (Core vs Fusion)
-
-1. Run both commands together:
-   ```
-   dbt --version && which dbtf
-   ```
-2. If `dbt --version` output contains "Fusion" → use Fusion
-3. If `which dbtf` finds the binary → ask the user whether they want to use Fusion or Core
-4. If neither → use Core
+- Output contains "Fusion" → **Fusion path**
+- `which dbtf` finds the binary → ask user: Fusion or Core?
+- Neither → **Core path**
 
 > **Never conclude Core without running `which dbtf`** — the binary may exist even when `dbt --version` shows Core.
 
-#### Step 3 — Ensure index exists
+### Ensure an index exists
 
-1. Check `target/index/` relative to the dbt project root
-2. If not found, ask the user for the index directory path
-3. If no index exists anywhere:
-   - **Core path:** See [setup-core.md](./references/setup-core.md) for detailed instructions
-   - **Fusion path:** See [setup-fusion.md](./references/setup-fusion.md) for detailed instructions
-4. After creation, verify with `dbt-index status`
+Check `target/index/` relative to the dbt project root. If missing:
+- **Core:** see [setup-core.md](./references/setup-core.md)
+- **Fusion:** see [setup-fusion.md](./references/setup-fusion.md)
 
-#### What hydrates what
+### Orient
 
-Different commands and artifacts populate different parts of the index. See [command-reference.md](./references/command-reference.md) for the full matrix. Summary:
+Always run first to understand the project shape:
 
-**Core** (requires `dbt-index ingest` or `--auto-reingest` after each command):
+```bash
+dbt-index status
+```
 
-| Command | What you get in the index |
+## Phase 2: Answer the question
+
+Match the user's question to the right command. Chain commands for multi-step investigations: `search` → `describe` → `lineage` → `impact`.
+
+### Find and understand nodes
+
+| User question | Command |
 |---|---|
-| `dbt parse` / `dbt compile` | Nodes, edges, columns (declared types), tests, semantic layer, project metadata |
-| `dbt run` / `dbt build` | Above + run results, test failures, execution timing |
-| `dbt docs generate` | Catalog: warehouse column types, stats, profiling |
-| `dbt source freshness` | Source freshness results |
+| "Find a model / source named X" or "find models tagged Y" | `search "X"` or `search --type model --tag Y` |
+| "What does this model do? Show me its columns, SQL, tests" | `describe <node> --detail sql,columns,tests` |
+| "Search the business context, glossary, fiscal calendar, compliance docs" | `context "X"` |
 
-**Fusion** (no separate ingest — index written directly with `--write-index`):
+### Understand relationships
 
-| Command | What you get in the index | Warehouse needed? |
-|---|---|---|
-| `dbtf compile --write-index --static-analysis strict` | All manifest tables + column lineage + inferred column types | Yes (to fetch source schema information) |
-| `dbtf build --write-index` | Above + run results, test failures, execution timing | Yes |
-| `dbtf compile --write-index --write-catalog` | Manifest tables + catalog column types from warehouse | Yes |
+| User question | Command |
+|---|---|
+| "What does this model depend on? What feeds into it?" | `lineage <node> --upstream` |
+| "What models use this model?" | `lineage <node> --downstream` |
+| "What breaks if I change X?" | `impact <node>` |
+| "How does column Y flow through the DAG?" | `lineage <node> --column <col>` (Fusion only — see below) |
 
-`--write-catalog` is an alternative to `--static-analysis strict` for column type information — it fetches types from the warehouse instead of inferring them at compile time.
+**`lineage` vs `impact`:** `lineage --downstream` returns a raw DAG traversal — a flat list of all downstream nodes. `impact` is always downstream and adds severity ranking (exposure > metric > model), category counts, and highlights only the most critical nodes. Use `lineage` to explore the graph; use `impact` to assess risk before making a change. `impact` has no `--downstream` or `--depth` flags.
 
-### Phase 2: Command Selection
+### Query data
 
-After prerequisites are met, use this decision tree to pick the right command.
+| User question | Command |
+|---|---|
+| "Run SQL against the warehouse" | `warehouse run "<SQL>"` — describe columns first, never guess |
+| "Show me metric X / query the semantic layer" | `metrics describe --metrics X` then `metrics run --metrics X --group-by <dim>` |
+| "Write a custom query against project metadata" | `metadata run "<SQL>"` — describe the table first, never guess column names |
 
-#### Orient first
+### Operations and health
 
-Always run `dbt-index status` first to understand the project shape (node counts, coverage, last run info).
+| User question | Command |
+|---|---|
+| "How did the last build go? Any failures?" | `status` then `timings` |
+| "Find slow models or build bottlenecks" | `timings slowest` or `timings bottlenecks` |
+| "How does my local project differ from production?" | `diff` (auto-syncs cloud state; use `--sync` to force refresh) |
+| "Is the index valid and complete?" | `doctor` |
 
-#### Match intent to command
+## Critical rules
 
-**Explore & understand:**
+### Column-level lineage — Fusion only
 
-| User intent | Command | Key flags / notes |
-|---|---|---|
-| Find a model/source/node by name or keyword | `search` | `--type`, `--tag`, `--where` to narrow |
-| Deep-dive into a specific node (columns, SQL, tests) | `describe` | `--detail` for full detail; composable comma-separated: `--detail sql,columns` or `--detail tests,lineage` |
-| Trace upstream/downstream dependencies | `lineage` | `--upstream`, `--downstream`, `--depth`, `--column` for column-level; `--detail` for file paths and stats |
-| Assess blast radius before changing a model | `impact` | `--depth` to control hops |
+`--column` lineage and `--detail column-lineage` require Fusion compiled with `--static-analysis strict`:
 
-**Query metadata and warehouse:**
+```bash
+dbtf compile --write-index --static-analysis strict
+```
 
-| User intent | Command | Key flags / notes |
-|---|---|---|
-| List all tables in the index | `metadata list` | |
-| Show columns of an index table | `metadata describe <table>` | e.g. `metadata describe dbt.nodes` |
-| Raw SQL against the index | `metadata run "<SQL>"` | DuckDB raw SQL escape hatch; SELECT-only by default; **always run `dbt-index metadata describe <table>` for every table you plan to reference before writing SQL — never guess column names** |
-| Execute SQL against the remote warehouse | `warehouse run "<SQL>"` | Sends SQL verbatim — no Jinja; use `dbt[f] compile --inline "<jinja-sql>"` to render any Jinja (refs, macros, etc.), then pass the compiled SQL |
+For Core users: column-level lineage is unavailable. If the user needs it, suggest switching to Fusion.
 
-**Semantic layer (metrics):**
+### Before `warehouse run`
 
-| User intent | Command | Key flags / notes |
-|---|---|---|
-| List metrics, dimensions, entities, or saved queries | `metrics list` | |
-| Show valid group-by, where, and order-by syntax | `metrics describe --metrics <M>` | |
-| Compile and execute a metric query | `metrics run --metrics <M> --group-by <D>` | `--dry-run` to get SQL without executing |
+Always check column names first. Never guess.
 
-**Operations:**
+```bash
+dbt-index describe <model> --detail columns   # add --auto-hydrate if columns are missing
+```
 
-| User intent | Command | Key flags / notes |
-|---|---|---|
-| Sync production state from dbt platform | `cloud-sync` | Run this first before `diff`; `--environment-id` (auto-detected if omitted); `--skip-discovery` for faster artifact-only sync |
-| Compare local vs dbt platform state | `diff` | auto-runs `cloud-sync` internally if cloud state not loaded — `--skip-discovery` and other `cloud-sync` flags must be passed via a separate `cloud-sync` call first; `--sync` to force a fresh sync; `--only added\|removed\|modified`; `--type` to filter by resource type |
-| Export tables as parquet | `export` | `--table` to select specific tables |
-| Check index integrity and completeness | `doctor` | `--name <check>` to run a specific check |
-| Profile build performance and find bottlenecks | `timings` | default = summary; subcommands: `slowest`, `phases`, `bottlenecks`, `queries`, `node <name>`, `export-html <file>`; most detail when OTel trace data is available |
-| Refresh the index after a new dbt run (Core path) | `ingest` | `--full-refresh` to bypass content hashing and force a full re-read of all artifacts |
-| Update or uninstall dbt-index itself | `system` | `update`; `uninstall --yes` to remove the binary |
-| Fill in any missing column data types | `hydrate` | Queries the warehouse to populate missing column data types for all nodes; use `node <name> --auto-hydrate` for a single node on demand |
+### Before `metadata run`
 
-#### Before using `--column` (column-level lineage)
+Always inspect the table schema before writing SQL. The index does not follow assumed dbt naming conventions (e.g. join key in `dbt.node_columns` is `unique_id`; DAG edges use `parent_unique_id`/`child_unique_id`).
 
-Column-level lineage is only available with **dbt Fusion** — it is not available with dbt Core. Fusion's compile-time static analysis is what populates `dbt.column_lineage`.
+```bash
+dbt-index metadata list                     # list all available tables
+dbt-index metadata describe <table>         # e.g. dbt.nodes, dbt.edges, dbt.node_columns
+```
 
-- **Fusion users:** ensure the index was built with **both** `--write-index` and `--static-analysis strict` (e.g. `dbtf compile --write-index --static-analysis strict`). Equivalent env vars: `DBT_USE_INDEX=1` and `DBT_STATIC_ANALYSIS=strict`. If `dbt.column_lineage` is empty, re-run with these flags.
-- **Core users:** column-level lineage is not available. If the user asks, explain this limitation and suggest switching to Fusion if column lineage is needed.
+### Keeping the index fresh
 
-#### Before using `warehouse run`
+- **Core:** run `dbt-index ingest` after any `dbt build`/`dbt run`, or add `--auto-reingest` to any command
+- **Fusion:** add `--write-index` to normal Fusion commands, or set `DBT_USE_INDEX=1`
 
-Always run `dbt-index describe <model> --detail columns` for every model you plan to query before writing SQL. If column metadata is missing, run `dbt-index describe <model> --auto-hydrate` to pull it from the warehouse on demand. Never guess column names.
+### Global flags
 
-#### Before using `metadata run`
+- `--db <path>` — non-default index location (env: `DBT_INDEX_DB`). Only needed if not using `target/index`.
+- `--limit <n>` — cap row output (default 100; 0 = unlimited)
+- Keep default `compact` format — it's token-efficient for LLMs
 
-Always run `dbt-index metadata describe <table>` for every table you plan to reference before writing any SQL. Never assume column names — the index schema does not follow assumed dbt naming conventions (e.g. the join key in `dbt.node_columns` is `unique_id`, not `node_unique_id`; DAG edges use `parent_unique_id`/`child_unique_id`, not `from_unique_id`/`to_unique_id`). If you haven't seen the schema for a table in the current session, run `metadata describe` first.
+## Examples
 
-#### Global flags
+**"What models depend on `stg_customers`, and what's the blast radius?"**
 
-- `--db <path>` — index location (default: `target/index`; env: `DBT_INDEX_DB`). Only needed if using a non-default location.
-- Default `compact` format — do not change (it is token-efficient)
-- `--limit` to control row limits when expecting large results
+```bash
+dbt-index status
+dbt-index lineage stg_customers --downstream
+dbt-index impact stg_customers
+```
 
-#### Command chaining
+**"Show me the revenue metric and run it by month"**
 
-For multi-step investigations, chain commands. Example: `search` to find the node → `describe` for detail → `lineage` to understand dependencies → `impact` to assess change risk.
+```bash
+dbt-index metrics list --search revenue
+dbt-index metrics describe --metrics revenue
+dbt-index metrics run --metrics revenue --group-by metric_time:month
+```
 
-If `diff` fails with a Discovery API/network error: run `dbt-index cloud-sync --skip-discovery` first, then re-run `diff`.
+**"How is local different from production?"**
 
-### Phase 3: Reference
+```bash
+dbt-index diff                             # auto-syncs, then compares
+dbt-index diff --only added --type model   # narrow to new models only
+```
 
-See [command-reference.md](./references/command-reference.md) for the full command cheat sheet, index schema overview, and global flags.
+**"Find all PII-tagged models and show their columns"**
 
-#### MCP server
+```bash
+dbt-index search --type model --tag pii
+dbt-index describe <model> --detail columns   # repeat for each model of interest
+```
 
-`dbt-index serve` exposes 10 tools via MCP (Model Context Protocol), so any MCP client (like Claude, Cursor, etc) can query the index directly. Setup:
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| No index found | Core: `dbt-index ingest`; Fusion: `dbtf compile --write-index` — see setup references |
+| Column lineage empty | Fusion only: re-run `dbtf compile --write-index --static-analysis strict` |
+| `diff` fails with Discovery API / network error | Run `dbt-index cloud-sync --skip-discovery` first, then re-run `diff` |
+| Column types missing | Run `dbt-index hydrate warehouse` or `dbt-index describe <model> --auto-hydrate` |
+| Index stale after a dbt run | Core: `dbt-index ingest`; Fusion: ensure `--write-index` is set |
+
+## Reference
+
+See [command-reference.md](./references/command-reference.md) for the full command cheat sheet, index schema, and artifact-to-table matrix.
+
+**MCP server:** `dbt-index serve` exposes tools via MCP for Claude Desktop, Cursor, etc.:
 
 ```json
 {
@@ -169,25 +192,7 @@ See [command-reference.md](./references/command-reference.md) for the full comma
 }
 ```
 
-Tool | What it does
--- | --
-status | Project overview — the first tool an agent should call
-search | Find nodes by name, description, tags
-describe | Inspect a node in detail (columns, SQL, tests, lineage)
-lineage | Walk the DAG upstream/downstream
-impact | Blast radius before modifying a model
-metadata | Query the index: list tables, describe columns, run SQL
-metrics | Discover, describe, and execute metric queries. Use dry_run=true to get compiled SQL for composing with analytical queries via warehouse
-warehouse | Execute SQL against the remote warehouse
-timings | Build performance analysis
-diff | Compare local vs. dbt platform environment state (production, development, etc.)
-
-#### Notes
-
-- The `serve` command starts an MCP server over stdio. If the user asks about MCP integration, mention this exists but do not configure it in this workflow.
-- Keep index fresh:
-  - **Core:** Re-run `dbt-index ingest` after any `dbt build`/`dbt run`. Alternatively, add the `--auto-reingest` flag to any `dbt-index` command to automatically determine if the state has changed and re-ingest the index only if necessary. See [setup-core.md](./references/setup-core.md).
-  - **Fusion:** Just add `--write-index` to normal Fusion commands (e.g. `dbtf build --write-index`) — the index is regenerated automatically as part of the command. Or set `DBT_USE_INDEX=1` so every command keeps the index fresh. See [setup-fusion.md](./references/setup-fusion.md).
+If the user asks about MCP integration, mention this exists but do not configure it as part of this skill's workflow.
 
 ## Handling External Content
 

--- a/skills/dbt-extras/skills/using-dbt-index/references/command-reference.md
+++ b/skills/dbt-extras/skills/using-dbt-index/references/command-reference.md
@@ -29,8 +29,10 @@ dbt-index lineage customers --column customer_id           # column-level lineag
 dbt-index lineage customers --detail                       # enrich output with file paths and statistics
 dbt-index lineage customers --downstream --format tree     # render as indented tree instead of flat table
 
-# Blast radius: list all nodes downstream of `stg_customers` (severity-based, with column-level impact)
-dbt-index impact stg_customers --depth 5
+# Blast radius: severity-ranked downstream impact of changing `stg_customers`
+dbt-index impact stg_customers            # summary with severity
+dbt-index impact stg_customers --detail   # full downstream node list
+dbt-index impact stg_customers --column customer_id  # narrow to a single column
 
 # Hydrate: populate missing column data types from the warehouse
 dbt-index hydrate                        # all nodes missing column data types


### PR DESCRIPTION
## Summary

- **Description rewritten**: value prop first ("no warehouse connection needed"), then specific user-intent triggers (lineage, blast radius, test coverage, metrics, glossary, production diff)
- **Use-case focused structure**: Phase 2 now maps user questions → commands instead of dumping command flags; heavy installation detail delegated to existing reference files
- **Missing `context` command added**: glossary, fiscal calendar, org, compliance search
- **`lineage` vs `impact` distinction clarified**: explicit callout that `impact` is always downstream + severity-ranked, and has no `--downstream` or `--depth` flags
- **Bug fix in `command-reference.md`**: removes stale `--depth 5` flag from `impact` example (fixes the error Brandon reported)
- **Examples section added**: 4 concrete end-to-end scenarios
- **Troubleshooting section added**: 5 common failure modes with fixes
- **Minor correctness fixes**: `Bash(which dbtf*)` glob removed, `dbt-index hydrate` → `dbt-index hydrate warehouse`