### PR TITLE
chore: bump plugin versions for next release

### DIFF
--- a/skills/dbt-extras/.claude-plugin/plugin.json
+++ b/skills/dbt-extras/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dbt-extras",
   "description": "Miscellaneous skills for dbt.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "dbt Labs"
   },

--- a/skills/dbt/.claude-plugin/plugin.json
+++ b/skills/dbt/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dbt",
   "description": "Skills for analytics engineering with dbt — building models, writing tests, querying the semantic layer, troubleshooting jobs, and more.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": {
     "name": "dbt Labs"
   },

--- a/skills/dbt/.cursor-plugin/plugin.json
+++ b/skills/dbt/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "dbt",
   "displayName": "dbt",
   "description": "Agent skills for dbt: data modeling, analytics engineering, semantic layer metrics, unit testing, job troubleshooting, and dbt MCP server setup. Covers dbt Core and dbt Cloud workflows.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": {
     "name": "dbt Labs"
   },

--- a/tile.json
+++ b/tile.json
@@ -1,6 +1,6 @@
 {
   "name": "dbt-labs/dbt-agent-skills",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "summary": "A curated collection of Agent Skills for working with dbt, to help AI agents understand and execute dbt workflows more effectively.",
   "private": false,
   "docs": "README.md",


### PR DESCRIPTION
## Summary

Version bumps for plugins changed in this release cycle:

| Plugin | File(s) | Old | New | Reason |
|--------|---------|-----|-----|--------|
| dbt | `.claude-plugin/plugin.json`, `.cursor-plugin/plugin.json` | `1.3.0` | `1.3.1` | Patch — Fusion `--resource-type` fix in `running-dbt-commands` (#111) |
| dbt-extras | `.claude-plugin/plugin.json` | `1.1.0` | `1.2.0` | Minor — `using-dbt-index` skill rewrite (#112) |
| tile.json | `tile.json` | `1.3.0` | `1.3.1` | Patch — covers `running-dbt-commands` change (`using-dbt-index` not listed in tile.json) |