### PR TITLE
fix(ci): migrate from deprecated tesslio/publish to tesslio/setup-tessl

### DIFF
--- a/.github/workflows/publish-tile.yml
+++ b/.github/workflows/publish-tile.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: tesslio/publish@dcef29a61e77d536ca82c7582d5225361862a644 # latest commit as of 2026-02-20
+      - uses: tesslio/setup-tessl@25ec223fc0da33b41b8044ff5ab2b85235f4f91e # v2
         with:
           token: ${{ secrets.TESSL_API_TOKEN }}
+      - run: tessl tile publish


### PR DESCRIPTION
## Summary

- `tesslio/publish` repo has been archived and deprecated in favour of `tesslio/setup-tessl`
- The pinned commit (`dcef29a`) predated a bug fix (commit `0a73f23`: *fix: use singular error from api, not deprecated errors*), which caused the [CI failure on the last push](https://github.com/dbt-labs/dbt-agent-skills/actions/runs/25366187286)
- Migrates to `tesslio/setup-tessl@v2` (pinned to commit SHA) + `tessl tile publish` as recommended in the new action's README