### PR TITLE
fix(ci): skip evals and document Tessl troubleshooting

### DIFF
--- a/.github/workflows/publish-tile.yml
+++ b/.github/workflows/publish-tile.yml
@@ -17,4 +17,4 @@ jobs:
       - uses: tesslio/setup-tessl@25ec223fc0da33b41b8044ff5ab2b85235f4f91e # v2
         with:
           token: ${{ secrets.TESSL_API_TOKEN }}
-      - run: tessl tile publish
+      - run: tessl tile publish --skip-evals

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -35,3 +35,5 @@ The Claude marketplace automatically scans this repository — no manual action 
 
 [Tessl](https://tessl.io) has a GitHub Action configured in this repo that handles submission automatically on merge to `main`. Skills are evaluated against Tessl's quality standards and added to their open registry.
 
+If the action fails with `401 Unauthorized`, the `TESSL_API_TOKEN` secret has expired. Doug Beatty or Benoit Perigaud can generate a new token at tessl.io and update the secret in the repo settings.
+

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -35,5 +35,8 @@ The Claude marketplace automatically scans this repository — no manual action 
 
 [Tessl](https://tessl.io) has a GitHub Action configured in this repo that handles submission automatically on merge to `main`. Skills are evaluated against Tessl's quality standards and added to their open registry.
 
-If the action fails with `401 Unauthorized`, the `TESSL_API_TOKEN` secret has expired. Doug Beatty or Benoit Perigaud can generate a new token at tessl.io and update the secret in the repo settings.
+**Troubleshooting:**
+
+- `401 Unauthorized` — the `TESSL_API_TOKEN` secret has expired. Doug Beatty or Benoit Perigaud can generate a new token at tessl.io and update the secret in the repo settings.
+- Eval parse errors — the `evals/` directory is not Tessl-format evals; the workflow uses `--skip-evals` to bypass this.
 


### PR DESCRIPTION
- Adds `--skip-evals` to `tessl tile publish` — the `evals/` directory uses a different format that Tessl misidentifies as broken eval scenarios
- Documents both known failure modes in RELEASING.md (expired token, eval parse errors)