### PR TITLE
DI-4173: scope job debugging to current project in troubleshooting skill

### DIFF
--- a/skills/dbt/skills/troubleshooting-dbt-job-errors/SKILL.md
+++ b/skills/dbt/skills/troubleshooting-dbt-job-errors/SKILL.md
@@ -40,9 +40,10 @@ A failing test is evidence of a problem. Changing the test to pass hides the pro
 ```mermaid
 flowchart TD
     A[Job failure reported] --> B{MCP Admin API available?}
-    B -->|yes| C[Use list_jobs_runs to get history]
+    B -->|yes| C[Determine current project_id]
     B -->|no| D[Ask user for logs and run_results.json]
-    C --> E[Use get_job_run_error for details]
+    C --> C2[list_jobs, filter by project_id]
+    C2 --> E[list_jobs_runs by job_id, get_job_run_error]
     D --> F[Classify error type]
     E --> F
     F --> G{Error type?}
@@ -59,6 +60,14 @@ flowchart TD
     M --> P[Document what was checked and next steps]
 ```
 
+## Step 0: Scope to the Current Project
+
+**The Admin API run tools are account-wide, not project-scoped.** `list_jobs_runs` without a `job_id` returns runs from *every* project in the account, so "the most recent run" may belong to a different project than the one you are investigating.
+
+1. Determine the current `project_id`. If unavailable, ask the user.
+2. Call `list_jobs` and keep only jobs whose `project_id` matches the current project (`list_jobs` returns `project_id` and `environment_id` per job).
+3. Only then call `list_jobs_runs(job_id=<id>, status="error", …)` for those jobs. Each returned run also carries `project_id` — discard any that don't match. Never select a run whose job isn't confirmed to belong to the current project.
+
 ## Step 1: Gather Job Run Information
 
 ### If dbt MCP Server Admin API Available
@@ -67,14 +76,20 @@ Use these tools first - they provide the most comprehensive data:
 
 | Tool | Purpose |
 |------|---------|
-| `list_jobs_runs` | Get recent run history, identify patterns |
+| `list_jobs` | List jobs in the account; filter by `project_id` to scope to the current project |
+| `list_jobs_runs` | Get recent run history for a specific job (always pass `job_id`) |
 | `get_job_run_error` | Get detailed error message and context |
 
 ```
-# Example: Get recent runs for job 12345
-list_jobs_runs(job_id=12345, limit=10)
+# Step 0: scope to current project (project_id = 1234 in this example)
+jobs = list_jobs()
+project_jobs = [j for j in jobs if j["project_id"] == 1234]
 
-# Example: Get error details for specific run
+# Step 1: get recent failed runs for each project job
+for job in project_jobs:
+    list_jobs_runs(job_id=job["id"], status="error", limit=5)
+
+# Step 2: get error details for a specific run
 get_job_run_error(run_id=67890)
 ```
 

--- a/skills/dbt/skills/troubleshooting-dbt-job-errors/SKILL.md
+++ b/skills/dbt/skills/troubleshooting-dbt-job-errors/SKILL.md
@@ -40,10 +40,9 @@ A failing test is evidence of a problem. Changing the test to pass hides the pro
 ```mermaid
 flowchart TD
     A[Job failure reported] --> B{MCP Admin API available?}
-    B -->|yes| C[Determine current project_id]
+    B -->|yes| C[list_jobs, filter to target project/env]
     B -->|no| D[Ask user for logs and run_results.json]
-    C --> C2[list_jobs, filter by project_id]
-    C2 --> E[list_jobs_runs by job_id, get_job_run_error]
+    C --> E[list_jobs_runs by job_id, get_job_run_error]
     D --> F[Classify error type]
     E --> F
     F --> G{Error type?}
@@ -60,36 +59,30 @@ flowchart TD
     M --> P[Document what was checked and next steps]
 ```
 
-## Step 0: Scope to the Current Project
-
-**The Admin API run tools are account-wide, not project-scoped.** `list_jobs_runs` without a `job_id` returns runs from *every* project in the account, so "the most recent run" may belong to a different project than the one you are investigating.
-
-1. Determine the current `project_id`. If unavailable, ask the user.
-2. Call `list_jobs` and keep only jobs whose `project_id` matches the current project (`list_jobs` returns `project_id` and `environment_id` per job).
-3. Only then call `list_jobs_runs(job_id=<id>, status="error", …)` for those jobs. Each returned run also carries `project_id` — discard any that don't match. Never select a run whose job isn't confirmed to belong to the current project.
-
 ## Step 1: Gather Job Run Information
 
 ### If dbt MCP Server Admin API Available
 
 Use these tools first - they provide the most comprehensive data:
 
+> **Note:** `list_jobs` and `list_jobs_runs` results may span multiple projects/environments depending on how the Admin API is configured. Each `list_jobs` entry carries `project_id` and `environment_id`; runs also carry `project_id`. When you have a target job, always pass `job_id` to `list_jobs_runs`. When selecting among jobs, filter to the project/environment you're investigating.
+
 | Tool | Purpose |
 |------|---------|
-| `list_jobs` | List jobs in the account; filter by `project_id` to scope to the current project |
+| `list_jobs` | List jobs; each entry carries `project_id` and `environment_id` for filtering to the target project/environment |
 | `list_jobs_runs` | Get recent run history for a specific job (always pass `job_id`) |
 | `get_job_run_error` | Get detailed error message and context |
 
 ```
-# Step 0: scope to current project (project_id = 1234 in this example)
+# List jobs and filter to the target project/environment (project_id = 1234 in this example)
 jobs = list_jobs()
-project_jobs = [j for j in jobs if j["project_id"] == 1234]
+target_jobs = [j for j in jobs if j["project_id"] == 1234]
 
-# Step 1: get recent failed runs for each project job
-for job in project_jobs:
+# Get recent failed runs for each job
+for job in target_jobs:
     list_jobs_runs(job_id=job["id"], status="error", limit=5)
 
-# Step 2: get error details for a specific run
+# Get error details for a specific run
 get_job_run_error(run_id=67890)
 ```
 
@@ -257,7 +250,7 @@ Commit this document to the repository so findings aren't lost.
 
 | Task | Tool/Command |
 |------|--------------|
-| Get job run history | `list_jobs_runs` (MCP) |
+| Get job run history | `list_jobs` (filter by project/env) → `list_jobs_runs(job_id=…)` (MCP) |
 | Get detailed error | `get_job_run_error` (MCP) |
 | Check recent git changes | `git log --oneline -20` |
 | Parse project | `dbt parse` |


### PR DESCRIPTION
## Why

When a Studio user asks the agent to debug job failures, it calls `list_jobs_runs` without a `job_id` or project filter and debugs the most-recent run account-wide — which can be from a completely different project.

## What

Revises the `troubleshooting-dbt-job-errors` skill with a client-agnostic correctness fix:

- Adds a **generic note** (not Studio-specific) that `list_jobs`/`list_jobs_runs` results may span multiple projects/environments depending on how the Admin API is configured. Instructs the agent to always pass `job_id` and filter to the project/environment being investigated.
- Updates the **mermaid diagram**, **Step 1 example**, and **Quick Reference** to consistently show the `list_jobs` (filter) → `list_jobs_runs(job_id=…)` flow rather than a bare account-wide call.

Studio-specific scoping (filter to `client_context.project_id`) lives in the ai-codegen-api system prompt — PR dbt-labs/ai-codegen-api#1143.

## Notes

Dropped the earlier "Step 0: determine the current `project_id`" framing per review feedback from @wiggzz: the tools aren't inherently account-wide — `AdminApiConfig` can scope them server-side, and true `project_id` scoping is in-flight in dbt-mcp. The account-wide behaviour is specific to how ACA wires the config today.

## Refs

- DI-4173
- dbt-labs/ai-codegen-api#1143 (Studio system prompt fix — merge this first, then bump the `dbt-skills` rev there)

Drafted by claude-sonnet-4-6 under the direction of @theyostalservice