### PR TITLE
fix invalid SQL syntax in reference example

### DIFF
--- a/skills/dbt/skills/adding-dbt-unit-test/references/examples.md
+++ b/skills/dbt/skills/adding-dbt-unit-test/references/examples.md
@@ -167,7 +167,7 @@ unit_tests:
         format: sql
         rows: |
           select 1 as id, 'gerda' as name, null as loaded_at union all
-          select 2 as id, 'michelle', null as loaded_at as name
+          select 2 as id, 'michelle' as name, null as loaded_at
 
 ```
 


### PR DESCRIPTION
resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-oss-template/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-oss-template/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
