### PR TITLE
Fix template placeholders, remove phantom Docker dependabot config

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -4,7 +4,7 @@ headerPath: header.tpl.md
 changelogPath: CHANGELOG.md
 versionExt: md
 envPrefix: CHANGIE_
-versionFormat: '## dbt-oss-template {{.Version}} - {{.Time.Format "January 02, 2006"}}'
+versionFormat: '## dbt-agent-skills {{.Version}} - {{.Time.Format "January 02, 2006"}}'
 kindFormat: '### {{.Kind}}'
 changeFormat: '* {{.Body}}'
 kinds:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,6 @@ updates:
       interval: "daily"
     rebase-strategy: "disabled"
 
-  # docker dependencies
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    rebase-strategy: "disabled"
-
   # github dependencies
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,9 +15,9 @@ resolves #
 
 ### Checklist
 
-- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-oss-template/blob/main/CONTRIBUTING.md) and understand what's expected of me
+- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-agent-skills/blob/main/CONTRIBUTING.md) and understand what's expected of me
 - [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
-- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-oss-template/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
+- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-agent-skills/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
  


### PR DESCRIPTION
## Summary

1. .github/pull_request_template.md: replace "dbt-oss-template" with "dbt-agent-skills" (there may be multiple occurrences)
2. .changie.yaml: replace "dbt-oss-template" with "dbt-agent-skills"
3. .github/dependabot.yml: remove the Docker ecosystem entry (there's no Dockerfile in this repo, so it has no effect)

## Test plan

- [x] Changes are cosmetic/config only — no behavior change
- [x] Verified patterns exist before fixing