### PR TITLE
feat: building looker lookml views from a dbt model

### DIFF
--- a/.changes/unreleased/Features-20260807-035713.yaml
+++ b/.changes/unreleased/Features-20260807-035713.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add skill for generating Looker LookML views and explores from dbt fact/dim models.
+time: 2026-08-07T03:57:13.884763+03:00
+custom:
+    Author: mustafaa7med
+    Issue: "147"

--- a/skills/dbt/skills/building-looker-lookml-from-dbt/SKILL.md
+++ b/skills/dbt/skills/building-looker-lookml-from-dbt/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: building-looker-lookml-from-dbt
+description: Generates LookML views and explores in a Looker project from a dbt fact or dim model, suggesting dimensions, measures, business-relevant derived metrics, and joins. Use when a user asks to create a new Looker view/model for a fact or dim table they've just built or are pointing to. Does not build or modify dbt models.
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(dbt *)
+user-invocable: false
+metadata:
+  author: mustafaa7med
+---
+
+# Building Looker LookML from dbt
+
+**Core principle:** LookML is generated from an existing fact or dim model, into a separate LookML project that the user points you to. This skill never touches dbt models — it's a one-way, downstream step from dbt to Looker.
+
+## When to Use
+
+- The user asks to create a new Looker view (or explore) for a fact and/or dim model they've built or named
+- The user wants LookML regenerated/updated for an existing fact/dim model whose columns changed
+
+**Do NOT use for:**
+
+- Building, modifying, or refactoring dbt models — this skill only reads finished fact/dim models and writes LookML. If no fact or dim model exists yet, say so and stop; don't create one.
+- Staging or intermediate models — LookML views are for BI-facing mart models only. If the user points you at a staging/intermediate model, flag that it's not typically exposed in Looker and confirm before proceeding.
+
+## Step 0: Find Out Where the LookML Lives
+
+LookML views are files (`.view.lkml`, `.model.lkml`) in a Looker project, which is almost always a **separate Git repo** from the dbt project. Unless the user has a Looker MCP active.
+
+**Always ask the user where this project lives** if it isn't already established in this conversation (e.g. a cloned Looker repo path on disk). Do not assume a location or create one unless the user asks for it. Once given a path:
+
+- Look at the existing folder structure and naming of `.view.lkml` files there to learn the team's convention — one view per mart model, views grouped by subject area, a specific `views/` subfolder, etc. — before writing anything new.
+- If you can't find any existing views to infer a convention from, ask rather than guessing.
+
+## Step 1: Understand the Business Context via dbt Exposures
+
+Before generating dimensions or, especially, suggesting metrics, look for a dbt **exposure** that documents the dashboard/use case this model feeds:
+
+```yaml
+exposures:
+  - name: sales_pipeline_dashboard
+    type: dashboard
+    depends_on:
+      - ref('fct__salesforce_activity')
+    description: >
+      Tracks opportunity stage progression and conversion rates for the sales team.
+```
+
+- If an exposure references this model, use its `description` and `depends_on` to understand what the model is for — this is what grounds good metric suggestions (see Step 3).
+- **If no exposure exists, do not guess the business context.** Ask the user a short clarifying question instead — e.g. "What does this fact table represent, and what should I know about how it's used?" Proceeding without this context risks suggesting metrics that don't match how the business actually thinks about the data.
+
+## Step 2: Check for an Existing View File
+
+Before writing anything:
+
+1. Determine the expected filename from the model name (see naming convention below) and check whether it already exists in the target directory.
+2. **If it exists, stop and ask the user** what they want to do — update it, leave it alone, or replace it. Never silently overwrite or create a duplicate file with a modified name.
+3. If it doesn't exist, proceed to generation.
+
+## Naming Convention
+
+The view name mirrors the dbt model name exactly, and the file is `<model_name>.view.lkml`:
+
+| dbt model | LookML view file |
+| --- | --- |
+| `fct__salesforce_activity` | `fct__salesforce_activity.view.lkml` |
+| `dim__salesforce_opportunities` | `dim__salesforce_opportunities.view.lkml` |
+
+Don't shorten, reformat, or reorder the name — the view name should make it obvious which dbt model it came from.
+
+## Step 3: Generate the View
+
+Read the model's YAML (columns, `data_type`, `description`, `data_tests`, `meta.looker` overrides) and its actual compiled SQL/schema to confirm current columns and types — see [references/mapping-dbt-types-to-lookml.md](references/mapping-dbt-types-to-lookml.md) for the type mapping and dimension-group rules.
+
+Applies to both fact and dim models:
+
+- **One view per dbt model**, unless the existing convention in the target repo says otherwise (checked in Step 0).
+- **`sql_table_name`**: reference the model's actual warehouse location (schema.table), read from the model's `config` (schema/alias/database) — never hardcode a name that could drift from how dbt actually materializes it.
+- **Primary key**: a column with a `unique` + `not_null` test (or a single-column `unique_key` in an incremental config) becomes `primary_key: yes` on its dimension.
+- **Dates/timestamps**: never emit a raw timestamp as a plain `string`/`number` dimension. Always use a `dimension_group` with `type: time` and a sensible `timeframes` list.
+- **`meta.looker` overrides win** over anything inferred from type/name.
+
+### If it's a fact model (`fct__...`)
+
+- Generate dimensions for all columns as above.
+- Generate measures based on what the table actually contains (e.g. a `count` on the primary key; sums on genuinely additive numeric columns).
+- **Suggest possible derived business metrics**, using the exposure's business context from Step 1. This is the most valuable and most error-prone part of the skill — see [references/suggesting-fact-metrics.md](references/suggesting-fact-metrics.md) for how to do this responsibly (e.g. a table with per-stage timestamp columns on a sales opportunity table suggests a stage-to-stage conversion-rate metric — but only surface it as a *suggestion* for the user to confirm, never add it to the view unprompted).
+
+### If it's a dim model (`dim__...`)
+
+- **Dimensions only** — do not generate measures or suggest metrics for dim models. A dim model describes entities, not events; metrics belong on the fact side.
+
+## Step 4: Create or Update the Explore
+
+After the view is written, check whether an explore is needed for this model:
+
+- If the model is a fact table, it's very likely the base of a new (or existing) explore.
+- Look at the fact model's columns for foreign keys (e.g. `opportunity_id` on `fct__salesforce_activity`) and check whether a corresponding dim model exists (`dim__salesforce_opportunities`) that would add useful descriptive fields.
+- **Suggest the join, don't assume it's wanted.** Present it as a recommendation — "`fct__salesforce_activity` has an `opportunity_id` FK; joining `dim__salesforce_opportunities` would add opportunity name, owner, and amount fields — want me to add this join?" — and confirm before adding it to the explore.
+- Follow [references/generating-explores-and-joins.md](references/generating-explores-and-joins.md) for how to derive join keys, join type, and `relationship:` correctly (via `relationships` tests where they exist, or the FK-naming heuristic above when they don't — always flagged as a suggestion either way).
+- Dim models generally don't need their own explore unless the user asks for one to browse the dimension standalone.
+
+## Reference Guides
+
+| Guide | Use When |
+| --- | --- |
+| [references/mapping-dbt-types-to-lookml.md](references/mapping-dbt-types-to-lookml.md) | Translating column data types (including Redshift-specific types) into LookML dimension/dimension_group types |
+| [references/suggesting-fact-metrics.md](references/suggesting-fact-metrics.md) | Turning a fact table's actual columns and business context into responsible, confirmed-before-adding metric suggestions |
+| [references/generating-explores-and-joins.md](references/generating-explores-and-joins.md) | Deriving join keys and relationship types from FK columns, `relationships` tests, and dim model lookups |
+
+## Common Mistakes and Red Flags
+
+| Mistake | Fix |
+| --- | --- |
+| Assuming where the LookML project lives | Always ask in Step 0 if not already given |
+| Guessing business context without an exposure | Ask a clarifying question instead — never invent the use case |
+| Overwriting an existing `.view.lkml` silently | Stop and ask the user what to do before touching an existing file |
+| Adding measures/metrics to a dim model | Dim models get dimensions only — no measures, no metric suggestions |
+| Adding a suggested metric or join directly without confirming | Suggestions are proposals — confirm before writing them into the file |
+| Emitting `type: string` for a timestamp column | Always use a `type: time` dimension group |
+| Building or editing the dbt model itself | Out of scope — this skill only reads finished fact/dim models |
+
+**STOP if you're about to:** write to a LookML path the user hasn't confirmed, overwrite an existing view file without asking, invent a business metric without exposure context or user confirmation, or add measures to a dim model.

--- a/skills/dbt/skills/building-looker-lookml-from-dbt/generating-explores-and-joins.md
+++ b/skills/dbt/skills/building-looker-lookml-from-dbt/generating-explores-and-joins.md
@@ -1,0 +1,65 @@
+# Generating Explores and Joins
+
+An `explore:` in LookML is a join graph. A fact model is almost always the base of an explore; dim models are the tables it joins out to. Every join below is a **suggestion to confirm with the user**, not something to write into the file automatically.
+
+## Finding join candidates
+
+For the fact model you just built a view for, look at its columns for foreign keys — typically an `_id` column that isn't the table's own primary key:
+
+```yaml
+# fct__salesforce_activity
+columns:
+  - name: activity_id       # primary key of this table
+  - name: opportunity_id    # looks like a foreign key
+  - name: activity_type
+  - name: logged_at
+```
+
+For each FK candidate, check whether a corresponding dim model exists:
+
+1. **Check for a `relationships` test** — the strongest signal:
+   ```yaml
+   - name: opportunity_id
+     data_tests:
+       - relationships:
+           to: ref('dim__salesforce_opportunities')
+           field: opportunity_id
+   ```
+   If this exists, the join is confirmed by dbt itself — use the `to`/`field` values directly as the `sql_on:`.
+
+2. **If no `relationships` test exists**, fall back to the naming heuristic: an FK column named `opportunity_id` strongly suggests a `dim__..._opportunities` (or similarly named) model exists. Check for it. If found, this is still just a **suggestion** — present it to the user rather than assuming the relationship is correct, since naming similarity isn't a guarantee the columns mean the same thing.
+
+3. **If neither signal exists**, don't invent a join — mention that you didn't find a confirmed or plausible relationship for that column, in case the user knows of one you can't see from the files alone.
+
+## Presenting the suggestion
+
+State it plainly, e.g.:
+
+> `fct__salesforce_activity` has an `opportunity_id` column. `dim__salesforce_opportunities` exists and has a matching `unique` + `not_null` test on `opportunity_id`. Joining it would let you slice activity by opportunity name, owner, and stage. Add this join to the explore?
+
+Only write the `join:` block after the user confirms.
+
+## Join type and relationship
+
+- Default to `type: left_outer` for fact → dim joins, so fact rows with a null FK aren't dropped.
+- Set `relationship:` based on what's actually true of the join key on the dim side:
+  - If the dim's join column has a `unique` test → `relationship: many_to_one`.
+  - If it doesn't, don't assert `many_to_one` — flag that the relationship's cardinality isn't confirmed, since an unconfirmed `many_to_one` on a non-unique key will silently fan out rows and inflate every measure in the explore.
+
+## Example
+
+Given the `relationships` test above, plus a `unique` test on `dim__salesforce_opportunities.opportunity_id`:
+
+```lkml
+explore: fct__salesforce_activity {
+  join: dim__salesforce_opportunities {
+    type: left_outer
+    sql_on: ${fct__salesforce_activity.opportunity_id} = ${dim__salesforce_opportunities.opportunity_id} ;;
+    relationship: many_to_one
+  }
+}
+```
+
+## Dim models generally don't need their own explore
+
+A dim model is usually only explored through the fact tables that join to it. Don't create a standalone explore for a dim model unless the user specifically asks to browse it on its own.

--- a/skills/dbt/skills/building-looker-lookml-from-dbt/mapping-dbt-types-to-lookml.md
+++ b/skills/dbt/skills/building-looker-lookml-from-dbt/mapping-dbt-types-to-lookml.md
@@ -1,0 +1,47 @@
+# Mapping dbt Column Types to LookML
+
+Use this table to translate a column's warehouse data type into a LookML dimension `type:`. Prefer the type declared in the model's YAML (`data_tests`/`data_type` under `columns:`); if it isn't declared, introspect with `dbt show --select <model> --limit 1` or a warehouse `information_schema` query rather than guessing from the column name.
+
+## General mapping
+
+| Source type | LookML `type:` | Notes |
+| --- | --- | --- |
+| `varchar`, `text`, `string`, `char` | `string` | Default case |
+| `boolean`, `bool` | `yesno` | LookML has no plain `boolean` dimension type |
+| `integer`, `bigint`, `smallint`, `int` | `number` | Do not add `value_format_name` unless the column is a measure of currency/percent |
+| `decimal`, `numeric`, `float`, `double precision`, `real` | `number` | Consider `value_format_name` if the YAML description implies currency, percent, etc. |
+| `date` | `dimension_group`, `type: time`, `datatypes: [date]` | `timeframes: [date, week, month, quarter, year]` is a reasonable default |
+| `timestamp`, `timestamptz`, `datetime` | `dimension_group`, `type: time`, `datatypes: [datetime]` (or `epoch` if stored as unix time) | `timeframes: [raw, time, date, week, month, quarter, year]` |
+| `json`, `jsonb`, `variant`, `object`, `struct` | `string` (usually) | Flag for manual review — nested/semi-structured columns often need per-key dimensions rather than a single dump; don't silently serialize the whole blob into one dimension without asking |
+| `array`, `list` | Flag for manual review | LookML has no native array type; needs either an unnest step upstream in dbt or an explicit decision on how to represent it |
+
+## Redshift-specific types
+
+| Redshift type | LookML `type:` | Notes |
+| --- | --- | --- |
+| `super` | Flag for manual review | Same reasoning as JSON above — don't guess a flattening strategy |
+| `geometry`, `geography` | Flag for manual review | No first-class LookML geo dimension type; typically extract lat/lon as separate `number` dimensions upstream in dbt, then map those |
+| `varchar(n)` | `string` | The length constraint doesn't need to be reflected in LookML |
+| `timestamp` vs `timestamptz` | Both → `dimension_group` (`type: time`) | If the warehouse column is `timestamptz`, note the timezone handling in the dimension's `description` so downstream users aren't surprised by conversion behavior |
+
+## Naming and grouping
+
+- A raw timestamp/date column should never appear as a standalone `dimension:` — it should always be wrapped as a `dimension_group` so Looker generates the `_date`, `_week`, `_month`, etc. variants automatically.
+- Name the dimension group after the column with the type suffix stripped (e.g. `created_at` → `dimension_group: created`), matching Looker's own generator convention, so the generated fields read as `created_date`, `created_month`, etc.
+- Boolean columns modeled as `is_*` or `has_*` in dbt should keep that prefix in the LookML dimension name — don't rename them.
+
+## When `meta.looker` is present
+
+If the model's YAML has:
+
+```yaml
+columns:
+  - name: order_status
+    data_type: varchar
+    meta:
+      looker:
+        value_format_name: id
+        hidden: true
+```
+
+Apply every key under `meta.looker` directly onto the generated dimension, overriding whatever the table above would otherwise produce. This block exists specifically so analytics engineers can correct cases the generator gets wrong — never override it with an inferred default.

--- a/skills/dbt/skills/building-looker-lookml-from-dbt/suggesting-fact-metrics.md
+++ b/skills/dbt/skills/building-looker-lookml-from-dbt/suggesting-fact-metrics.md
@@ -1,0 +1,44 @@
+# Suggesting Business Metrics on Fact Tables
+
+This is the highest-value and highest-risk part of the skill: reading a fact table's actual shape and proposing metrics a business user would recognize — without inventing something the data doesn't actually support, and without adding anything to the LookML without confirmation.
+
+## Ground every suggestion in two things
+
+1. **What the columns actually contain** — not what a generic fact table "usually" has.
+2. **The business context from the dbt exposure** (Step 1 in SKILL.md), or the user's own explanation if no exposure exists.
+
+If you have neither, don't suggest metrics — ask what the table represents first.
+
+## Pattern: per-stage timestamp columns → stage conversion metrics
+
+A common shape on funnel/pipeline fact tables is one timestamp column per stage the record can pass through:
+
+```yaml
+columns:
+  - name: entered_prospecting_at
+  - name: entered_qualification_at
+  - name: entered_proposal_at
+  - name: entered_closed_won_at
+  - name: entered_closed_lost_at
+```
+
+This shape supports:
+
+- **Stage duration**: time between consecutive non-null stage timestamps for a given record (`entered_proposal_at - entered_qualification_at`).
+- **Stage-to-stage conversion rate**: `count(records where entered_X_at is not null and entered_Y_at is not null) / count(records where entered_X_at is not null)` for adjacent stages.
+- **Overall win rate**: `count(entered_closed_won_at is not null) / count(entered_closed_won_at is not null OR entered_closed_lost_at is not null)`.
+
+Only propose the specific stages that actually exist as columns — don't assume a generic sales funnel shape (e.g. don't assume "qualification" exists just because "prospecting" and "proposal" do).
+
+## Other shapes worth recognizing
+
+- **A single `status`/`stage` column with no per-stage timestamps** → can support a distribution/count-by-status measure, but *not* a duration or conversion-rate metric — there's no time dimension to compute a rate from. Don't propose a conversion metric here; propose a count-by-status breakdown instead.
+- **An amount/value column alongside a status column** (e.g. `opportunity_amount`, `stage`) → supports weighted-pipeline metrics (`sum(amount) where stage not in (closed_won, closed_lost)`), but only if the exposure/user context confirms this is genuinely how the business values open pipeline — don't assume every amount column should be summed for every status.
+- **A boolean/flag column** (`is_converted`, `is_churned`) → supports a straightforward rate measure (`count(where flag) / count(*)`), which is low-risk to propose since it needs no invented logic.
+- **Event-level fact tables with a repeated grain per entity** (e.g. one row per page view, one row per activity) → be cautious proposing "conversion" metrics directly on the fact; often the correct move is a *derived* measure at a different grain, which may be better served by a dbt model change rather than a LookML measure. If the correct fix looks like it needs new dbt logic, say so and stop — that's out of scope for this skill.
+
+## How to present suggestions
+
+- List each suggested metric with the plain-language business question it answers, the columns it would use, and the LookML `measure:` you'd write for it.
+- Never write the suggested measure into the file until the user confirms which ones they want.
+- If a suggested metric requires calculating something dbt hasn't already precomputed (e.g. a time delta between two `dimension_group` timestamps), show the LookML `sql:` you'd use — LookML supports this directly (`sql: ${entered_proposal_raw} - ${entered_qualification_raw} ;;` with an appropriate `type: duration` measure) — but flag if the calculation would be meaningfully more reliable if computed once in dbt instead of on every query.


### PR DESCRIPTION
Solves issue #147

## **What**

Adding a new skill called`building-looker-lookml-from-dbt` It triggers when a user asks to create a Looker view for a fact or dim model they've built. It's strictly one-directional and downstream: it reads a finished fact/dim model and writes LookML into a separate Looker project the user points it to, it never builds or edits dbt models.

## **Why**

The existing skill set covers model building, testing, the semantic layer, and mesh governance, but nothing addresses turning a finished fact/dim model into a usable Looker view. This skill covers:

- Creating LookML views derived from the fact and/or the dim in a dbt model.
- Generating dimensions (with correct type mapping, including Redshift-specific types) and a primary key from a fact/dim model's YAML
- Generating measures and *suggesting* business-relevant derived metrics on fact models only (e.g. stage-to-stage conversion rate from per-stage timestamp columns), grounded in the model's dbt exposure rather than invented
- Keeping dim models metric-free, since dim models describe entities, not events
- Suggesting joins from FK columns and `relationships` tests, and only adding them to an explore after the user confirms
- Asking where the target Looker project lives instead of assuming, and stopping to ask before overwriting an existing `.view.lkml` file.
- Create an explore out of the created LookML Views.

## **What's included**

- `building-looker-lookml-from-dbt/SKILL.md`
- `references/mapping-dbt-types-to-lookml.md` — type mapping table, including a Redshift-specific section
- `references/suggesting-fact-metrics.md` — patterns for recognizing metric-worthy column shapes on fact tables and presenting them as confirmed-before-adding suggestions
- `references/generating-explores-and-joins.md` — join derivation from FK columns and `relationships` tests, always presented as a suggestion

## **Testing performed**

- Validated `SKILL.md` frontmatter against the spec in `CONTRIBUTING.md` (`name` matches folder name, `description` starts by stating the trigger, only allowed frontmatter fields used, `user-invocable: false`).
- Manually walked the skill against a sample fact table with per-stage timestamp columns and a matching dim table, with and without a `relationships` test, to confirm the suggested metrics and join were presented as suggestions rather than written automatically.
- Confirmed the skill stops and asks when: no LookML path is given, an exposure can't be found, and an existing view file is already present.
- No existing skills reference or depend on this one, so no cross-skill regressions expected.

## Checklist

- [x]  I have read [the contributing guide](https://github.com/dbt-labs/dbt-agent-skills/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run changie new to [create a changelog entry](https://github.com/dbt-labs/dbt-agent-skills/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)