### PR TITLE
Add bundle-regeneration workflow and regenerate compiled reference bundles

### DIFF
--- a/.github/workflows/upgrading-dbt-core-kb.yml
+++ b/.github/workflows/upgrading-dbt-core-kb.yml
@@ -1,0 +1,93 @@
+name: upgrading-dbt-core KB
+
+# The upgrading-dbt-core skill reads pre-compiled reference bundles
+# (references/kb_<version>_<warehouse>.json) rather than running `collect` at
+# migration time. The bundles are a pure function of kb/ + tools.py and are
+# committed, so this job regenerates them on every PR that could invalidate them
+# and pushes the result back to the PR branch.
+#
+# Why this cannot loop:
+#   1. Pushes made with the default GITHUB_TOKEN do not trigger workflow runs.
+#      GitHub suppresses that specifically to prevent recursion, so the commit
+#      below starts no second run. (This changes if the token is ever swapped
+#      for a PAT or GitHub App token.)
+#   2. Even if it did re-trigger, collect-all is deterministic and writes no
+#      timestamps, so the next run regenerates identical bytes, finds nothing to
+#      commit, and pushes nothing. The loop has a fixed point at one iteration.
+# No actor/message guard is needed, and adding one would obscure the above.
+
+permissions:
+  contents: write
+
+on:
+  pull_request:
+    paths:
+      - "skills/dbt-migration/skills/upgrading-dbt-core/kb/**"
+      - "skills/dbt-migration/skills/upgrading-dbt-core/references/**"
+      - "skills/dbt-migration/skills/upgrading-dbt-core/scripts/**"
+      - ".github/workflows/upgrading-dbt-core-kb.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bundles:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: skills/dbt-migration/skills/upgrading-dbt-core
+    env:
+      HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      # A fork PR gets a read-only GITHUB_TOKEN and no push access to the fork,
+      # so it takes the verify-only path below. Using pull_request_target to get
+      # a writable token instead would execute the PR's own tools.py with write
+      # scope on a public repo — don't.
+      CAN_PUSH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # actions/checkout@v6
+        with:
+          # The PR branch itself, not the ephemeral merge commit, so there is
+          # something to push back to.
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install pyyaml jsonschema
+
+      - name: Validate the kb corpus
+        run: python scripts/validate.py
+
+      - name: Regenerate reference bundles
+        run: python scripts/tools.py collect-all --prune
+
+      - name: Commit regenerated bundles
+        if: env.CAN_PUSH == 'true'
+        run: |
+          # --porcelain, not `git diff`: a brand-new bundle (new adapter dir or
+          # new from_version in kb/) is untracked, and git diff would miss it.
+          if [ -z "$(git status --porcelain -- references)" ]; then
+            echo "references/ already in sync with kb/ — nothing to commit"
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add references
+          git commit -m "chore: regenerate upgrading-dbt-core reference bundles"
+          # Retry on a race with a contributor pushing to the same branch
+          # mid-run; the rebase replays our commit on top of theirs.
+          for attempt in 1 2 3; do
+            if git push origin "HEAD:$HEAD_REF"; then
+              echo "pushed regenerated bundles to $HEAD_REF"
+              exit 0
+            fi
+            echo "push rejected (attempt $attempt), rebasing on $HEAD_REF"
+            git pull --rebase origin "$HEAD_REF" || exit 1
+          done
+          echo "::error::could not push regenerated bundles to $HEAD_REF after 3 attempts"
+          exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,17 @@ build-backend = "setuptools.build_meta"
 exclude = ["evals", "evals.*", "scripts", "scripts.*"]
 
 [tool.setuptools.package-data]
-skills = ["**/*.md", "**/*.sh"]
+# The precompiled issue bundles are scoped to this one skill deliberately: they
+# are the only non-doc resource an agent loads at runtime, and each bundle is
+# self-contained (every issue carries its own action, automation_type, and
+# detection/fixing context), so the kb/ YAML corpus they are generated from does
+# not need to ship. A blanket **/*.json would pull in unrelated files from every
+# other skill.
+skills = [
+    "**/*.md",
+    "**/*.sh",
+    "dbt-migration/skills/upgrading-dbt-core/references/*.json",
+]
 
 [dependency-groups]
 dev = [

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_10_bigquery.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_10_bigquery.json
@@ -1,0 +1,224 @@
+{
+  "from_version": "1.10",
+  "warehouse": "bigquery",
+  "target_version": "1.12",
+  "count": 9,
+  "issues": [
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_10_core.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_10_core.json
@@ -1,0 +1,224 @@
+{
+  "from_version": "1.10",
+  "warehouse": "core",
+  "target_version": "1.12",
+  "count": 9,
+  "issues": [
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_10_databricks.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_10_databricks.json
@@ -1,0 +1,224 @@
+{
+  "from_version": "1.10",
+  "warehouse": "databricks",
+  "target_version": "1.12",
+  "count": 9,
+  "issues": [
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_10_redshift.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_10_redshift.json
@@ -1,0 +1,224 @@
+{
+  "from_version": "1.10",
+  "warehouse": "redshift",
+  "target_version": "1.12",
+  "count": 9,
+  "issues": [
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_10_snowflake.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_10_snowflake.json
@@ -1,0 +1,224 @@
+{
+  "from_version": "1.10",
+  "warehouse": "snowflake",
+  "target_version": "1.12",
+  "count": 9,
+  "issues": [
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_10_spark.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_10_spark.json
@@ -1,0 +1,224 @@
+{
+  "from_version": "1.10",
+  "warehouse": "spark",
+  "target_version": "1.12",
+  "count": 9,
+  "issues": [
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_11_bigquery.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_11_bigquery.json
@@ -1,0 +1,176 @@
+{
+  "from_version": "1.11",
+  "warehouse": "bigquery",
+  "target_version": "1.12",
+  "count": 7,
+  "issues": [
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_11_core.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_11_core.json
@@ -1,0 +1,176 @@
+{
+  "from_version": "1.11",
+  "warehouse": "core",
+  "target_version": "1.12",
+  "count": 7,
+  "issues": [
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_11_databricks.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_11_databricks.json
@@ -1,0 +1,176 @@
+{
+  "from_version": "1.11",
+  "warehouse": "databricks",
+  "target_version": "1.12",
+  "count": 7,
+  "issues": [
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_11_redshift.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_11_redshift.json
@@ -1,0 +1,176 @@
+{
+  "from_version": "1.11",
+  "warehouse": "redshift",
+  "target_version": "1.12",
+  "count": 7,
+  "issues": [
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_11_snowflake.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_11_snowflake.json
@@ -1,0 +1,176 @@
+{
+  "from_version": "1.11",
+  "warehouse": "snowflake",
+  "target_version": "1.12",
+  "count": 7,
+  "issues": [
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_11_spark.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_11_spark.json
@@ -1,0 +1,176 @@
+{
+  "from_version": "1.11",
+  "warehouse": "spark",
+  "target_version": "1.12",
+  "count": 7,
+  "issues": [
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_3_bigquery.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_3_bigquery.json
@@ -1,0 +1,1012 @@
+{
+  "from_version": "1.3",
+  "warehouse": "bigquery",
+  "target_version": "1.12",
+  "count": 47,
+  "issues": [
+    {
+      "issue_id": "1_3_001",
+      "sort_order": 1010,
+      "change": "Python model default materialization changed from view to table",
+      "action": "Set materialized='view' explicitly on Python models that relied on the old view default",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Python models without an explicit materialized config now create tables instead of views, changing storage/cost and downstream freshness expectations",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Enumerate Python models: models/**/*.py containing `def model(dbt, session)`.\n- Determine each model's effective materialization, in precedence order:\n  - an inline `dbt.config(materialized=...)` call inside model(dbt, session);\n  - a config() block;\n  - the matching model's YAML config in models/**/*.yml;\n  - the models: tree in dbt_project.yml (path-scoped config).\n- A model is affected if NONE of these set materialized: it defaulted to view, now defaults\n  to table.\n- SQL models are unaffected (their default was already view and is unchanged).",
+        "fixing": "- Only change models where the prior view behavior was actually intended (thin passthrough,\n  or a downstream tool expects a view).\n- For those, add materialized='view' at the most local level that already carries config:\n  prefer `dbt.config(materialized='view')` inside the function, else `materialized: view` in\n  the model's YAML, else under dbt_project.yml models:.\n- Do NOT blanket-force every Python model to view \u2014 the new table default is usually desirable;\n  flag ambiguous ones in the results report rather than guessing.\n- After editing run dbt parse; if it fails because dbt.config was placed outside the function,\n  move the call to the first statement inside def model(...)."
+      },
+      "_path": "kb/core/1_3_001.yaml"
+    },
+    {
+      "issue_id": "1_3_002",
+      "sort_order": 1020,
+      "change": "on-run-start / on-run-end hooks no longer halt execution on failure",
+      "action": "Find alternative approaches if hooks were used as guards/circuit-breakers that must abort a run",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start/on-run-end hook now appends an error result and continues instead of raising; guard/circuit-breaker hooks no longer abort the run",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for on-run-start: and on-run-end: keys (string or list).\n- Also scan these keys in any vendored package dbt_project.yml.\n- Flag hooks whose SQL acts as a precondition/guard:\n  - a SELECT that RAISES/THROWS, or calls an assertion macro;\n  - `{% if ... %}{{ exceptions.raise_compiler_error(...) }}{% endif %}`;\n  - SQL that intentionally errors (divide-by-zero, invalid cast) to stop a run.\n- Purely side-effecting hooks (grants, logging, audit inserts) are NOT affected.",
+        "fixing": "- Behavior change dbt parse cannot validate, so it is advisory.\n- For guard hooks: document that they no longer abort the run in 1.4+, and recommend moving the\n  precondition into a pre-flight step outside the run (a separate `dbt run-operation` gate in\n  CI, or a data test CI checks before proceeding).\n- Do not rewrite the hook's SQL automatically.\n- Record each guard-style hook in the results report with issue_id, the dbt_project.yml\n  location, and the suggested CI-gate alternative.\n- No parse impact expected; run dbt parse only to confirm no YAML was broken by edits."
+      },
+      "_path": "kb/core/1_3_002.yaml"
+    },
+    {
+      "issue_id": "1_3_003",
+      "sort_order": 1030,
+      "change": "pre_hook / post_hook (underscore form) now properly late-rendered",
+      "action": "Verify hook behavior if using underscore-form hooks that contain Jinja evaluated at parse time",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Hooks written with the underscore form (pre_hook/post_hook) that contain Jinja now render at runtime instead of parse time, matching the hyphen form; values resolved at parse time may differ",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Search the underscore spellings pre_hook and post_hook (NOT pre-hook/post-hook) across\n  models/**/*.sql config() blocks, models/**/*.yml, and dbt_project.yml.\n- Regex: `(pre_hook|post_hook)\\s*[:=]`.\n- Of those, flag hooks whose value contains Jinja ({{ ... }} or {% ... %}) whose result depends\n  on parse-vs-runtime timing: {{ this }}, {{ run_started_at }}, runtime var()/env_var(), or the\n  result of a statement/run_query.\n- Static string hooks are unaffected.",
+        "fixing": "- Advisory/verification change \u2014 late rendering generally makes underscore hooks behave\n  correctly, so most projects need no edit.\n- Only intervene if a hook relied on the old parse-time rendering (rare).\n- Where behavior matters, note it in the results report and suggest confirming the hook still\n  produces the intended SQL at runtime.\n- Optionally normalize underscore hooks to the canonical hyphen form (pre-hook/post-hook) for\n  clarity, but this is cosmetic.\n- Run dbt parse after any edit; if a config() edit breaks parse, revert to the original key\n  spelling."
+      },
+      "_path": "kb/core/1_3_003.yaml"
+    },
+    {
+      "issue_id": "1_3_008",
+      "sort_order": 1080,
+      "change": "Job labels longer than 63 characters are silently truncated instead of erroring",
+      "action": "Review labels longer than 63 chars so truncation does not collide or mislead",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "bigquery",
+      "impact": "Labels that previously raised an error now succeed with a value truncated to 63 characters, which can produce duplicate or misleading label values",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Find BigQuery label configs with values (or keys) exceeding 63 characters.\n- Look in dbt_project.yml and models/**/*.yml for `labels:` maps under model/+config.\n- Look in config() blocks in models/**/*.sql with `labels={...}`, plus query_comment/labels macros.\n- Flag entries whose value string length > 63.\n- Especially flag long labels sharing a >63-char prefix (they truncate to the same value).\n- Also consider Jinja-built label values whose rendered length could exceed 63.",
+        "fixing": "- Shorten each offending label value to <= 63 chars while keeping it unique and meaningful\n  (e.g. abbreviate a long team/pipeline name, drop redundant prefixes).\n- Preserve intent; do not merely chop at 63 if that collides with another label.\n- For Jinja-computed labels, wrap or shorten the expression so the rendered result is <= 63.\n- Does not affect dbt parse; run parse only to confirm YAML/config edits are valid, and note\n  the change in the results report.\n- If a label is generated out-of-repo (injected by a job/orchestrator), record it in the\n  results report instead of editing."
+      },
+      "_path": "kb/bigquery/1_3_008.yaml"
+    },
+    {
+      "issue_id": "1_3_009",
+      "sort_order": 1090,
+      "change": "google-cloud-bigquery dependency bumped from >=1.25,<3 to ~=3.0",
+      "action": "Ensure the environment supports google-cloud-bigquery 3.x",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "bigquery",
+      "impact": "Environments pinned to google-cloud-bigquery 2.x will fail to resolve or install alongside dbt-bigquery 1.4",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": true,
+      "context": {
+        "detection": "- This is a Python dependency concern (no in-model footprint).\n- Read dependency manifests: requirements.txt, requirements*.txt, setup.py, pyproject.toml,\n  Pipfile, and any constraints files.\n- Flag an explicit pin of google-cloud-bigquery to a 2.x range or an upper bound <3\n  (regex `google-cloud-bigquery\\s*[<=~!].*` pinning below 3).\n- Also flag transitive pins via constraints files.\n- If no such pin exists, mark skipped-not-present.",
+        "fixing": "- ADVISORY ONLY: never run pip/poetry/uv or otherwise mutate the installed environment.\n- If a conflicting pin exists in a repo dependency file, propose editing it to allow 3.x\n  (e.g. `google-cloud-bigquery<3` / `==2.*` -> `google-cloud-bigquery~=3.0` or `>=3,<4`) and\n  surface the suggested diff.\n- If the pin lives outside the repo (base image, org constraints), record it in the results report.\n- Excluded from the dbt parse verify loop; parse does not reflect installed package versions."
+      },
+      "_path": "kb/bigquery/1_3_009.yaml"
+    },
+    {
+      "issue_id": "1_3_012",
+      "sort_order": 1120,
+      "change": "current_timestamp macro dispatch migrated from dbt-utils to dbt-core",
+      "action": "Replace dbt_utils.current_timestamp() calls with dbt.current_timestamp()",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "bigquery",
+      "impact": "Projects calling dbt_utils.current_timestamp() should migrate to the built-in dbt.current_timestamp()",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep models/ and macros/ for `dbt_utils.current_timestamp(` (and dispatched variants).\n- The macro moved into dbt-core, so the dbt_utils-namespaced call is deprecated.",
+        "fixing": "- Handled by `dbt-autofix deprecations`.\n- After autofix runs, review the diff for `dbt_utils.current_timestamp()` ->\n  `dbt.current_timestamp()` rewrites and confirm they were applied.\n- Manual fallback: rewrite any call autofix missed yourself.\n- Not parse-detectable; verify the diff rather than relying on parse."
+      },
+      "_path": "kb/bigquery/1_3_012.yaml"
+    },
+    {
+      "issue_id": "1_3_013",
+      "sort_order": 1130,
+      "change": "Metric attributes sql / type / type: expression deprecation warnings updated",
+      "action": "Migrate metric attrs to expression, calculation_method, and calculation_method: derived",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Legacy metric attribute names emit deprecation warnings; slated for removal",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan models/**/*.yml for `metrics:` blocks using legacy attrs `sql:`, `type:`, or\n  `type: expression`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (attribute rename to expression/calculation_method).\n- Review the autofix diff and confirm each metric was rewritten.\n- NOTE: this is the 1.3->1.4 attribute rename only; the full MetricFlow rewrite is the separate\n  1.5->1.6 issue 1_5_001.\n- Manual fallback: apply the attribute renames yourself if autofix skipped any."
+      },
+      "_path": "kb/core/1_3_013.yaml"
+    },
+    {
+      "issue_id": "1_3_014",
+      "sort_order": 1140,
+      "change": "Merge SQL predicates wrapped in parens; predicates kwarg renamed to incremental_predicates",
+      "action": "Update custom incremental strategy macros using arg_dict['predicates'] to incremental_predicates",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Custom strategy macros reading arg_dict['predicates'] break; generated merge SQL wraps predicates in parens",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/ for custom incremental/merge macros referencing `predicates`\n  (e.g. `arg_dict['predicates']`, `config.get('predicates')`).",
+        "fixing": "- Handled by `dbt-autofix deprecations` where applicable (rename `predicates` ->\n  `incremental_predicates`).\n- Review the diff.\n- Manual fallback: rename the kwarg in any custom macro autofix did not touch.\n- Behavior/warehouse effect (paren-wrapping) is validated in the build-green layer, not parse."
+      },
+      "_path": "kb/core/1_3_014.yaml"
+    },
+    {
+      "issue_id": "1_4_001",
+      "sort_order": 2010,
+      "change": "--select/--exclude now accumulate when passed multiple times (argparse -> Click)",
+      "action": "Review scripts/jobs passing --select or --exclude more than once; collapse to a single flag with the intended union",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Scripts relying on last-wins override now see both selections combined, selecting more nodes than intended",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep in-repo invocation sites for repeated selection flags on a single command: shell scripts\n  (*.sh), Makefiles, CI YAML (.github/**, .gitlab-ci.yml, azure-pipelines.yml), tox.ini, and dbt\n  wrapper scripts.\n- Pattern: one dbt command containing two or more `--select`/`-s` or `--exclude` tokens (regex\n  `(--select|--exclude|-s)\\b.*\\b(--select|--exclude|-s)\\b`).\n- The real risk lives OUTSIDE the repo in dbt platform job definitions, so in-repo presence may be\n  zero even when the project is affected.",
+        "fixing": "- For each in-repo command with duplicated selection flags, decide intent: pre-1.5 was last-wins (only\n  the final flag applied); 1.5+ is union (all applied).\n- If the old intent was 'use only the last selection', delete the earlier occurrences. If a union was\n  intended, it already works \u2014 leave it.\n- Example: `dbt run --select tag:nightly --select my_model` (1.4 ran only my_model) -> `dbt run\n  --select my_model`.\n- Not visible to dbt parse.\n- ALWAYS add a results entry (manual-required): dbt platform job commands and orchestration outside\n  this repo may pass the flags multiple times; list the affected in-repo sites and tell the user to\n  audit job definitions."
+      },
+      "_path": "kb/core/1_4_001.yaml"
+    },
+    {
+      "issue_id": "1_4_002",
+      "sort_order": 2020,
+      "change": "Duplicate CLI flags before and after the subcommand now raise an error",
+      "action": "Ensure each CLI flag appears only once per dbt invocation",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands like `dbt --flag run --flag` now fail instead of silently taking one value",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan in-repo dbt invocation sites (shell scripts, Makefiles, CI YAML, tox.ini, wrapper scripts) for\n  a single dbt command repeating the same flag, especially placed both before and after the\n  subcommand.\n- Examples: `dbt --debug run --debug`, or a repeated `--profiles-dir` / `--target` / `--vars`.\n- Likeliest offenders: global flags (--debug, --profiles-dir, --project-dir, --target, --log-format)\n  appearing twice.\n- As with selection flags, the primary risk is in dbt platform job commands outside the repo.",
+        "fixing": "- Remove the duplicate occurrence, keeping the one with the intended value (pre-1.5 resolved to a\n  single value, so pick that).\n- Example: `dbt --target prod run --target prod` -> `dbt run --target prod`.\n- If two occurrences carry DIFFERENT values it was already ambiguous \u2014 keep the value the user\n  confirms and record the resolution in the migration log.\n- Not visible to dbt parse.\n- Add a results entry (manual-required) directing the user to audit external job/orchestration\n  commands for duplicated flags, since those now hard-error."
+      },
+      "_path": "kb/core/1_4_002.yaml"
+    },
+    {
+      "issue_id": "1_4_003",
+      "sort_order": 2030,
+      "change": "log-path in dbt_project.yml deprecated",
+      "action": "Move log-path out of dbt_project.yml to the --log-path CLI flag or DBT_LOG_PATH env var",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning at parse time; becomes fatal under --warn-error",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for a top-level `log-path:` key (regex `^\\s*log-path\\s*:`). Present if the key\n  exists with any value.\n- Only one location to check.",
+        "fixing": "- Remove the `log-path:` key from dbt_project.yml.\n- Re-provision out-of-repo: either the `--log-path <dir>` CLI flag on dbt invocations or the\n  `DBT_LOG_PATH` env var.\n- Because the effective destination now lives in job commands / env config outside this repo, add a\n  results entry recording the old value and telling the user to set --log-path/DBT_LOG_PATH wherever\n  dbt is invoked (CI, dbt platform jobs).\n- After removing the key, run dbt parse; the deprecation warning should be gone.\n- If parse still warns, confirm no other config file (a profiles-level or imported yml) re-declares\n  log-path."
+      },
+      "_path": "kb/core/1_4_003.yaml"
+    },
+    {
+      "issue_id": "1_4_004",
+      "sort_order": 2040,
+      "change": "target-path in dbt_project.yml deprecated",
+      "action": "Move target-path out of dbt_project.yml to the --target-path CLI flag or DBT_TARGET_PATH env var",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning at parse time; becomes fatal under --warn-error",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for a top-level `target-path:` key (regex `^\\s*target-path\\s*:`). Present if\n  the key exists.",
+        "fixing": "- Remove the `target-path:` key from dbt_project.yml.\n- Re-provision via the `--target-path <dir>` CLI flag or `DBT_TARGET_PATH` env var wherever dbt runs.\n- Add a results entry recording the old value and directing the user to set\n  --target-path/DBT_TARGET_PATH in job commands / CI / dbt platform, since anything reading generated\n  artifacts (manifest.json, run_results.json) from the custom path must be pointed at the new\n  location.\n- After removal, run dbt parse to confirm the warning is cleared."
+      },
+      "_path": "kb/core/1_4_004.yaml"
+    },
+    {
+      "issue_id": "1_4_005",
+      "sort_order": 2050,
+      "change": "DBT_NO_PRINT environment variable deprecated in favor of DBT_PRINT",
+      "action": "Replace DBT_NO_PRINT=true with DBT_PRINT=false",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for the literal `DBT_NO_PRINT` in CI YAML (.github/**, .gitlab-ci.yml, etc.),\n  Dockerfiles, .env / *.env files, shell scripts, Makefiles, and tox.ini. Present if the token appears\n  anywhere.\n- The variable is frequently set in orchestration outside the repo, so an in-repo miss does not mean\n  the project is clear.",
+        "fixing": "- Translate the value: DBT_NO_PRINT=true (suppress prints) becomes DBT_PRINT=false; DBT_NO_PRINT=false\n  becomes DBT_PRINT=true.\n- Update every in-repo occurrence found.\n- This is an env-var rename, not a Python-environment change, so it is a normal advisory edit (not\n  environment_change) and is not verified by dbt parse.\n- Add a results entry telling the user to replace DBT_NO_PRINT in external CI / dbt platform\n  environment settings with DBT_PRINT (inverted value)."
+      },
+      "_path": "kb/core/1_4_005.yaml"
+    },
+    {
+      "issue_id": "1_4_006",
+      "sort_order": 2060,
+      "change": "DBT_ARTIFACT_STATE_PATH environment variable deprecated in favor of DBT_STATE",
+      "action": "Replace DBT_ARTIFACT_STATE_PATH with DBT_STATE",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_ARTIFACT_STATE_PATH` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Commonly used in Slim CI / state-deferral setups that live in orchestration outside the repo.",
+        "fixing": "- Rename the variable to `DBT_STATE`, keeping the same value (path to the state/manifest directory).\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry telling the user to rename DBT_ARTIFACT_STATE_PATH to DBT_STATE in external CI\n  and dbt platform job environments used for state:modified / --defer selection."
+      },
+      "_path": "kb/core/1_4_006.yaml"
+    },
+    {
+      "issue_id": "1_4_007",
+      "sort_order": 2070,
+      "change": "DBT_FAVOR_STATE_MODE environment variable deprecated in favor of DBT_FAVOR_STATE",
+      "action": "Replace DBT_FAVOR_STATE_MODE with DBT_FAVOR_STATE",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_FAVOR_STATE_MODE` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Typically set in state-based CI selection outside the repo.",
+        "fixing": "- Rename to `DBT_FAVOR_STATE`, preserving the value.\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry directing the user to rename this variable in external CI / dbt platform\n  environments."
+      },
+      "_path": "kb/core/1_4_007.yaml"
+    },
+    {
+      "issue_id": "1_4_008",
+      "sort_order": 2080,
+      "change": "DBT_DEFER_TO_STATE environment variable deprecated in favor of DBT_DEFER",
+      "action": "Replace DBT_DEFER_TO_STATE with DBT_DEFER",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_DEFER_TO_STATE` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Used in --defer based CI workflows that usually live outside the repo.",
+        "fixing": "- Rename to `DBT_DEFER`, preserving the boolean value.\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry directing the user to rename DBT_DEFER_TO_STATE to DBT_DEFER in external CI /\n  dbt platform environments."
+      },
+      "_path": "kb/core/1_4_008.yaml"
+    },
+    {
+      "issue_id": "1_4_015",
+      "sort_order": 2150,
+      "change": "insert_overwrite partition collection now adds IGNORE NULLS",
+      "action": "Review incremental models with insert_overwrite that may have NULL partition values",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "bigquery",
+      "impact": "Rows whose partition column is NULL no longer trigger partition overwrites under insert_overwrite",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Find BigQuery incremental models using insert_overwrite with dynamic partitions: models/**/*.sql\n  with `materialized='incremental'` (or YAML config) AND `incremental_strategy='insert_overwrite'` AND\n  a `partition_by=` config, where `partitions` is not statically supplied.\n- The behavior change matters only if the partitioning column can be NULL for some rows.\n- Grep model SQL for the partition column and assess whether NULLs are possible (no NOT NULL\n  guarantee, nullable source).",
+        "fixing": "- Usually NO code change is required \u2014 this is a correctness improvement (NULL-partition rows\n  previously overwrote partitions unexpectedly).\n- Action is to REVIEW: if a model legitimately relies on a NULL/`__NULL__` partition being\n  overwritten, coalesce the partition column to a sentinel non-NULL value before partitioning, or\n  handle those rows explicitly.\n- Invisible to dbt parse and not warehouse-verifiable here.\n- For any model where NULL partition rows are plausible and behavior could change, record a results\n  entry naming the model and column so the user can confirm against real data; otherwise mark\n  skipped-not-present."
+      },
+      "_path": "kb/bigquery/1_4_015.yaml"
+    },
+    {
+      "issue_id": "1_5_001",
+      "sort_order": 3010,
+      "change": "Metric YAML schema completely rewritten for MetricFlow",
+      "action": "Rewrite all metric definitions using the new type/type_params/filter format",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "All existing metric YAML definitions fail to parse in 1.6; the pre-1.6 UnparsedMetric fields (calculation_method, expression, sql, model, type: expression) and the rename_metric_attr compatibility shim were removed.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Search every YAML file under models/ and any schema-file globs declared in dbt_project.yml\n  (models/**/*.yml, models/**/*.yaml, plus any top-level metrics/ dir) for a `metrics:` block.\n- Flag a metric as legacy (pre-1.6) if its entry uses ANY of these keys: `calculation_method`,\n  `expression`, `sql`, `type: expression`, a top-level `type:` with the old enum\n  (`count`/`sum`/...), `model:`, `timestamp:`, `time_grains:`, `dimensions:` directly on the\n  metric, or `filters:` (the list-of-dict old form).\n- The new MetricFlow schema instead uses `type:` with values simple|ratio|cumulative|derived\n  plus a `type_params:` block. If a metric already has `type_params:`, it is migrated \u2014 skip it.\n- Also grep packages.yml for `dbt_metrics` usage and models for `metrics.calculate(` /\n  `metrics.develop(` macro calls \u2014 those depend on the old package and must be flagged too.",
+        "fixing": "- Rewrite each legacy metric into the new schema. Attribute mapping:\n  - `calculation_method` -> `type`: sum/average/min/max/count/count_distinct/median become\n    `type: simple` with `type_params.measure`; derived/expression become `type: derived` with\n    `type_params.expr` and `type_params.metrics`.\n  - `expression`/`sql` -> `type_params.measure` (the semantic measure name), or\n    `type_params.expr` for a derived metric.\n  - `model:` -> moves into a `semantic_models:` definition (see example below).\n  - `filters:` -> `filter:` (a single `{{ Dimension(...) }}` string, or keep the WHERE fragment).\n- Concrete before/after:\n  BEFORE (1.5):\n    metrics:\n      - name: total_revenue\n        calculation_method: sum\n        expression: amount\n        model: ref('orders')\n        timestamp: order_date\n        time_grains: [day, month]\n        dimensions: [status]\n  AFTER (1.6, MetricFlow):\n    semantic_models:\n      - name: orders\n        model: ref('orders')\n        defaults:\n          agg_time_dimension: order_date\n        entities:\n          - name: order\n            type: primary\n        dimensions:\n          - name: order_date\n            type: time\n            type_params: {time_granularity: day}\n          - name: status\n            type: categorical\n        measures:\n          - name: amount\n            agg: sum\n            agg_time_dimension: order_date\n    metrics:\n      - name: total_revenue\n        type: simple\n        type_params:\n          measure: amount\n- Derived example: `calculation_method: derived` + `expression: revenue - cost` becomes\n  `type: derived` with `type_params: {expr: 'revenue - cost', metrics: [{name: revenue},\n  {name: cost}]}`.\n- Judgment-heavy: 1.6 requires a `semantic_models:` layer that did not exist in 1.5, so the\n  measure/entity/dimension split cannot always be inferred mechanically.\n- If you cannot confidently reconstruct the semantic model (e.g. the source model's grain or\n  entities are ambiguous), do NOT guess \u2014 record the metric in the results report with\n  the original YAML and the suggested new shape, and move on.\n- After editing, run `dbt parse`. On a metric/semantic-model validation error, re-read it;\n  reverting to legacy form is NOT an option (it won't parse in 1.6) \u2014 instead leave the\n  semantic_model skeleton and flag it manual.\n- Remove `dbt_metrics` / `metrics.calculate` usages and flag them as requiring the\n  MetricFlow / Semantic Layer migration (out of scope for parse)."
+      },
+      "_path": "kb/core/1_5_001.yaml"
+    },
+    {
+      "issue_id": "1_5_002",
+      "sort_order": 3020,
+      "change": "Duplicate node names allowed across packages",
+      "action": "Disambiguate cross-package references with two-argument ref('package_name', 'model_name')",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.5 a flat manifest dict raised DuplicateResourceNameError; in 1.6 names are stored per-package, so a project and an installed package can legitimately share a model name. Single-argument ref() to a name that exists in more than one package becomes ambiguous (AmbiguousAliasError / wrong node).",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant if packages.yml / dependencies.yml declares packages.\n- Build the set of model/seed/snapshot names defined in the local project (models/**/*.sql,\n  seeds/**/*.csv, snapshots/**/*.sql).\n- Where available, add the names exposed by installed packages under dbt_packages/*/models.\n- Grep all .sql/.yml for single-argument `ref('name')` / `ref(\"name\")` whose `name` collides\n  with a name present in BOTH the local project and a package (or in two packages) \u2014 those are\n  the ambiguous refs.\n- If no packages are installed, mark skipped-not-present.",
+        "fixing": "- For each ambiguous single-arg ref, rewrite to the two-argument form\n  `ref('<package_name>', '<model_name>')`.\n- Choose the package the author intended; default to the local project's own model unless the\n  surrounding SQL clearly consumes the package's version.\n- Example: `ref('customers')` -> `ref('my_project', 'customers')` or\n  `ref('dbt_utils', 'customers')`. Leave unambiguous refs untouched.\n- After edits run `dbt parse`; a remaining AmbiguousAliasError names the offending ref and node.\n- If you cannot determine which package is intended, record it in the results report\n  rather than guessing \u2014 picking the wrong package silently changes lineage."
+      },
+      "_path": "kb/core/1_5_002.yaml"
+    },
+    {
+      "issue_id": "1_5_003",
+      "sort_order": 3030,
+      "change": "collect_freshness macro return type changed",
+      "action": "Update any custom collect_freshness macro override to return the full result object (table + response) instead of just the table",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.6 core's default collect_freshness returns a dict-like {table, response} object; a custom override that returns only the agate table triggers a deprecation warning and will break source freshness in later versions.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/**/*.sql for a macro named `collect_freshness` (i.e. `{% macro collect_freshness(`\n  or `{% macro <adapter>__collect_freshness(`).\n- If none exists, the project uses core's implementation \u2014 mark skipped-not-present.\n- If one exists, inspect its final `{{ return(...) }}` and flag it if it returns the query\n  result table directly (e.g. `return(load_result('collect_freshness').table)` or\n  `return(table)`) rather than the full result object.",
+        "fixing": "- Change the macro to capture the full result and return an object exposing both the table and\n  the adapter response.\n- Pattern: `{% set result = run_query(...) %}` then\n  `{{ return({'table': result.table, 'response': result.response}) }}`.\n- Mirror core's 1.6 signature: it returns `load_result('collect_freshness')`, which already has\n  `.table` and `.response`.\n- Simplest safe fix, if the override only existed to tweak the SQL: align the return statement\n  with core 1.6's macro body.\n- After editing run `dbt parse`.\n- If the override is complex or the intended response object is unclear, record it in the\n  results report with a pointer to core's 1.6 collect_freshness for reference."
+      },
+      "_path": "kb/core/1_5_003.yaml"
+    },
+    {
+      "issue_id": "1_6_011",
+      "sort_order": 4005,
+      "change": "dbt clean errors when clean-targets include source paths or paths outside the project",
+      "action": "Remove source paths (e.g. models/, macros/) and any path outside the project directory from clean-targets in dbt_project.yml",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "dbt clean now raises an error instead of silently deleting the wrong directories when clean-targets references source paths or paths outside the project root",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml's clean-targets list.\n- Flag any entry that resolves (relative to the project root) to a configured source path\n  (model-paths, seed-paths, macro-paths, etc.) or that resolves outside the project directory\n  (e.g. ../shared, /absolute/path).",
+        "fixing": "- Remove the offending entries from clean-targets, keeping only build/output directories\n  (e.g. target, dbt_packages, logs).\n- Re-run dbt clean to confirm it no longer errors."
+      },
+      "_path": "kb/core/1_6_011.yaml"
+    },
+    {
+      "issue_id": "1_6_001",
+      "sort_order": 4010,
+      "change": "New warning when --state and --target point to the same directory",
+      "action": "Fix --state/--target configuration so they reference distinct directories",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "WarnStateTargetEqual raised (informational) for previously silent misconfiguration; fatal under --warn-error",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- This is a runtime CLI/job configuration issue, not a repo-source issue, so `dbt parse` cannot\n  surface it. Detect by scanning invocation sites, not models.\n- Grep the repo for `--state` and `--target` / `--target-path` in shell scripts, Makefiles, and\n  `scripts/**/*.sh`.\n- Also grep CI configs: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `tox.ini`.\n- Check `dbt_project.yml` for a `target-path:` key (deprecated since 1.5 but may still be present).\n- Check for `DBT_STATE` / `DBT_TARGET_PATH` env vars in CI.\n- Flag any invocation where `--state` and `--target`/`--target-path` resolve to the same directory\n  (commonly both set to `target/`).\n- Note the value is frequently supplied outside the repo (dbt platform job definitions,\n  orchestration tools), which parse cannot see.",
+        "fixing": "- Point `--state` at a directory separate from the run's `--target` \u2014 e.g. keep run output in\n  `target/` and the comparison manifest in a distinct dir such as `state/` or `prod-artifacts/`.\n- Concretely, in the offending script/CI step change the duplicated paths so a command like\n  `dbt build --state ./state --target-path ./target` uses different dirs, and populate the state\n  artifacts there.\n- If the same-directory usage lives outside the repo (a dbt platform job command, an orchestration\n  tool), it cannot be edited from the repo.\n- For that out-of-repo case: record it in the results artifact (target/dbt_migration_results.json)\n  as manual-required with the issue_id, the invocation location if known, and the suggested command\n  change, then prompt the user.\n- This change never requires a repo edit to pass `dbt parse`; it is advisory / out-of-repo only."
+      },
+      "_path": "kb/core/1_6_001.yaml"
+    },
+    {
+      "issue_id": "1_6_002",
+      "sort_order": 4020,
+      "change": "Breaking contract changes on unversioned models now warn instead of error",
+      "action": "Add --warn-error (or version the models) to retain the previous hard-error behavior on breaking contract changes",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Unversioned models with a breaking schema/contract change warn via warn_or_error() instead of erroring; CI that relied on the error to block may now pass silently",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan schema YAML (`models/**/*.yml`, `models/**/*.yaml`) for models declaring `contract:` with\n  `enforced: true` that do NOT declare a `version:` / `versions:` block (i.e. unversioned).\n- Those unversioned enforced-contract models are the ones whose breaking contract changes now only\n  warn.\n- Also detect reliance on the old error behavior: grep CI/scripts for `dbt build` / `dbt run`\n  invocations that lack `--warn-error` or `--warn-error-options`.\n- Those flags are what previously turned the contract breakage into a hard failure.\n- This is a behavior/policy change; `dbt parse` stays clean either way, so detection is about intent,\n  not parse errors.",
+        "fixing": "- Preferred: preserve strict behavior by adding `--warn-error` (or a scoped `--warn-error-options`\n  targeting contract deprecations) to the relevant dbt invocation.\n- If that invocation is defined outside the repo (dbt platform job command, orchestration tool), it\n  cannot be edited here: record it in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the suggested flag, and prompt the user.\n- Alternative in-repo fix: add a `version:` to the affected models \u2014 versioning makes breaking\n  contract changes error again.\n- But versioning reshapes ref() resolution and downstream references, so only do it when the user\n  explicitly wants versioned models; note that trade-off in the results report rather than silently\n  versioning.\n- No edit is required for `dbt parse` to succeed."
+      },
+      "_path": "kb/core/1_6_002.yaml"
+    },
+    {
+      "issue_id": "1_6_003",
+      "sort_order": 4030,
+      "change": "New warning for contracted models with bare numeric columns (no precision/scale)",
+      "action": "Add explicit precision and scale to numeric column data_types in enforced contracts (e.g. numeric(38,3))",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with 'data_type: numeric' (or 'decimal') and no precision/scale in an enforced contract now emit a warning at parse time in 1.7",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- In schema YAML (`models/**/*.yml`, `models/**/*.yaml`), find models with `contract:`\n  `enforced: true` and columns whose `data_type` is a bare numeric type with no precision/scale.\n- Match the data_type value (case-insensitive) against `^(numeric|decimal|number)$` (no parentheses).\n- Types that already include `(p,s)` like `numeric(38,3)` are fine and must be left alone.\n- Only columns inside enforced-contract models trigger the warning; bare numeric on non-contracted\n  models is not affected.",
+        "fixing": "- For each flagged column, replace the bare type with an explicit precision/scale, e.g.\n  `data_type: numeric` -> `data_type: numeric(38,3)`.\n- Choose precision/scale from evidence in this order:\n- (1) an existing cast in the model SQL (e.g. `cast(x as numeric(18,2))`) \u2014 match it;\n- (2) the warehouse's documented default for unqualified numeric if the model is already built\n  (Snowflake NUMBER default is (38,0); Redshift/Postgres NUMERIC default is (38,0));\n- (3) if unknown, use a safe wide default `numeric(38,6)` and note the assumption in the results\n  report.\n- Preserve YAML quoting/style.\n- After editing, run `dbt parse`; if it fails, the likely cause is a mismatched type name for the\n  adapter (e.g. Snowflake prefers `number(38,3)`) \u2014 retry with the adapter-native spelling.\n- If the correct precision genuinely cannot be determined, leave the column and record it in the\n  results artifact (target/dbt_migration_results.json) as manual-required for the user to confirm."
+      },
+      "_path": "kb/core/1_6_003.yaml"
+    },
+    {
+      "issue_id": "1_6_006",
+      "sort_order": 4060,
+      "change": "job_execution_timeout now actually cancels queries via asyncio",
+      "action": "Review all job_execution_timeout_seconds values and increase them where legitimate long-running queries could now be cancelled",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "bigquery",
+      "impact": "Queries exceeding job_execution_timeout_seconds are now actually cancelled and error; previously the timeout was passed but not enforced, so long queries silently ran to completion",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep for `job_execution_timeout_seconds` across the project: `profiles.yml`\n  (`outputs.<target>`), `dbt_project.yml` (`models:` config), model config() blocks, and schema\n  YAML `config:` blocks.\n- Any value set low relative to real query runtimes is now a live cancellation risk.\n- This is a runtime/behavior change invisible to `dbt parse`.",
+        "fixing": "- No edit is needed to pass parse or reach 1.8. The action is protective.\n- For each configured job_execution_timeout_seconds, assess whether real models run longer than the\n  value; if so, raise it (e.g. comfortably above observed p99 runtime) in the same location it is\n  configured.\n- Where the value lives in `profiles.yml` outside the repo, record the recommendation in the\n  results artifact (target/dbt_migration_results.json) as manual-required instead of editing.\n- If no timeout is set anywhere, BigQuery's own default applies and there is nothing to change \u2014\n  note it and move on.\n- Do not lower any timeouts. True impact is only observable in the warehouse build-green layer."
+      },
+      "_path": "kb/bigquery/1_6_006.yaml"
+    },
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_3_core.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_3_core.json
@@ -1,0 +1,912 @@
+{
+  "from_version": "1.3",
+  "warehouse": "core",
+  "target_version": "1.12",
+  "count": 42,
+  "issues": [
+    {
+      "issue_id": "1_3_001",
+      "sort_order": 1010,
+      "change": "Python model default materialization changed from view to table",
+      "action": "Set materialized='view' explicitly on Python models that relied on the old view default",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Python models without an explicit materialized config now create tables instead of views, changing storage/cost and downstream freshness expectations",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Enumerate Python models: models/**/*.py containing `def model(dbt, session)`.\n- Determine each model's effective materialization, in precedence order:\n  - an inline `dbt.config(materialized=...)` call inside model(dbt, session);\n  - a config() block;\n  - the matching model's YAML config in models/**/*.yml;\n  - the models: tree in dbt_project.yml (path-scoped config).\n- A model is affected if NONE of these set materialized: it defaulted to view, now defaults\n  to table.\n- SQL models are unaffected (their default was already view and is unchanged).",
+        "fixing": "- Only change models where the prior view behavior was actually intended (thin passthrough,\n  or a downstream tool expects a view).\n- For those, add materialized='view' at the most local level that already carries config:\n  prefer `dbt.config(materialized='view')` inside the function, else `materialized: view` in\n  the model's YAML, else under dbt_project.yml models:.\n- Do NOT blanket-force every Python model to view \u2014 the new table default is usually desirable;\n  flag ambiguous ones in the results report rather than guessing.\n- After editing run dbt parse; if it fails because dbt.config was placed outside the function,\n  move the call to the first statement inside def model(...)."
+      },
+      "_path": "kb/core/1_3_001.yaml"
+    },
+    {
+      "issue_id": "1_3_002",
+      "sort_order": 1020,
+      "change": "on-run-start / on-run-end hooks no longer halt execution on failure",
+      "action": "Find alternative approaches if hooks were used as guards/circuit-breakers that must abort a run",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start/on-run-end hook now appends an error result and continues instead of raising; guard/circuit-breaker hooks no longer abort the run",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for on-run-start: and on-run-end: keys (string or list).\n- Also scan these keys in any vendored package dbt_project.yml.\n- Flag hooks whose SQL acts as a precondition/guard:\n  - a SELECT that RAISES/THROWS, or calls an assertion macro;\n  - `{% if ... %}{{ exceptions.raise_compiler_error(...) }}{% endif %}`;\n  - SQL that intentionally errors (divide-by-zero, invalid cast) to stop a run.\n- Purely side-effecting hooks (grants, logging, audit inserts) are NOT affected.",
+        "fixing": "- Behavior change dbt parse cannot validate, so it is advisory.\n- For guard hooks: document that they no longer abort the run in 1.4+, and recommend moving the\n  precondition into a pre-flight step outside the run (a separate `dbt run-operation` gate in\n  CI, or a data test CI checks before proceeding).\n- Do not rewrite the hook's SQL automatically.\n- Record each guard-style hook in the results report with issue_id, the dbt_project.yml\n  location, and the suggested CI-gate alternative.\n- No parse impact expected; run dbt parse only to confirm no YAML was broken by edits."
+      },
+      "_path": "kb/core/1_3_002.yaml"
+    },
+    {
+      "issue_id": "1_3_003",
+      "sort_order": 1030,
+      "change": "pre_hook / post_hook (underscore form) now properly late-rendered",
+      "action": "Verify hook behavior if using underscore-form hooks that contain Jinja evaluated at parse time",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Hooks written with the underscore form (pre_hook/post_hook) that contain Jinja now render at runtime instead of parse time, matching the hyphen form; values resolved at parse time may differ",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Search the underscore spellings pre_hook and post_hook (NOT pre-hook/post-hook) across\n  models/**/*.sql config() blocks, models/**/*.yml, and dbt_project.yml.\n- Regex: `(pre_hook|post_hook)\\s*[:=]`.\n- Of those, flag hooks whose value contains Jinja ({{ ... }} or {% ... %}) whose result depends\n  on parse-vs-runtime timing: {{ this }}, {{ run_started_at }}, runtime var()/env_var(), or the\n  result of a statement/run_query.\n- Static string hooks are unaffected.",
+        "fixing": "- Advisory/verification change \u2014 late rendering generally makes underscore hooks behave\n  correctly, so most projects need no edit.\n- Only intervene if a hook relied on the old parse-time rendering (rare).\n- Where behavior matters, note it in the results report and suggest confirming the hook still\n  produces the intended SQL at runtime.\n- Optionally normalize underscore hooks to the canonical hyphen form (pre-hook/post-hook) for\n  clarity, but this is cosmetic.\n- Run dbt parse after any edit; if a config() edit breaks parse, revert to the original key\n  spelling."
+      },
+      "_path": "kb/core/1_3_003.yaml"
+    },
+    {
+      "issue_id": "1_3_013",
+      "sort_order": 1130,
+      "change": "Metric attributes sql / type / type: expression deprecation warnings updated",
+      "action": "Migrate metric attrs to expression, calculation_method, and calculation_method: derived",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Legacy metric attribute names emit deprecation warnings; slated for removal",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan models/**/*.yml for `metrics:` blocks using legacy attrs `sql:`, `type:`, or\n  `type: expression`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (attribute rename to expression/calculation_method).\n- Review the autofix diff and confirm each metric was rewritten.\n- NOTE: this is the 1.3->1.4 attribute rename only; the full MetricFlow rewrite is the separate\n  1.5->1.6 issue 1_5_001.\n- Manual fallback: apply the attribute renames yourself if autofix skipped any."
+      },
+      "_path": "kb/core/1_3_013.yaml"
+    },
+    {
+      "issue_id": "1_3_014",
+      "sort_order": 1140,
+      "change": "Merge SQL predicates wrapped in parens; predicates kwarg renamed to incremental_predicates",
+      "action": "Update custom incremental strategy macros using arg_dict['predicates'] to incremental_predicates",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Custom strategy macros reading arg_dict['predicates'] break; generated merge SQL wraps predicates in parens",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/ for custom incremental/merge macros referencing `predicates`\n  (e.g. `arg_dict['predicates']`, `config.get('predicates')`).",
+        "fixing": "- Handled by `dbt-autofix deprecations` where applicable (rename `predicates` ->\n  `incremental_predicates`).\n- Review the diff.\n- Manual fallback: rename the kwarg in any custom macro autofix did not touch.\n- Behavior/warehouse effect (paren-wrapping) is validated in the build-green layer, not parse."
+      },
+      "_path": "kb/core/1_3_014.yaml"
+    },
+    {
+      "issue_id": "1_4_001",
+      "sort_order": 2010,
+      "change": "--select/--exclude now accumulate when passed multiple times (argparse -> Click)",
+      "action": "Review scripts/jobs passing --select or --exclude more than once; collapse to a single flag with the intended union",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Scripts relying on last-wins override now see both selections combined, selecting more nodes than intended",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep in-repo invocation sites for repeated selection flags on a single command: shell scripts\n  (*.sh), Makefiles, CI YAML (.github/**, .gitlab-ci.yml, azure-pipelines.yml), tox.ini, and dbt\n  wrapper scripts.\n- Pattern: one dbt command containing two or more `--select`/`-s` or `--exclude` tokens (regex\n  `(--select|--exclude|-s)\\b.*\\b(--select|--exclude|-s)\\b`).\n- The real risk lives OUTSIDE the repo in dbt platform job definitions, so in-repo presence may be\n  zero even when the project is affected.",
+        "fixing": "- For each in-repo command with duplicated selection flags, decide intent: pre-1.5 was last-wins (only\n  the final flag applied); 1.5+ is union (all applied).\n- If the old intent was 'use only the last selection', delete the earlier occurrences. If a union was\n  intended, it already works \u2014 leave it.\n- Example: `dbt run --select tag:nightly --select my_model` (1.4 ran only my_model) -> `dbt run\n  --select my_model`.\n- Not visible to dbt parse.\n- ALWAYS add a results entry (manual-required): dbt platform job commands and orchestration outside\n  this repo may pass the flags multiple times; list the affected in-repo sites and tell the user to\n  audit job definitions."
+      },
+      "_path": "kb/core/1_4_001.yaml"
+    },
+    {
+      "issue_id": "1_4_002",
+      "sort_order": 2020,
+      "change": "Duplicate CLI flags before and after the subcommand now raise an error",
+      "action": "Ensure each CLI flag appears only once per dbt invocation",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands like `dbt --flag run --flag` now fail instead of silently taking one value",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan in-repo dbt invocation sites (shell scripts, Makefiles, CI YAML, tox.ini, wrapper scripts) for\n  a single dbt command repeating the same flag, especially placed both before and after the\n  subcommand.\n- Examples: `dbt --debug run --debug`, or a repeated `--profiles-dir` / `--target` / `--vars`.\n- Likeliest offenders: global flags (--debug, --profiles-dir, --project-dir, --target, --log-format)\n  appearing twice.\n- As with selection flags, the primary risk is in dbt platform job commands outside the repo.",
+        "fixing": "- Remove the duplicate occurrence, keeping the one with the intended value (pre-1.5 resolved to a\n  single value, so pick that).\n- Example: `dbt --target prod run --target prod` -> `dbt run --target prod`.\n- If two occurrences carry DIFFERENT values it was already ambiguous \u2014 keep the value the user\n  confirms and record the resolution in the migration log.\n- Not visible to dbt parse.\n- Add a results entry (manual-required) directing the user to audit external job/orchestration\n  commands for duplicated flags, since those now hard-error."
+      },
+      "_path": "kb/core/1_4_002.yaml"
+    },
+    {
+      "issue_id": "1_4_003",
+      "sort_order": 2030,
+      "change": "log-path in dbt_project.yml deprecated",
+      "action": "Move log-path out of dbt_project.yml to the --log-path CLI flag or DBT_LOG_PATH env var",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning at parse time; becomes fatal under --warn-error",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for a top-level `log-path:` key (regex `^\\s*log-path\\s*:`). Present if the key\n  exists with any value.\n- Only one location to check.",
+        "fixing": "- Remove the `log-path:` key from dbt_project.yml.\n- Re-provision out-of-repo: either the `--log-path <dir>` CLI flag on dbt invocations or the\n  `DBT_LOG_PATH` env var.\n- Because the effective destination now lives in job commands / env config outside this repo, add a\n  results entry recording the old value and telling the user to set --log-path/DBT_LOG_PATH wherever\n  dbt is invoked (CI, dbt platform jobs).\n- After removing the key, run dbt parse; the deprecation warning should be gone.\n- If parse still warns, confirm no other config file (a profiles-level or imported yml) re-declares\n  log-path."
+      },
+      "_path": "kb/core/1_4_003.yaml"
+    },
+    {
+      "issue_id": "1_4_004",
+      "sort_order": 2040,
+      "change": "target-path in dbt_project.yml deprecated",
+      "action": "Move target-path out of dbt_project.yml to the --target-path CLI flag or DBT_TARGET_PATH env var",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning at parse time; becomes fatal under --warn-error",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for a top-level `target-path:` key (regex `^\\s*target-path\\s*:`). Present if\n  the key exists.",
+        "fixing": "- Remove the `target-path:` key from dbt_project.yml.\n- Re-provision via the `--target-path <dir>` CLI flag or `DBT_TARGET_PATH` env var wherever dbt runs.\n- Add a results entry recording the old value and directing the user to set\n  --target-path/DBT_TARGET_PATH in job commands / CI / dbt platform, since anything reading generated\n  artifacts (manifest.json, run_results.json) from the custom path must be pointed at the new\n  location.\n- After removal, run dbt parse to confirm the warning is cleared."
+      },
+      "_path": "kb/core/1_4_004.yaml"
+    },
+    {
+      "issue_id": "1_4_005",
+      "sort_order": 2050,
+      "change": "DBT_NO_PRINT environment variable deprecated in favor of DBT_PRINT",
+      "action": "Replace DBT_NO_PRINT=true with DBT_PRINT=false",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for the literal `DBT_NO_PRINT` in CI YAML (.github/**, .gitlab-ci.yml, etc.),\n  Dockerfiles, .env / *.env files, shell scripts, Makefiles, and tox.ini. Present if the token appears\n  anywhere.\n- The variable is frequently set in orchestration outside the repo, so an in-repo miss does not mean\n  the project is clear.",
+        "fixing": "- Translate the value: DBT_NO_PRINT=true (suppress prints) becomes DBT_PRINT=false; DBT_NO_PRINT=false\n  becomes DBT_PRINT=true.\n- Update every in-repo occurrence found.\n- This is an env-var rename, not a Python-environment change, so it is a normal advisory edit (not\n  environment_change) and is not verified by dbt parse.\n- Add a results entry telling the user to replace DBT_NO_PRINT in external CI / dbt platform\n  environment settings with DBT_PRINT (inverted value)."
+      },
+      "_path": "kb/core/1_4_005.yaml"
+    },
+    {
+      "issue_id": "1_4_006",
+      "sort_order": 2060,
+      "change": "DBT_ARTIFACT_STATE_PATH environment variable deprecated in favor of DBT_STATE",
+      "action": "Replace DBT_ARTIFACT_STATE_PATH with DBT_STATE",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_ARTIFACT_STATE_PATH` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Commonly used in Slim CI / state-deferral setups that live in orchestration outside the repo.",
+        "fixing": "- Rename the variable to `DBT_STATE`, keeping the same value (path to the state/manifest directory).\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry telling the user to rename DBT_ARTIFACT_STATE_PATH to DBT_STATE in external CI\n  and dbt platform job environments used for state:modified / --defer selection."
+      },
+      "_path": "kb/core/1_4_006.yaml"
+    },
+    {
+      "issue_id": "1_4_007",
+      "sort_order": 2070,
+      "change": "DBT_FAVOR_STATE_MODE environment variable deprecated in favor of DBT_FAVOR_STATE",
+      "action": "Replace DBT_FAVOR_STATE_MODE with DBT_FAVOR_STATE",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_FAVOR_STATE_MODE` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Typically set in state-based CI selection outside the repo.",
+        "fixing": "- Rename to `DBT_FAVOR_STATE`, preserving the value.\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry directing the user to rename this variable in external CI / dbt platform\n  environments."
+      },
+      "_path": "kb/core/1_4_007.yaml"
+    },
+    {
+      "issue_id": "1_4_008",
+      "sort_order": 2080,
+      "change": "DBT_DEFER_TO_STATE environment variable deprecated in favor of DBT_DEFER",
+      "action": "Replace DBT_DEFER_TO_STATE with DBT_DEFER",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_DEFER_TO_STATE` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Used in --defer based CI workflows that usually live outside the repo.",
+        "fixing": "- Rename to `DBT_DEFER`, preserving the boolean value.\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry directing the user to rename DBT_DEFER_TO_STATE to DBT_DEFER in external CI /\n  dbt platform environments."
+      },
+      "_path": "kb/core/1_4_008.yaml"
+    },
+    {
+      "issue_id": "1_5_001",
+      "sort_order": 3010,
+      "change": "Metric YAML schema completely rewritten for MetricFlow",
+      "action": "Rewrite all metric definitions using the new type/type_params/filter format",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "All existing metric YAML definitions fail to parse in 1.6; the pre-1.6 UnparsedMetric fields (calculation_method, expression, sql, model, type: expression) and the rename_metric_attr compatibility shim were removed.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Search every YAML file under models/ and any schema-file globs declared in dbt_project.yml\n  (models/**/*.yml, models/**/*.yaml, plus any top-level metrics/ dir) for a `metrics:` block.\n- Flag a metric as legacy (pre-1.6) if its entry uses ANY of these keys: `calculation_method`,\n  `expression`, `sql`, `type: expression`, a top-level `type:` with the old enum\n  (`count`/`sum`/...), `model:`, `timestamp:`, `time_grains:`, `dimensions:` directly on the\n  metric, or `filters:` (the list-of-dict old form).\n- The new MetricFlow schema instead uses `type:` with values simple|ratio|cumulative|derived\n  plus a `type_params:` block. If a metric already has `type_params:`, it is migrated \u2014 skip it.\n- Also grep packages.yml for `dbt_metrics` usage and models for `metrics.calculate(` /\n  `metrics.develop(` macro calls \u2014 those depend on the old package and must be flagged too.",
+        "fixing": "- Rewrite each legacy metric into the new schema. Attribute mapping:\n  - `calculation_method` -> `type`: sum/average/min/max/count/count_distinct/median become\n    `type: simple` with `type_params.measure`; derived/expression become `type: derived` with\n    `type_params.expr` and `type_params.metrics`.\n  - `expression`/`sql` -> `type_params.measure` (the semantic measure name), or\n    `type_params.expr` for a derived metric.\n  - `model:` -> moves into a `semantic_models:` definition (see example below).\n  - `filters:` -> `filter:` (a single `{{ Dimension(...) }}` string, or keep the WHERE fragment).\n- Concrete before/after:\n  BEFORE (1.5):\n    metrics:\n      - name: total_revenue\n        calculation_method: sum\n        expression: amount\n        model: ref('orders')\n        timestamp: order_date\n        time_grains: [day, month]\n        dimensions: [status]\n  AFTER (1.6, MetricFlow):\n    semantic_models:\n      - name: orders\n        model: ref('orders')\n        defaults:\n          agg_time_dimension: order_date\n        entities:\n          - name: order\n            type: primary\n        dimensions:\n          - name: order_date\n            type: time\n            type_params: {time_granularity: day}\n          - name: status\n            type: categorical\n        measures:\n          - name: amount\n            agg: sum\n            agg_time_dimension: order_date\n    metrics:\n      - name: total_revenue\n        type: simple\n        type_params:\n          measure: amount\n- Derived example: `calculation_method: derived` + `expression: revenue - cost` becomes\n  `type: derived` with `type_params: {expr: 'revenue - cost', metrics: [{name: revenue},\n  {name: cost}]}`.\n- Judgment-heavy: 1.6 requires a `semantic_models:` layer that did not exist in 1.5, so the\n  measure/entity/dimension split cannot always be inferred mechanically.\n- If you cannot confidently reconstruct the semantic model (e.g. the source model's grain or\n  entities are ambiguous), do NOT guess \u2014 record the metric in the results report with\n  the original YAML and the suggested new shape, and move on.\n- After editing, run `dbt parse`. On a metric/semantic-model validation error, re-read it;\n  reverting to legacy form is NOT an option (it won't parse in 1.6) \u2014 instead leave the\n  semantic_model skeleton and flag it manual.\n- Remove `dbt_metrics` / `metrics.calculate` usages and flag them as requiring the\n  MetricFlow / Semantic Layer migration (out of scope for parse)."
+      },
+      "_path": "kb/core/1_5_001.yaml"
+    },
+    {
+      "issue_id": "1_5_002",
+      "sort_order": 3020,
+      "change": "Duplicate node names allowed across packages",
+      "action": "Disambiguate cross-package references with two-argument ref('package_name', 'model_name')",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.5 a flat manifest dict raised DuplicateResourceNameError; in 1.6 names are stored per-package, so a project and an installed package can legitimately share a model name. Single-argument ref() to a name that exists in more than one package becomes ambiguous (AmbiguousAliasError / wrong node).",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant if packages.yml / dependencies.yml declares packages.\n- Build the set of model/seed/snapshot names defined in the local project (models/**/*.sql,\n  seeds/**/*.csv, snapshots/**/*.sql).\n- Where available, add the names exposed by installed packages under dbt_packages/*/models.\n- Grep all .sql/.yml for single-argument `ref('name')` / `ref(\"name\")` whose `name` collides\n  with a name present in BOTH the local project and a package (or in two packages) \u2014 those are\n  the ambiguous refs.\n- If no packages are installed, mark skipped-not-present.",
+        "fixing": "- For each ambiguous single-arg ref, rewrite to the two-argument form\n  `ref('<package_name>', '<model_name>')`.\n- Choose the package the author intended; default to the local project's own model unless the\n  surrounding SQL clearly consumes the package's version.\n- Example: `ref('customers')` -> `ref('my_project', 'customers')` or\n  `ref('dbt_utils', 'customers')`. Leave unambiguous refs untouched.\n- After edits run `dbt parse`; a remaining AmbiguousAliasError names the offending ref and node.\n- If you cannot determine which package is intended, record it in the results report\n  rather than guessing \u2014 picking the wrong package silently changes lineage."
+      },
+      "_path": "kb/core/1_5_002.yaml"
+    },
+    {
+      "issue_id": "1_5_003",
+      "sort_order": 3030,
+      "change": "collect_freshness macro return type changed",
+      "action": "Update any custom collect_freshness macro override to return the full result object (table + response) instead of just the table",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.6 core's default collect_freshness returns a dict-like {table, response} object; a custom override that returns only the agate table triggers a deprecation warning and will break source freshness in later versions.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/**/*.sql for a macro named `collect_freshness` (i.e. `{% macro collect_freshness(`\n  or `{% macro <adapter>__collect_freshness(`).\n- If none exists, the project uses core's implementation \u2014 mark skipped-not-present.\n- If one exists, inspect its final `{{ return(...) }}` and flag it if it returns the query\n  result table directly (e.g. `return(load_result('collect_freshness').table)` or\n  `return(table)`) rather than the full result object.",
+        "fixing": "- Change the macro to capture the full result and return an object exposing both the table and\n  the adapter response.\n- Pattern: `{% set result = run_query(...) %}` then\n  `{{ return({'table': result.table, 'response': result.response}) }}`.\n- Mirror core's 1.6 signature: it returns `load_result('collect_freshness')`, which already has\n  `.table` and `.response`.\n- Simplest safe fix, if the override only existed to tweak the SQL: align the return statement\n  with core 1.6's macro body.\n- After editing run `dbt parse`.\n- If the override is complex or the intended response object is unclear, record it in the\n  results report with a pointer to core's 1.6 collect_freshness for reference."
+      },
+      "_path": "kb/core/1_5_003.yaml"
+    },
+    {
+      "issue_id": "1_6_011",
+      "sort_order": 4005,
+      "change": "dbt clean errors when clean-targets include source paths or paths outside the project",
+      "action": "Remove source paths (e.g. models/, macros/) and any path outside the project directory from clean-targets in dbt_project.yml",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "dbt clean now raises an error instead of silently deleting the wrong directories when clean-targets references source paths or paths outside the project root",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml's clean-targets list.\n- Flag any entry that resolves (relative to the project root) to a configured source path\n  (model-paths, seed-paths, macro-paths, etc.) or that resolves outside the project directory\n  (e.g. ../shared, /absolute/path).",
+        "fixing": "- Remove the offending entries from clean-targets, keeping only build/output directories\n  (e.g. target, dbt_packages, logs).\n- Re-run dbt clean to confirm it no longer errors."
+      },
+      "_path": "kb/core/1_6_011.yaml"
+    },
+    {
+      "issue_id": "1_6_001",
+      "sort_order": 4010,
+      "change": "New warning when --state and --target point to the same directory",
+      "action": "Fix --state/--target configuration so they reference distinct directories",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "WarnStateTargetEqual raised (informational) for previously silent misconfiguration; fatal under --warn-error",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- This is a runtime CLI/job configuration issue, not a repo-source issue, so `dbt parse` cannot\n  surface it. Detect by scanning invocation sites, not models.\n- Grep the repo for `--state` and `--target` / `--target-path` in shell scripts, Makefiles, and\n  `scripts/**/*.sh`.\n- Also grep CI configs: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `tox.ini`.\n- Check `dbt_project.yml` for a `target-path:` key (deprecated since 1.5 but may still be present).\n- Check for `DBT_STATE` / `DBT_TARGET_PATH` env vars in CI.\n- Flag any invocation where `--state` and `--target`/`--target-path` resolve to the same directory\n  (commonly both set to `target/`).\n- Note the value is frequently supplied outside the repo (dbt platform job definitions,\n  orchestration tools), which parse cannot see.",
+        "fixing": "- Point `--state` at a directory separate from the run's `--target` \u2014 e.g. keep run output in\n  `target/` and the comparison manifest in a distinct dir such as `state/` or `prod-artifacts/`.\n- Concretely, in the offending script/CI step change the duplicated paths so a command like\n  `dbt build --state ./state --target-path ./target` uses different dirs, and populate the state\n  artifacts there.\n- If the same-directory usage lives outside the repo (a dbt platform job command, an orchestration\n  tool), it cannot be edited from the repo.\n- For that out-of-repo case: record it in the results artifact (target/dbt_migration_results.json)\n  as manual-required with the issue_id, the invocation location if known, and the suggested command\n  change, then prompt the user.\n- This change never requires a repo edit to pass `dbt parse`; it is advisory / out-of-repo only."
+      },
+      "_path": "kb/core/1_6_001.yaml"
+    },
+    {
+      "issue_id": "1_6_002",
+      "sort_order": 4020,
+      "change": "Breaking contract changes on unversioned models now warn instead of error",
+      "action": "Add --warn-error (or version the models) to retain the previous hard-error behavior on breaking contract changes",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Unversioned models with a breaking schema/contract change warn via warn_or_error() instead of erroring; CI that relied on the error to block may now pass silently",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan schema YAML (`models/**/*.yml`, `models/**/*.yaml`) for models declaring `contract:` with\n  `enforced: true` that do NOT declare a `version:` / `versions:` block (i.e. unversioned).\n- Those unversioned enforced-contract models are the ones whose breaking contract changes now only\n  warn.\n- Also detect reliance on the old error behavior: grep CI/scripts for `dbt build` / `dbt run`\n  invocations that lack `--warn-error` or `--warn-error-options`.\n- Those flags are what previously turned the contract breakage into a hard failure.\n- This is a behavior/policy change; `dbt parse` stays clean either way, so detection is about intent,\n  not parse errors.",
+        "fixing": "- Preferred: preserve strict behavior by adding `--warn-error` (or a scoped `--warn-error-options`\n  targeting contract deprecations) to the relevant dbt invocation.\n- If that invocation is defined outside the repo (dbt platform job command, orchestration tool), it\n  cannot be edited here: record it in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the suggested flag, and prompt the user.\n- Alternative in-repo fix: add a `version:` to the affected models \u2014 versioning makes breaking\n  contract changes error again.\n- But versioning reshapes ref() resolution and downstream references, so only do it when the user\n  explicitly wants versioned models; note that trade-off in the results report rather than silently\n  versioning.\n- No edit is required for `dbt parse` to succeed."
+      },
+      "_path": "kb/core/1_6_002.yaml"
+    },
+    {
+      "issue_id": "1_6_003",
+      "sort_order": 4030,
+      "change": "New warning for contracted models with bare numeric columns (no precision/scale)",
+      "action": "Add explicit precision and scale to numeric column data_types in enforced contracts (e.g. numeric(38,3))",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with 'data_type: numeric' (or 'decimal') and no precision/scale in an enforced contract now emit a warning at parse time in 1.7",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- In schema YAML (`models/**/*.yml`, `models/**/*.yaml`), find models with `contract:`\n  `enforced: true` and columns whose `data_type` is a bare numeric type with no precision/scale.\n- Match the data_type value (case-insensitive) against `^(numeric|decimal|number)$` (no parentheses).\n- Types that already include `(p,s)` like `numeric(38,3)` are fine and must be left alone.\n- Only columns inside enforced-contract models trigger the warning; bare numeric on non-contracted\n  models is not affected.",
+        "fixing": "- For each flagged column, replace the bare type with an explicit precision/scale, e.g.\n  `data_type: numeric` -> `data_type: numeric(38,3)`.\n- Choose precision/scale from evidence in this order:\n- (1) an existing cast in the model SQL (e.g. `cast(x as numeric(18,2))`) \u2014 match it;\n- (2) the warehouse's documented default for unqualified numeric if the model is already built\n  (Snowflake NUMBER default is (38,0); Redshift/Postgres NUMERIC default is (38,0));\n- (3) if unknown, use a safe wide default `numeric(38,6)` and note the assumption in the results\n  report.\n- Preserve YAML quoting/style.\n- After editing, run `dbt parse`; if it fails, the likely cause is a mismatched type name for the\n  adapter (e.g. Snowflake prefers `number(38,3)`) \u2014 retry with the adapter-native spelling.\n- If the correct precision genuinely cannot be determined, leave the column and record it in the\n  results artifact (target/dbt_migration_results.json) as manual-required for the user to confirm."
+      },
+      "_path": "kb/core/1_6_003.yaml"
+    },
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_3_databricks.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_3_databricks.json
@@ -1,0 +1,1012 @@
+{
+  "from_version": "1.3",
+  "warehouse": "databricks",
+  "target_version": "1.12",
+  "count": 47,
+  "issues": [
+    {
+      "issue_id": "1_3_001",
+      "sort_order": 1010,
+      "change": "Python model default materialization changed from view to table",
+      "action": "Set materialized='view' explicitly on Python models that relied on the old view default",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Python models without an explicit materialized config now create tables instead of views, changing storage/cost and downstream freshness expectations",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Enumerate Python models: models/**/*.py containing `def model(dbt, session)`.\n- Determine each model's effective materialization, in precedence order:\n  - an inline `dbt.config(materialized=...)` call inside model(dbt, session);\n  - a config() block;\n  - the matching model's YAML config in models/**/*.yml;\n  - the models: tree in dbt_project.yml (path-scoped config).\n- A model is affected if NONE of these set materialized: it defaulted to view, now defaults\n  to table.\n- SQL models are unaffected (their default was already view and is unchanged).",
+        "fixing": "- Only change models where the prior view behavior was actually intended (thin passthrough,\n  or a downstream tool expects a view).\n- For those, add materialized='view' at the most local level that already carries config:\n  prefer `dbt.config(materialized='view')` inside the function, else `materialized: view` in\n  the model's YAML, else under dbt_project.yml models:.\n- Do NOT blanket-force every Python model to view \u2014 the new table default is usually desirable;\n  flag ambiguous ones in the results report rather than guessing.\n- After editing run dbt parse; if it fails because dbt.config was placed outside the function,\n  move the call to the first statement inside def model(...)."
+      },
+      "_path": "kb/core/1_3_001.yaml"
+    },
+    {
+      "issue_id": "1_3_002",
+      "sort_order": 1020,
+      "change": "on-run-start / on-run-end hooks no longer halt execution on failure",
+      "action": "Find alternative approaches if hooks were used as guards/circuit-breakers that must abort a run",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start/on-run-end hook now appends an error result and continues instead of raising; guard/circuit-breaker hooks no longer abort the run",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for on-run-start: and on-run-end: keys (string or list).\n- Also scan these keys in any vendored package dbt_project.yml.\n- Flag hooks whose SQL acts as a precondition/guard:\n  - a SELECT that RAISES/THROWS, or calls an assertion macro;\n  - `{% if ... %}{{ exceptions.raise_compiler_error(...) }}{% endif %}`;\n  - SQL that intentionally errors (divide-by-zero, invalid cast) to stop a run.\n- Purely side-effecting hooks (grants, logging, audit inserts) are NOT affected.",
+        "fixing": "- Behavior change dbt parse cannot validate, so it is advisory.\n- For guard hooks: document that they no longer abort the run in 1.4+, and recommend moving the\n  precondition into a pre-flight step outside the run (a separate `dbt run-operation` gate in\n  CI, or a data test CI checks before proceeding).\n- Do not rewrite the hook's SQL automatically.\n- Record each guard-style hook in the results report with issue_id, the dbt_project.yml\n  location, and the suggested CI-gate alternative.\n- No parse impact expected; run dbt parse only to confirm no YAML was broken by edits."
+      },
+      "_path": "kb/core/1_3_002.yaml"
+    },
+    {
+      "issue_id": "1_3_003",
+      "sort_order": 1030,
+      "change": "pre_hook / post_hook (underscore form) now properly late-rendered",
+      "action": "Verify hook behavior if using underscore-form hooks that contain Jinja evaluated at parse time",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Hooks written with the underscore form (pre_hook/post_hook) that contain Jinja now render at runtime instead of parse time, matching the hyphen form; values resolved at parse time may differ",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Search the underscore spellings pre_hook and post_hook (NOT pre-hook/post-hook) across\n  models/**/*.sql config() blocks, models/**/*.yml, and dbt_project.yml.\n- Regex: `(pre_hook|post_hook)\\s*[:=]`.\n- Of those, flag hooks whose value contains Jinja ({{ ... }} or {% ... %}) whose result depends\n  on parse-vs-runtime timing: {{ this }}, {{ run_started_at }}, runtime var()/env_var(), or the\n  result of a statement/run_query.\n- Static string hooks are unaffected.",
+        "fixing": "- Advisory/verification change \u2014 late rendering generally makes underscore hooks behave\n  correctly, so most projects need no edit.\n- Only intervene if a hook relied on the old parse-time rendering (rare).\n- Where behavior matters, note it in the results report and suggest confirming the hook still\n  produces the intended SQL at runtime.\n- Optionally normalize underscore hooks to the canonical hyphen form (pre-hook/post-hook) for\n  clarity, but this is cosmetic.\n- Run dbt parse after any edit; if a config() edit breaks parse, revert to the original key\n  spelling."
+      },
+      "_path": "kb/core/1_3_003.yaml"
+    },
+    {
+      "issue_id": "1_3_004",
+      "sort_order": 1040,
+      "change": "Schema containing '.' now raises an exception (was a warning)",
+      "action": "Split a 'catalog.schema' value into separate catalog and schema fields",
+      "category": "Breaking",
+      "component": "adapter",
+      "adapter_type": "databricks",
+      "impact": "Projects using schema: catalog.schema (a dotted value) fail at startup with a DbtValidationError instead of only warning",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Look for a dotted schema value in two places:\n  - in-repo generate_schema_name / custom schema macros and +schema:/schema: configs in\n    dbt_project.yml and models/**/*.yml where the value contains a dot\n    (regex `schema:\\s*['\\\"]?[\\w]+\\.[\\w]+`);\n  - out-of-repo: profiles.yml schema: field with a dot (often the real source of\n    catalog.schema).\n- The catalog half must move to the database/catalog field.\n- Also check custom macros that concatenate schema names with '.'.",
+        "fixing": "- Where the dotted value lives in the repo (dbt_project.yml or a schema config), split it: left\n  side -> database (Databricks catalog), right side -> schema.\n  Example: `schema: my_catalog.analytics` -> `database: my_catalog` + `schema: analytics`.\n- If the dotted value comes from profiles.yml (out of repo) OR from a generate_schema_name macro\n  that builds names dynamically, do NOT silently edit connection files the skill shouldn't own \u2014\n  record it in the results report (out_of_repo_risk) with the exact key and needed split, and\n  prompt the user.\n- After any in-repo edit run dbt parse; if a schema macro still emits a dotted name, adjust the\n  macro logic to emit catalog via database instead."
+      },
+      "_path": "kb/databricks/1_3_004.yaml"
+    },
+    {
+      "issue_id": "1_3_005",
+      "sort_order": 1050,
+      "change": "Identifiers now quoted by default with backticks",
+      "action": "Review custom macros that assume unquoted identifiers; override via quoting: config only if needed",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "databricks",
+      "impact": "All generated SQL now uses backtick-quoted identifiers (DatabricksQuotePolicy all True), which makes identifiers case/character sensitive and can break string-matching custom macros",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan macros/**/*.sql for logic that builds or matches relation/identifier names as raw\n  strings and would break when names arrive backtick-quoted:\n  - string comparisons against relation.identifier/schema/database;\n  - manual construction of `` `db`.`schema`.`table` `` names;\n  - regex/replace on relation names, or information_schema lookups matching unquoted names.\n- Check for a quoting: config in dbt_project.yml (database/schema/identifier) that may now\n  double-handle quoting.\n- Most standard projects using ref()/source() and Relation objects need NO change.",
+        "fixing": "- Prefer NOT changing anything: the new backtick default is correct for Databricks.\n- Only act when a custom macro compares or constructs identifier strings \u2014 update it to use\n  Relation methods (relation.render(), .include(), adapter.quote()) instead of raw strings.\n- Escape hatch: a `quoting: {identifier: false}` block in dbt_project.yml can restore unquoted\n  behavior, but recommend only if a fix is impractical, and flag it in the results report.\n- Behavior is invisible to dbt parse; run parse only to confirm macro edits compile \u2014 real\n  validation is the warehouse build layer."
+      },
+      "_path": "kb/databricks/1_3_005.yaml"
+    },
+    {
+      "issue_id": "1_3_006",
+      "sort_order": 1060,
+      "change": "dbt_spark_get_incremental_sql macro dispatch removed",
+      "action": "Migrate custom incremental overrides to the adapter.get_incremental_strategy_macro dispatch",
+      "category": "Breaking",
+      "component": "adapter",
+      "adapter_type": "databricks",
+      "impact": "Custom macros overriding dbt_spark_get_incremental_sql are silently ignored \u2014 the incremental strategy they intended no longer takes effect",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/**/*.sql for definitions or references to dbt_spark_get_incremental_sql\n  (regex `macro\\s+.*get_incremental_sql` or `dbt_spark_get_incremental_sql`).\n- A project-level override, or a package that overrides it, indicates the issue.\n- Also look for custom incremental strategy SQL keyed off this macro name.\n- If no such override exists, mark skipped-not-present.",
+        "fixing": "- Rewrite the override to plug into the newer dispatch: define get_incremental_strategy_macro /\n  the strategy-specific macro (e.g. get_incremental_<strategy>_sql) that\n  adapter.get_incremental_strategy_macro resolves, rather than the removed\n  dbt_spark_get_incremental_sql.\n- Move the body of the old macro into the correctly named strategy macro and register the\n  strategy.\n- Incremental behavior is warehouse-observable and not caught by parse: after editing run dbt\n  parse to confirm the macro compiles, then flag the change in the results report for\n  build-layer verification.\n- If the strategy is custom and the correct new macro name is unclear, record it in the results\n  report."
+      },
+      "_path": "kb/databricks/1_3_006.yaml"
+    },
+    {
+      "issue_id": "1_3_013",
+      "sort_order": 1130,
+      "change": "Metric attributes sql / type / type: expression deprecation warnings updated",
+      "action": "Migrate metric attrs to expression, calculation_method, and calculation_method: derived",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Legacy metric attribute names emit deprecation warnings; slated for removal",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan models/**/*.yml for `metrics:` blocks using legacy attrs `sql:`, `type:`, or\n  `type: expression`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (attribute rename to expression/calculation_method).\n- Review the autofix diff and confirm each metric was rewritten.\n- NOTE: this is the 1.3->1.4 attribute rename only; the full MetricFlow rewrite is the separate\n  1.5->1.6 issue 1_5_001.\n- Manual fallback: apply the attribute renames yourself if autofix skipped any."
+      },
+      "_path": "kb/core/1_3_013.yaml"
+    },
+    {
+      "issue_id": "1_3_014",
+      "sort_order": 1140,
+      "change": "Merge SQL predicates wrapped in parens; predicates kwarg renamed to incremental_predicates",
+      "action": "Update custom incremental strategy macros using arg_dict['predicates'] to incremental_predicates",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Custom strategy macros reading arg_dict['predicates'] break; generated merge SQL wraps predicates in parens",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/ for custom incremental/merge macros referencing `predicates`\n  (e.g. `arg_dict['predicates']`, `config.get('predicates')`).",
+        "fixing": "- Handled by `dbt-autofix deprecations` where applicable (rename `predicates` ->\n  `incremental_predicates`).\n- Review the diff.\n- Manual fallback: rename the kwarg in any custom macro autofix did not touch.\n- Behavior/warehouse effect (paren-wrapping) is validated in the build-green layer, not parse."
+      },
+      "_path": "kb/core/1_3_014.yaml"
+    },
+    {
+      "issue_id": "1_4_001",
+      "sort_order": 2010,
+      "change": "--select/--exclude now accumulate when passed multiple times (argparse -> Click)",
+      "action": "Review scripts/jobs passing --select or --exclude more than once; collapse to a single flag with the intended union",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Scripts relying on last-wins override now see both selections combined, selecting more nodes than intended",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep in-repo invocation sites for repeated selection flags on a single command: shell scripts\n  (*.sh), Makefiles, CI YAML (.github/**, .gitlab-ci.yml, azure-pipelines.yml), tox.ini, and dbt\n  wrapper scripts.\n- Pattern: one dbt command containing two or more `--select`/`-s` or `--exclude` tokens (regex\n  `(--select|--exclude|-s)\\b.*\\b(--select|--exclude|-s)\\b`).\n- The real risk lives OUTSIDE the repo in dbt platform job definitions, so in-repo presence may be\n  zero even when the project is affected.",
+        "fixing": "- For each in-repo command with duplicated selection flags, decide intent: pre-1.5 was last-wins (only\n  the final flag applied); 1.5+ is union (all applied).\n- If the old intent was 'use only the last selection', delete the earlier occurrences. If a union was\n  intended, it already works \u2014 leave it.\n- Example: `dbt run --select tag:nightly --select my_model` (1.4 ran only my_model) -> `dbt run\n  --select my_model`.\n- Not visible to dbt parse.\n- ALWAYS add a results entry (manual-required): dbt platform job commands and orchestration outside\n  this repo may pass the flags multiple times; list the affected in-repo sites and tell the user to\n  audit job definitions."
+      },
+      "_path": "kb/core/1_4_001.yaml"
+    },
+    {
+      "issue_id": "1_4_002",
+      "sort_order": 2020,
+      "change": "Duplicate CLI flags before and after the subcommand now raise an error",
+      "action": "Ensure each CLI flag appears only once per dbt invocation",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands like `dbt --flag run --flag` now fail instead of silently taking one value",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan in-repo dbt invocation sites (shell scripts, Makefiles, CI YAML, tox.ini, wrapper scripts) for\n  a single dbt command repeating the same flag, especially placed both before and after the\n  subcommand.\n- Examples: `dbt --debug run --debug`, or a repeated `--profiles-dir` / `--target` / `--vars`.\n- Likeliest offenders: global flags (--debug, --profiles-dir, --project-dir, --target, --log-format)\n  appearing twice.\n- As with selection flags, the primary risk is in dbt platform job commands outside the repo.",
+        "fixing": "- Remove the duplicate occurrence, keeping the one with the intended value (pre-1.5 resolved to a\n  single value, so pick that).\n- Example: `dbt --target prod run --target prod` -> `dbt run --target prod`.\n- If two occurrences carry DIFFERENT values it was already ambiguous \u2014 keep the value the user\n  confirms and record the resolution in the migration log.\n- Not visible to dbt parse.\n- Add a results entry (manual-required) directing the user to audit external job/orchestration\n  commands for duplicated flags, since those now hard-error."
+      },
+      "_path": "kb/core/1_4_002.yaml"
+    },
+    {
+      "issue_id": "1_4_003",
+      "sort_order": 2030,
+      "change": "log-path in dbt_project.yml deprecated",
+      "action": "Move log-path out of dbt_project.yml to the --log-path CLI flag or DBT_LOG_PATH env var",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning at parse time; becomes fatal under --warn-error",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for a top-level `log-path:` key (regex `^\\s*log-path\\s*:`). Present if the key\n  exists with any value.\n- Only one location to check.",
+        "fixing": "- Remove the `log-path:` key from dbt_project.yml.\n- Re-provision out-of-repo: either the `--log-path <dir>` CLI flag on dbt invocations or the\n  `DBT_LOG_PATH` env var.\n- Because the effective destination now lives in job commands / env config outside this repo, add a\n  results entry recording the old value and telling the user to set --log-path/DBT_LOG_PATH wherever\n  dbt is invoked (CI, dbt platform jobs).\n- After removing the key, run dbt parse; the deprecation warning should be gone.\n- If parse still warns, confirm no other config file (a profiles-level or imported yml) re-declares\n  log-path."
+      },
+      "_path": "kb/core/1_4_003.yaml"
+    },
+    {
+      "issue_id": "1_4_004",
+      "sort_order": 2040,
+      "change": "target-path in dbt_project.yml deprecated",
+      "action": "Move target-path out of dbt_project.yml to the --target-path CLI flag or DBT_TARGET_PATH env var",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning at parse time; becomes fatal under --warn-error",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for a top-level `target-path:` key (regex `^\\s*target-path\\s*:`). Present if\n  the key exists.",
+        "fixing": "- Remove the `target-path:` key from dbt_project.yml.\n- Re-provision via the `--target-path <dir>` CLI flag or `DBT_TARGET_PATH` env var wherever dbt runs.\n- Add a results entry recording the old value and directing the user to set\n  --target-path/DBT_TARGET_PATH in job commands / CI / dbt platform, since anything reading generated\n  artifacts (manifest.json, run_results.json) from the custom path must be pointed at the new\n  location.\n- After removal, run dbt parse to confirm the warning is cleared."
+      },
+      "_path": "kb/core/1_4_004.yaml"
+    },
+    {
+      "issue_id": "1_4_005",
+      "sort_order": 2050,
+      "change": "DBT_NO_PRINT environment variable deprecated in favor of DBT_PRINT",
+      "action": "Replace DBT_NO_PRINT=true with DBT_PRINT=false",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for the literal `DBT_NO_PRINT` in CI YAML (.github/**, .gitlab-ci.yml, etc.),\n  Dockerfiles, .env / *.env files, shell scripts, Makefiles, and tox.ini. Present if the token appears\n  anywhere.\n- The variable is frequently set in orchestration outside the repo, so an in-repo miss does not mean\n  the project is clear.",
+        "fixing": "- Translate the value: DBT_NO_PRINT=true (suppress prints) becomes DBT_PRINT=false; DBT_NO_PRINT=false\n  becomes DBT_PRINT=true.\n- Update every in-repo occurrence found.\n- This is an env-var rename, not a Python-environment change, so it is a normal advisory edit (not\n  environment_change) and is not verified by dbt parse.\n- Add a results entry telling the user to replace DBT_NO_PRINT in external CI / dbt platform\n  environment settings with DBT_PRINT (inverted value)."
+      },
+      "_path": "kb/core/1_4_005.yaml"
+    },
+    {
+      "issue_id": "1_4_006",
+      "sort_order": 2060,
+      "change": "DBT_ARTIFACT_STATE_PATH environment variable deprecated in favor of DBT_STATE",
+      "action": "Replace DBT_ARTIFACT_STATE_PATH with DBT_STATE",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_ARTIFACT_STATE_PATH` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Commonly used in Slim CI / state-deferral setups that live in orchestration outside the repo.",
+        "fixing": "- Rename the variable to `DBT_STATE`, keeping the same value (path to the state/manifest directory).\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry telling the user to rename DBT_ARTIFACT_STATE_PATH to DBT_STATE in external CI\n  and dbt platform job environments used for state:modified / --defer selection."
+      },
+      "_path": "kb/core/1_4_006.yaml"
+    },
+    {
+      "issue_id": "1_4_007",
+      "sort_order": 2070,
+      "change": "DBT_FAVOR_STATE_MODE environment variable deprecated in favor of DBT_FAVOR_STATE",
+      "action": "Replace DBT_FAVOR_STATE_MODE with DBT_FAVOR_STATE",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_FAVOR_STATE_MODE` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Typically set in state-based CI selection outside the repo.",
+        "fixing": "- Rename to `DBT_FAVOR_STATE`, preserving the value.\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry directing the user to rename this variable in external CI / dbt platform\n  environments."
+      },
+      "_path": "kb/core/1_4_007.yaml"
+    },
+    {
+      "issue_id": "1_4_008",
+      "sort_order": 2080,
+      "change": "DBT_DEFER_TO_STATE environment variable deprecated in favor of DBT_DEFER",
+      "action": "Replace DBT_DEFER_TO_STATE with DBT_DEFER",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_DEFER_TO_STATE` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Used in --defer based CI workflows that usually live outside the repo.",
+        "fixing": "- Rename to `DBT_DEFER`, preserving the boolean value.\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry directing the user to rename DBT_DEFER_TO_STATE to DBT_DEFER in external CI /\n  dbt platform environments."
+      },
+      "_path": "kb/core/1_4_008.yaml"
+    },
+    {
+      "issue_id": "1_5_001",
+      "sort_order": 3010,
+      "change": "Metric YAML schema completely rewritten for MetricFlow",
+      "action": "Rewrite all metric definitions using the new type/type_params/filter format",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "All existing metric YAML definitions fail to parse in 1.6; the pre-1.6 UnparsedMetric fields (calculation_method, expression, sql, model, type: expression) and the rename_metric_attr compatibility shim were removed.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Search every YAML file under models/ and any schema-file globs declared in dbt_project.yml\n  (models/**/*.yml, models/**/*.yaml, plus any top-level metrics/ dir) for a `metrics:` block.\n- Flag a metric as legacy (pre-1.6) if its entry uses ANY of these keys: `calculation_method`,\n  `expression`, `sql`, `type: expression`, a top-level `type:` with the old enum\n  (`count`/`sum`/...), `model:`, `timestamp:`, `time_grains:`, `dimensions:` directly on the\n  metric, or `filters:` (the list-of-dict old form).\n- The new MetricFlow schema instead uses `type:` with values simple|ratio|cumulative|derived\n  plus a `type_params:` block. If a metric already has `type_params:`, it is migrated \u2014 skip it.\n- Also grep packages.yml for `dbt_metrics` usage and models for `metrics.calculate(` /\n  `metrics.develop(` macro calls \u2014 those depend on the old package and must be flagged too.",
+        "fixing": "- Rewrite each legacy metric into the new schema. Attribute mapping:\n  - `calculation_method` -> `type`: sum/average/min/max/count/count_distinct/median become\n    `type: simple` with `type_params.measure`; derived/expression become `type: derived` with\n    `type_params.expr` and `type_params.metrics`.\n  - `expression`/`sql` -> `type_params.measure` (the semantic measure name), or\n    `type_params.expr` for a derived metric.\n  - `model:` -> moves into a `semantic_models:` definition (see example below).\n  - `filters:` -> `filter:` (a single `{{ Dimension(...) }}` string, or keep the WHERE fragment).\n- Concrete before/after:\n  BEFORE (1.5):\n    metrics:\n      - name: total_revenue\n        calculation_method: sum\n        expression: amount\n        model: ref('orders')\n        timestamp: order_date\n        time_grains: [day, month]\n        dimensions: [status]\n  AFTER (1.6, MetricFlow):\n    semantic_models:\n      - name: orders\n        model: ref('orders')\n        defaults:\n          agg_time_dimension: order_date\n        entities:\n          - name: order\n            type: primary\n        dimensions:\n          - name: order_date\n            type: time\n            type_params: {time_granularity: day}\n          - name: status\n            type: categorical\n        measures:\n          - name: amount\n            agg: sum\n            agg_time_dimension: order_date\n    metrics:\n      - name: total_revenue\n        type: simple\n        type_params:\n          measure: amount\n- Derived example: `calculation_method: derived` + `expression: revenue - cost` becomes\n  `type: derived` with `type_params: {expr: 'revenue - cost', metrics: [{name: revenue},\n  {name: cost}]}`.\n- Judgment-heavy: 1.6 requires a `semantic_models:` layer that did not exist in 1.5, so the\n  measure/entity/dimension split cannot always be inferred mechanically.\n- If you cannot confidently reconstruct the semantic model (e.g. the source model's grain or\n  entities are ambiguous), do NOT guess \u2014 record the metric in the results report with\n  the original YAML and the suggested new shape, and move on.\n- After editing, run `dbt parse`. On a metric/semantic-model validation error, re-read it;\n  reverting to legacy form is NOT an option (it won't parse in 1.6) \u2014 instead leave the\n  semantic_model skeleton and flag it manual.\n- Remove `dbt_metrics` / `metrics.calculate` usages and flag them as requiring the\n  MetricFlow / Semantic Layer migration (out of scope for parse)."
+      },
+      "_path": "kb/core/1_5_001.yaml"
+    },
+    {
+      "issue_id": "1_5_002",
+      "sort_order": 3020,
+      "change": "Duplicate node names allowed across packages",
+      "action": "Disambiguate cross-package references with two-argument ref('package_name', 'model_name')",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.5 a flat manifest dict raised DuplicateResourceNameError; in 1.6 names are stored per-package, so a project and an installed package can legitimately share a model name. Single-argument ref() to a name that exists in more than one package becomes ambiguous (AmbiguousAliasError / wrong node).",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant if packages.yml / dependencies.yml declares packages.\n- Build the set of model/seed/snapshot names defined in the local project (models/**/*.sql,\n  seeds/**/*.csv, snapshots/**/*.sql).\n- Where available, add the names exposed by installed packages under dbt_packages/*/models.\n- Grep all .sql/.yml for single-argument `ref('name')` / `ref(\"name\")` whose `name` collides\n  with a name present in BOTH the local project and a package (or in two packages) \u2014 those are\n  the ambiguous refs.\n- If no packages are installed, mark skipped-not-present.",
+        "fixing": "- For each ambiguous single-arg ref, rewrite to the two-argument form\n  `ref('<package_name>', '<model_name>')`.\n- Choose the package the author intended; default to the local project's own model unless the\n  surrounding SQL clearly consumes the package's version.\n- Example: `ref('customers')` -> `ref('my_project', 'customers')` or\n  `ref('dbt_utils', 'customers')`. Leave unambiguous refs untouched.\n- After edits run `dbt parse`; a remaining AmbiguousAliasError names the offending ref and node.\n- If you cannot determine which package is intended, record it in the results report\n  rather than guessing \u2014 picking the wrong package silently changes lineage."
+      },
+      "_path": "kb/core/1_5_002.yaml"
+    },
+    {
+      "issue_id": "1_5_003",
+      "sort_order": 3030,
+      "change": "collect_freshness macro return type changed",
+      "action": "Update any custom collect_freshness macro override to return the full result object (table + response) instead of just the table",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.6 core's default collect_freshness returns a dict-like {table, response} object; a custom override that returns only the agate table triggers a deprecation warning and will break source freshness in later versions.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/**/*.sql for a macro named `collect_freshness` (i.e. `{% macro collect_freshness(`\n  or `{% macro <adapter>__collect_freshness(`).\n- If none exists, the project uses core's implementation \u2014 mark skipped-not-present.\n- If one exists, inspect its final `{{ return(...) }}` and flag it if it returns the query\n  result table directly (e.g. `return(load_result('collect_freshness').table)` or\n  `return(table)`) rather than the full result object.",
+        "fixing": "- Change the macro to capture the full result and return an object exposing both the table and\n  the adapter response.\n- Pattern: `{% set result = run_query(...) %}` then\n  `{{ return({'table': result.table, 'response': result.response}) }}`.\n- Mirror core's 1.6 signature: it returns `load_result('collect_freshness')`, which already has\n  `.table` and `.response`.\n- Simplest safe fix, if the override only existed to tweak the SQL: align the return statement\n  with core 1.6's macro body.\n- After editing run `dbt parse`.\n- If the override is complex or the intended response object is unclear, record it in the\n  results report with a pointer to core's 1.6 collect_freshness for reference."
+      },
+      "_path": "kb/core/1_5_003.yaml"
+    },
+    {
+      "issue_id": "1_5_010",
+      "sort_order": 3100,
+      "change": "Default socket timeout set to 180 seconds",
+      "action": "Adjust _socket_timeout in connection_parameters if long-idle connections time out",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "databricks",
+      "impact": "1.6 introduces a default socket timeout of 180s. Long-idle connections (e.g. warehouses that were paused/cold) may now time out where they previously waited indefinitely.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": true,
+      "context": {
+        "detection": "- Behavioral connection change invisible to `dbt parse`.\n- Check the databricks output in profiles.yml (usually out of repo) for a\n  `connect_timeout` / `_socket_timeout` / `connection_parameters` setting.\n- Risk signals: projects querying serverless / auto-stopping SQL warehouses with long cold-start\n  times, or long-running single statements exceeding 180s of socket idleness.",
+        "fixing": "- ADVISORY ONLY.\n- If timeouts are a risk, recommend setting `_socket_timeout` under `connection_parameters` in\n  the databricks profile to a higher value; otherwise no change.\n- profiles.yml is usually out of repo and this is warehouse behavior \u2014 add a manual-actions entry\n  noting the new 180s default and the tuning knob.\n- Excluded from the parse verify loop."
+      },
+      "_path": "kb/databricks/1_5_010.yaml"
+    },
+    {
+      "issue_id": "1_6_011",
+      "sort_order": 4005,
+      "change": "dbt clean errors when clean-targets include source paths or paths outside the project",
+      "action": "Remove source paths (e.g. models/, macros/) and any path outside the project directory from clean-targets in dbt_project.yml",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "dbt clean now raises an error instead of silently deleting the wrong directories when clean-targets references source paths or paths outside the project root",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml's clean-targets list.\n- Flag any entry that resolves (relative to the project root) to a configured source path\n  (model-paths, seed-paths, macro-paths, etc.) or that resolves outside the project directory\n  (e.g. ../shared, /absolute/path).",
+        "fixing": "- Remove the offending entries from clean-targets, keeping only build/output directories\n  (e.g. target, dbt_packages, logs).\n- Re-run dbt clean to confirm it no longer errors."
+      },
+      "_path": "kb/core/1_6_011.yaml"
+    },
+    {
+      "issue_id": "1_6_001",
+      "sort_order": 4010,
+      "change": "New warning when --state and --target point to the same directory",
+      "action": "Fix --state/--target configuration so they reference distinct directories",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "WarnStateTargetEqual raised (informational) for previously silent misconfiguration; fatal under --warn-error",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- This is a runtime CLI/job configuration issue, not a repo-source issue, so `dbt parse` cannot\n  surface it. Detect by scanning invocation sites, not models.\n- Grep the repo for `--state` and `--target` / `--target-path` in shell scripts, Makefiles, and\n  `scripts/**/*.sh`.\n- Also grep CI configs: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `tox.ini`.\n- Check `dbt_project.yml` for a `target-path:` key (deprecated since 1.5 but may still be present).\n- Check for `DBT_STATE` / `DBT_TARGET_PATH` env vars in CI.\n- Flag any invocation where `--state` and `--target`/`--target-path` resolve to the same directory\n  (commonly both set to `target/`).\n- Note the value is frequently supplied outside the repo (dbt platform job definitions,\n  orchestration tools), which parse cannot see.",
+        "fixing": "- Point `--state` at a directory separate from the run's `--target` \u2014 e.g. keep run output in\n  `target/` and the comparison manifest in a distinct dir such as `state/` or `prod-artifacts/`.\n- Concretely, in the offending script/CI step change the duplicated paths so a command like\n  `dbt build --state ./state --target-path ./target` uses different dirs, and populate the state\n  artifacts there.\n- If the same-directory usage lives outside the repo (a dbt platform job command, an orchestration\n  tool), it cannot be edited from the repo.\n- For that out-of-repo case: record it in the results artifact (target/dbt_migration_results.json)\n  as manual-required with the issue_id, the invocation location if known, and the suggested command\n  change, then prompt the user.\n- This change never requires a repo edit to pass `dbt parse`; it is advisory / out-of-repo only."
+      },
+      "_path": "kb/core/1_6_001.yaml"
+    },
+    {
+      "issue_id": "1_6_002",
+      "sort_order": 4020,
+      "change": "Breaking contract changes on unversioned models now warn instead of error",
+      "action": "Add --warn-error (or version the models) to retain the previous hard-error behavior on breaking contract changes",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Unversioned models with a breaking schema/contract change warn via warn_or_error() instead of erroring; CI that relied on the error to block may now pass silently",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan schema YAML (`models/**/*.yml`, `models/**/*.yaml`) for models declaring `contract:` with\n  `enforced: true` that do NOT declare a `version:` / `versions:` block (i.e. unversioned).\n- Those unversioned enforced-contract models are the ones whose breaking contract changes now only\n  warn.\n- Also detect reliance on the old error behavior: grep CI/scripts for `dbt build` / `dbt run`\n  invocations that lack `--warn-error` or `--warn-error-options`.\n- Those flags are what previously turned the contract breakage into a hard failure.\n- This is a behavior/policy change; `dbt parse` stays clean either way, so detection is about intent,\n  not parse errors.",
+        "fixing": "- Preferred: preserve strict behavior by adding `--warn-error` (or a scoped `--warn-error-options`\n  targeting contract deprecations) to the relevant dbt invocation.\n- If that invocation is defined outside the repo (dbt platform job command, orchestration tool), it\n  cannot be edited here: record it in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the suggested flag, and prompt the user.\n- Alternative in-repo fix: add a `version:` to the affected models \u2014 versioning makes breaking\n  contract changes error again.\n- But versioning reshapes ref() resolution and downstream references, so only do it when the user\n  explicitly wants versioned models; note that trade-off in the results report rather than silently\n  versioning.\n- No edit is required for `dbt parse` to succeed."
+      },
+      "_path": "kb/core/1_6_002.yaml"
+    },
+    {
+      "issue_id": "1_6_003",
+      "sort_order": 4030,
+      "change": "New warning for contracted models with bare numeric columns (no precision/scale)",
+      "action": "Add explicit precision and scale to numeric column data_types in enforced contracts (e.g. numeric(38,3))",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with 'data_type: numeric' (or 'decimal') and no precision/scale in an enforced contract now emit a warning at parse time in 1.7",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- In schema YAML (`models/**/*.yml`, `models/**/*.yaml`), find models with `contract:`\n  `enforced: true` and columns whose `data_type` is a bare numeric type with no precision/scale.\n- Match the data_type value (case-insensitive) against `^(numeric|decimal|number)$` (no parentheses).\n- Types that already include `(p,s)` like `numeric(38,3)` are fine and must be left alone.\n- Only columns inside enforced-contract models trigger the warning; bare numeric on non-contracted\n  models is not affected.",
+        "fixing": "- For each flagged column, replace the bare type with an explicit precision/scale, e.g.\n  `data_type: numeric` -> `data_type: numeric(38,3)`.\n- Choose precision/scale from evidence in this order:\n- (1) an existing cast in the model SQL (e.g. `cast(x as numeric(18,2))`) \u2014 match it;\n- (2) the warehouse's documented default for unqualified numeric if the model is already built\n  (Snowflake NUMBER default is (38,0); Redshift/Postgres NUMERIC default is (38,0));\n- (3) if unknown, use a safe wide default `numeric(38,6)` and note the assumption in the results\n  report.\n- Preserve YAML quoting/style.\n- After editing, run `dbt parse`; if it fails, the likely cause is a mismatched type name for the\n  adapter (e.g. Snowflake prefers `number(38,3)`) \u2014 retry with the adapter-native spelling.\n- If the correct precision genuinely cannot be determined, leave the column and record it in the\n  results artifact (target/dbt_migration_results.json) as manual-required for the user to confirm."
+      },
+      "_path": "kb/core/1_6_003.yaml"
+    },
+    {
+      "issue_id": "1_6_005",
+      "sort_order": 4050,
+      "change": "Default catalog set to hive_metastore when not specified",
+      "action": "Verify the default matches expectations; set catalog explicitly in profiles.yml if a different catalog is intended",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "databricks",
+      "impact": "Projects that did not set a catalog now explicitly resolve to hive_metastore; relations may be created/read in hive_metastore instead of a previously-implicit Unity Catalog default",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": true,
+      "context": {
+        "detection": "- This is a connection/environment default, not a repo-source change, so `dbt parse` cannot see it.\n- Inspect the Databricks connection config: `profiles.yml` (`outputs.<target>.catalog`) and any\n  `catalog:` / `database:` set in `dbt_project.yml` or model configs.\n- Flag the project if NO catalog/database is set anywhere for the Databricks target \u2014 those projects\n  now implicitly get `hive_metastore`.\n- If a catalog is already set explicitly, no action.\n- Note `profiles.yml` often lives outside the repo (`~/.dbt/` or dbt platform connection settings).",
+        "fixing": "- Advisory / environment change only \u2014 never mutate credentials or run anything.\n- If the workspace uses Unity Catalog and the user expects a UC catalog rather than the legacy\n  hive_metastore, add an explicit `catalog: <name>` to the Databricks output in `profiles.yml` (or\n  the platform connection).\n- If `profiles.yml` is inside the repo, apply the advisory edit and record it in the results report.\n- If it is outside the repo, record the recommended `catalog:` setting in the results artifact\n  (target/dbt_migration_results.json) as advisory and prompt the user to confirm the intended\n  catalog.\n- Exclude from the parse-verify loop (parse does not reflect connection settings)."
+      },
+      "_path": "kb/databricks/1_6_005.yaml"
+    },
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_3_redshift.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_3_redshift.json
@@ -1,0 +1,1092 @@
+{
+  "from_version": "1.3",
+  "warehouse": "redshift",
+  "target_version": "1.12",
+  "count": 51,
+  "issues": [
+    {
+      "issue_id": "1_3_001",
+      "sort_order": 1010,
+      "change": "Python model default materialization changed from view to table",
+      "action": "Set materialized='view' explicitly on Python models that relied on the old view default",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Python models without an explicit materialized config now create tables instead of views, changing storage/cost and downstream freshness expectations",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Enumerate Python models: models/**/*.py containing `def model(dbt, session)`.\n- Determine each model's effective materialization, in precedence order:\n  - an inline `dbt.config(materialized=...)` call inside model(dbt, session);\n  - a config() block;\n  - the matching model's YAML config in models/**/*.yml;\n  - the models: tree in dbt_project.yml (path-scoped config).\n- A model is affected if NONE of these set materialized: it defaulted to view, now defaults\n  to table.\n- SQL models are unaffected (their default was already view and is unchanged).",
+        "fixing": "- Only change models where the prior view behavior was actually intended (thin passthrough,\n  or a downstream tool expects a view).\n- For those, add materialized='view' at the most local level that already carries config:\n  prefer `dbt.config(materialized='view')` inside the function, else `materialized: view` in\n  the model's YAML, else under dbt_project.yml models:.\n- Do NOT blanket-force every Python model to view \u2014 the new table default is usually desirable;\n  flag ambiguous ones in the results report rather than guessing.\n- After editing run dbt parse; if it fails because dbt.config was placed outside the function,\n  move the call to the first statement inside def model(...)."
+      },
+      "_path": "kb/core/1_3_001.yaml"
+    },
+    {
+      "issue_id": "1_3_002",
+      "sort_order": 1020,
+      "change": "on-run-start / on-run-end hooks no longer halt execution on failure",
+      "action": "Find alternative approaches if hooks were used as guards/circuit-breakers that must abort a run",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start/on-run-end hook now appends an error result and continues instead of raising; guard/circuit-breaker hooks no longer abort the run",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for on-run-start: and on-run-end: keys (string or list).\n- Also scan these keys in any vendored package dbt_project.yml.\n- Flag hooks whose SQL acts as a precondition/guard:\n  - a SELECT that RAISES/THROWS, or calls an assertion macro;\n  - `{% if ... %}{{ exceptions.raise_compiler_error(...) }}{% endif %}`;\n  - SQL that intentionally errors (divide-by-zero, invalid cast) to stop a run.\n- Purely side-effecting hooks (grants, logging, audit inserts) are NOT affected.",
+        "fixing": "- Behavior change dbt parse cannot validate, so it is advisory.\n- For guard hooks: document that they no longer abort the run in 1.4+, and recommend moving the\n  precondition into a pre-flight step outside the run (a separate `dbt run-operation` gate in\n  CI, or a data test CI checks before proceeding).\n- Do not rewrite the hook's SQL automatically.\n- Record each guard-style hook in the results report with issue_id, the dbt_project.yml\n  location, and the suggested CI-gate alternative.\n- No parse impact expected; run dbt parse only to confirm no YAML was broken by edits."
+      },
+      "_path": "kb/core/1_3_002.yaml"
+    },
+    {
+      "issue_id": "1_3_003",
+      "sort_order": 1030,
+      "change": "pre_hook / post_hook (underscore form) now properly late-rendered",
+      "action": "Verify hook behavior if using underscore-form hooks that contain Jinja evaluated at parse time",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Hooks written with the underscore form (pre_hook/post_hook) that contain Jinja now render at runtime instead of parse time, matching the hyphen form; values resolved at parse time may differ",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Search the underscore spellings pre_hook and post_hook (NOT pre-hook/post-hook) across\n  models/**/*.sql config() blocks, models/**/*.yml, and dbt_project.yml.\n- Regex: `(pre_hook|post_hook)\\s*[:=]`.\n- Of those, flag hooks whose value contains Jinja ({{ ... }} or {% ... %}) whose result depends\n  on parse-vs-runtime timing: {{ this }}, {{ run_started_at }}, runtime var()/env_var(), or the\n  result of a statement/run_query.\n- Static string hooks are unaffected.",
+        "fixing": "- Advisory/verification change \u2014 late rendering generally makes underscore hooks behave\n  correctly, so most projects need no edit.\n- Only intervene if a hook relied on the old parse-time rendering (rare).\n- Where behavior matters, note it in the results report and suggest confirming the hook still\n  produces the intended SQL at runtime.\n- Optionally normalize underscore hooks to the canonical hyphen form (pre-hook/post-hook) for\n  clarity, but this is cosmetic.\n- Run dbt parse after any edit; if a config() edit breaks parse, revert to the original key\n  spelling."
+      },
+      "_path": "kb/core/1_3_003.yaml"
+    },
+    {
+      "issue_id": "1_3_007",
+      "sort_order": 1070,
+      "change": "keepalives_idle default changed from 240 to 4 seconds",
+      "action": "Review keepalives_idle in profiles.yml; set it to 240 explicitly if the old behavior is needed",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "Connections on slow or idle networks may drop sooner because the TCP keepalive idle default dropped from 240s to 4s",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": true,
+      "context": {
+        "detection": "- This is a connection/profiles concern (no in-model footprint).\n- Read profiles.yml (typically ~/.dbt/profiles.yml or a repo-local profiles.yml) for the\n  redshift output(s) and check whether keepalives_idle is set.\n- If absent, the effective default silently changes from 240 to 4 in 1.4.\n- If explicitly set, no change is needed. models/** and dbt_project.yml are irrelevant here.",
+        "fixing": "- ADVISORY ONLY: environment/profiles change; never mutate live credentials or run any command.\n- If profiles.yml is in the repo and lacks keepalives_idle, suggest adding keepalives_idle: 240\n  under the affected redshift target to preserve pre-1.4 behavior (only if the user reported\n  idle-network drops).\n- Record the recommendation in the results report with the target name.\n- Do NOT run pip or connect to the warehouse.\n- Excluded from the dbt parse verify loop because parse does not reflect connection settings."
+      },
+      "_path": "kb/redshift/1_3_007.yaml"
+    },
+    {
+      "issue_id": "1_3_013",
+      "sort_order": 1130,
+      "change": "Metric attributes sql / type / type: expression deprecation warnings updated",
+      "action": "Migrate metric attrs to expression, calculation_method, and calculation_method: derived",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Legacy metric attribute names emit deprecation warnings; slated for removal",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan models/**/*.yml for `metrics:` blocks using legacy attrs `sql:`, `type:`, or\n  `type: expression`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (attribute rename to expression/calculation_method).\n- Review the autofix diff and confirm each metric was rewritten.\n- NOTE: this is the 1.3->1.4 attribute rename only; the full MetricFlow rewrite is the separate\n  1.5->1.6 issue 1_5_001.\n- Manual fallback: apply the attribute renames yourself if autofix skipped any."
+      },
+      "_path": "kb/core/1_3_013.yaml"
+    },
+    {
+      "issue_id": "1_3_014",
+      "sort_order": 1140,
+      "change": "Merge SQL predicates wrapped in parens; predicates kwarg renamed to incremental_predicates",
+      "action": "Update custom incremental strategy macros using arg_dict['predicates'] to incremental_predicates",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Custom strategy macros reading arg_dict['predicates'] break; generated merge SQL wraps predicates in parens",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/ for custom incremental/merge macros referencing `predicates`\n  (e.g. `arg_dict['predicates']`, `config.get('predicates')`).",
+        "fixing": "- Handled by `dbt-autofix deprecations` where applicable (rename `predicates` ->\n  `incremental_predicates`).\n- Review the diff.\n- Manual fallback: rename the kwarg in any custom macro autofix did not touch.\n- Behavior/warehouse effect (paren-wrapping) is validated in the build-green layer, not parse."
+      },
+      "_path": "kb/core/1_3_014.yaml"
+    },
+    {
+      "issue_id": "1_4_001",
+      "sort_order": 2010,
+      "change": "--select/--exclude now accumulate when passed multiple times (argparse -> Click)",
+      "action": "Review scripts/jobs passing --select or --exclude more than once; collapse to a single flag with the intended union",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Scripts relying on last-wins override now see both selections combined, selecting more nodes than intended",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep in-repo invocation sites for repeated selection flags on a single command: shell scripts\n  (*.sh), Makefiles, CI YAML (.github/**, .gitlab-ci.yml, azure-pipelines.yml), tox.ini, and dbt\n  wrapper scripts.\n- Pattern: one dbt command containing two or more `--select`/`-s` or `--exclude` tokens (regex\n  `(--select|--exclude|-s)\\b.*\\b(--select|--exclude|-s)\\b`).\n- The real risk lives OUTSIDE the repo in dbt platform job definitions, so in-repo presence may be\n  zero even when the project is affected.",
+        "fixing": "- For each in-repo command with duplicated selection flags, decide intent: pre-1.5 was last-wins (only\n  the final flag applied); 1.5+ is union (all applied).\n- If the old intent was 'use only the last selection', delete the earlier occurrences. If a union was\n  intended, it already works \u2014 leave it.\n- Example: `dbt run --select tag:nightly --select my_model` (1.4 ran only my_model) -> `dbt run\n  --select my_model`.\n- Not visible to dbt parse.\n- ALWAYS add a results entry (manual-required): dbt platform job commands and orchestration outside\n  this repo may pass the flags multiple times; list the affected in-repo sites and tell the user to\n  audit job definitions."
+      },
+      "_path": "kb/core/1_4_001.yaml"
+    },
+    {
+      "issue_id": "1_4_002",
+      "sort_order": 2020,
+      "change": "Duplicate CLI flags before and after the subcommand now raise an error",
+      "action": "Ensure each CLI flag appears only once per dbt invocation",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands like `dbt --flag run --flag` now fail instead of silently taking one value",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan in-repo dbt invocation sites (shell scripts, Makefiles, CI YAML, tox.ini, wrapper scripts) for\n  a single dbt command repeating the same flag, especially placed both before and after the\n  subcommand.\n- Examples: `dbt --debug run --debug`, or a repeated `--profiles-dir` / `--target` / `--vars`.\n- Likeliest offenders: global flags (--debug, --profiles-dir, --project-dir, --target, --log-format)\n  appearing twice.\n- As with selection flags, the primary risk is in dbt platform job commands outside the repo.",
+        "fixing": "- Remove the duplicate occurrence, keeping the one with the intended value (pre-1.5 resolved to a\n  single value, so pick that).\n- Example: `dbt --target prod run --target prod` -> `dbt run --target prod`.\n- If two occurrences carry DIFFERENT values it was already ambiguous \u2014 keep the value the user\n  confirms and record the resolution in the migration log.\n- Not visible to dbt parse.\n- Add a results entry (manual-required) directing the user to audit external job/orchestration\n  commands for duplicated flags, since those now hard-error."
+      },
+      "_path": "kb/core/1_4_002.yaml"
+    },
+    {
+      "issue_id": "1_4_003",
+      "sort_order": 2030,
+      "change": "log-path in dbt_project.yml deprecated",
+      "action": "Move log-path out of dbt_project.yml to the --log-path CLI flag or DBT_LOG_PATH env var",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning at parse time; becomes fatal under --warn-error",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for a top-level `log-path:` key (regex `^\\s*log-path\\s*:`). Present if the key\n  exists with any value.\n- Only one location to check.",
+        "fixing": "- Remove the `log-path:` key from dbt_project.yml.\n- Re-provision out-of-repo: either the `--log-path <dir>` CLI flag on dbt invocations or the\n  `DBT_LOG_PATH` env var.\n- Because the effective destination now lives in job commands / env config outside this repo, add a\n  results entry recording the old value and telling the user to set --log-path/DBT_LOG_PATH wherever\n  dbt is invoked (CI, dbt platform jobs).\n- After removing the key, run dbt parse; the deprecation warning should be gone.\n- If parse still warns, confirm no other config file (a profiles-level or imported yml) re-declares\n  log-path."
+      },
+      "_path": "kb/core/1_4_003.yaml"
+    },
+    {
+      "issue_id": "1_4_004",
+      "sort_order": 2040,
+      "change": "target-path in dbt_project.yml deprecated",
+      "action": "Move target-path out of dbt_project.yml to the --target-path CLI flag or DBT_TARGET_PATH env var",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning at parse time; becomes fatal under --warn-error",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for a top-level `target-path:` key (regex `^\\s*target-path\\s*:`). Present if\n  the key exists.",
+        "fixing": "- Remove the `target-path:` key from dbt_project.yml.\n- Re-provision via the `--target-path <dir>` CLI flag or `DBT_TARGET_PATH` env var wherever dbt runs.\n- Add a results entry recording the old value and directing the user to set\n  --target-path/DBT_TARGET_PATH in job commands / CI / dbt platform, since anything reading generated\n  artifacts (manifest.json, run_results.json) from the custom path must be pointed at the new\n  location.\n- After removal, run dbt parse to confirm the warning is cleared."
+      },
+      "_path": "kb/core/1_4_004.yaml"
+    },
+    {
+      "issue_id": "1_4_005",
+      "sort_order": 2050,
+      "change": "DBT_NO_PRINT environment variable deprecated in favor of DBT_PRINT",
+      "action": "Replace DBT_NO_PRINT=true with DBT_PRINT=false",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for the literal `DBT_NO_PRINT` in CI YAML (.github/**, .gitlab-ci.yml, etc.),\n  Dockerfiles, .env / *.env files, shell scripts, Makefiles, and tox.ini. Present if the token appears\n  anywhere.\n- The variable is frequently set in orchestration outside the repo, so an in-repo miss does not mean\n  the project is clear.",
+        "fixing": "- Translate the value: DBT_NO_PRINT=true (suppress prints) becomes DBT_PRINT=false; DBT_NO_PRINT=false\n  becomes DBT_PRINT=true.\n- Update every in-repo occurrence found.\n- This is an env-var rename, not a Python-environment change, so it is a normal advisory edit (not\n  environment_change) and is not verified by dbt parse.\n- Add a results entry telling the user to replace DBT_NO_PRINT in external CI / dbt platform\n  environment settings with DBT_PRINT (inverted value)."
+      },
+      "_path": "kb/core/1_4_005.yaml"
+    },
+    {
+      "issue_id": "1_4_006",
+      "sort_order": 2060,
+      "change": "DBT_ARTIFACT_STATE_PATH environment variable deprecated in favor of DBT_STATE",
+      "action": "Replace DBT_ARTIFACT_STATE_PATH with DBT_STATE",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_ARTIFACT_STATE_PATH` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Commonly used in Slim CI / state-deferral setups that live in orchestration outside the repo.",
+        "fixing": "- Rename the variable to `DBT_STATE`, keeping the same value (path to the state/manifest directory).\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry telling the user to rename DBT_ARTIFACT_STATE_PATH to DBT_STATE in external CI\n  and dbt platform job environments used for state:modified / --defer selection."
+      },
+      "_path": "kb/core/1_4_006.yaml"
+    },
+    {
+      "issue_id": "1_4_007",
+      "sort_order": 2070,
+      "change": "DBT_FAVOR_STATE_MODE environment variable deprecated in favor of DBT_FAVOR_STATE",
+      "action": "Replace DBT_FAVOR_STATE_MODE with DBT_FAVOR_STATE",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_FAVOR_STATE_MODE` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Typically set in state-based CI selection outside the repo.",
+        "fixing": "- Rename to `DBT_FAVOR_STATE`, preserving the value.\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry directing the user to rename this variable in external CI / dbt platform\n  environments."
+      },
+      "_path": "kb/core/1_4_007.yaml"
+    },
+    {
+      "issue_id": "1_4_008",
+      "sort_order": 2080,
+      "change": "DBT_DEFER_TO_STATE environment variable deprecated in favor of DBT_DEFER",
+      "action": "Replace DBT_DEFER_TO_STATE with DBT_DEFER",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_DEFER_TO_STATE` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Used in --defer based CI workflows that usually live outside the repo.",
+        "fixing": "- Rename to `DBT_DEFER`, preserving the boolean value.\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry directing the user to rename DBT_DEFER_TO_STATE to DBT_DEFER in external CI /\n  dbt platform environments."
+      },
+      "_path": "kb/core/1_4_008.yaml"
+    },
+    {
+      "issue_id": "1_4_011",
+      "sort_order": 2110,
+      "change": "RedshiftAdapter parent class changed from PostgresAdapter to SQLAdapter",
+      "action": "Update custom adapter/plugin code that subclasses or relies on RedshiftAdapter extending PostgresAdapter",
+      "category": "Breaking",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "Custom adapter plugins extending RedshiftAdapter, or code assuming Postgres-adapter methods, may break",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Affects only projects that ship CUSTOM Python adapter code.\n- Grep the repo's Python files for `from dbt.adapters.redshift` / `RedshiftAdapter`,\n  `PostgresAdapter`, or subclasses inheriting from these.\n- Also check macros overriding Postgres-inherited behavior (e.g. `redshift__` / `postgres__` macro\n  pairs in macros/**/*.sql where the Redshift path assumed Postgres defaults).\n- Most standard dbt projects have NO such code and are unaffected \u2014 report skipped-not-present.",
+        "fixing": "- For custom adapter classes: change the base from PostgresAdapter to SQLAdapter and re-implement any\n  Postgres-specific methods previously inherited (Redshift no longer gets them for free).\n- For overridden macros relying on postgres__ dispatch, provide explicit redshift__ implementations.\n- Python/plugin code is not exercised by dbt parse of the project models; parse cannot validate it.\n- If the project has no custom adapter code, mark skipped-not-present.\n- If custom code exists but the correct re-implementation is non-trivial, record a results entry\n  (manual-required) with the affected files."
+      },
+      "_path": "kb/redshift/1_4_011.yaml"
+    },
+    {
+      "issue_id": "1_4_013",
+      "sort_order": 2130,
+      "change": "connect_timeout default introduced at 30 seconds",
+      "action": "Set connect_timeout explicitly in the Redshift profile if 30s is insufficient",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "Connections without an explicit timeout now time out after 30 seconds",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": true,
+      "context": {
+        "detection": "- Inspect any in-repo profiles.yml or profile fixture for a Redshift output that does NOT set\n  `connect_timeout:`. Present when the field is absent (it now defaults to 30s).\n- If profiles.yml lives only in ~/.dbt (outside the repo), there is nothing to detect in-repo \u2014 treat\n  as advisory.",
+        "fixing": "- ADVISORY ONLY \u2014 this is a profiles.yml / connection change, never executed.\n- If an in-repo profile is present and 30s could be too short (high network latency, VPN), add\n  `connect_timeout: <seconds>` to the Redshift output. Otherwise record an advisory note only.\n- EXCLUDED from the dbt parse verify loop.\n- Add a results entry telling the user to set connect_timeout in their real profiles.yml if the\n  default 30s causes premature connection timeouts."
+      },
+      "_path": "kb/redshift/1_4_013.yaml"
+    },
+    {
+      "issue_id": "1_4_014",
+      "sort_order": 2140,
+      "change": "iam_duration_seconds, search_path, and keepalives_idle profile fields removed",
+      "action": "Remove these fields from the Redshift profile; reproduce search_path via a SET search_path pre-hook",
+      "category": "Breaking",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "Profiles still declaring iam_duration_seconds, search_path, or keepalives_idle error on connection",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": true,
+      "context": {
+        "detection": "- Search in-repo profiles.yml / profile fixtures for the keys `iam_duration_seconds:`, `search_path:`,\n  or `keepalives_idle:` under a Redshift output (regex\n  `^\\s*(iam_duration_seconds|search_path|keepalives_idle)\\s*:`).\n- These now cause a hard connection error.\n- profiles.yml commonly lives in ~/.dbt outside the repo, so the primary fix is out-of-repo.",
+        "fixing": "- Remove all three keys wherever they appear in an in-repo profile.\n- To preserve search_path behavior, add a pre-hook running `SET search_path TO <schemas>` \u2014 e.g. in\n  dbt_project.yml `on-run-start: \"SET search_path TO analytics, public\"` or a model-level pre_hook.\n- iam_duration_seconds and keepalives_idle have no direct replacement; drop them.\n- Not verified by dbt parse (connection-time error).\n- Because the authoritative profiles.yml is usually outside the repo, ALWAYS add a results entry\n  telling the user to remove these keys from their real profiles.yml and to add the SET search_path\n  pre-hook if they relied on a custom search_path."
+      },
+      "_path": "kb/redshift/1_4_014.yaml"
+    },
+    {
+      "issue_id": "1_5_001",
+      "sort_order": 3010,
+      "change": "Metric YAML schema completely rewritten for MetricFlow",
+      "action": "Rewrite all metric definitions using the new type/type_params/filter format",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "All existing metric YAML definitions fail to parse in 1.6; the pre-1.6 UnparsedMetric fields (calculation_method, expression, sql, model, type: expression) and the rename_metric_attr compatibility shim were removed.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Search every YAML file under models/ and any schema-file globs declared in dbt_project.yml\n  (models/**/*.yml, models/**/*.yaml, plus any top-level metrics/ dir) for a `metrics:` block.\n- Flag a metric as legacy (pre-1.6) if its entry uses ANY of these keys: `calculation_method`,\n  `expression`, `sql`, `type: expression`, a top-level `type:` with the old enum\n  (`count`/`sum`/...), `model:`, `timestamp:`, `time_grains:`, `dimensions:` directly on the\n  metric, or `filters:` (the list-of-dict old form).\n- The new MetricFlow schema instead uses `type:` with values simple|ratio|cumulative|derived\n  plus a `type_params:` block. If a metric already has `type_params:`, it is migrated \u2014 skip it.\n- Also grep packages.yml for `dbt_metrics` usage and models for `metrics.calculate(` /\n  `metrics.develop(` macro calls \u2014 those depend on the old package and must be flagged too.",
+        "fixing": "- Rewrite each legacy metric into the new schema. Attribute mapping:\n  - `calculation_method` -> `type`: sum/average/min/max/count/count_distinct/median become\n    `type: simple` with `type_params.measure`; derived/expression become `type: derived` with\n    `type_params.expr` and `type_params.metrics`.\n  - `expression`/`sql` -> `type_params.measure` (the semantic measure name), or\n    `type_params.expr` for a derived metric.\n  - `model:` -> moves into a `semantic_models:` definition (see example below).\n  - `filters:` -> `filter:` (a single `{{ Dimension(...) }}` string, or keep the WHERE fragment).\n- Concrete before/after:\n  BEFORE (1.5):\n    metrics:\n      - name: total_revenue\n        calculation_method: sum\n        expression: amount\n        model: ref('orders')\n        timestamp: order_date\n        time_grains: [day, month]\n        dimensions: [status]\n  AFTER (1.6, MetricFlow):\n    semantic_models:\n      - name: orders\n        model: ref('orders')\n        defaults:\n          agg_time_dimension: order_date\n        entities:\n          - name: order\n            type: primary\n        dimensions:\n          - name: order_date\n            type: time\n            type_params: {time_granularity: day}\n          - name: status\n            type: categorical\n        measures:\n          - name: amount\n            agg: sum\n            agg_time_dimension: order_date\n    metrics:\n      - name: total_revenue\n        type: simple\n        type_params:\n          measure: amount\n- Derived example: `calculation_method: derived` + `expression: revenue - cost` becomes\n  `type: derived` with `type_params: {expr: 'revenue - cost', metrics: [{name: revenue},\n  {name: cost}]}`.\n- Judgment-heavy: 1.6 requires a `semantic_models:` layer that did not exist in 1.5, so the\n  measure/entity/dimension split cannot always be inferred mechanically.\n- If you cannot confidently reconstruct the semantic model (e.g. the source model's grain or\n  entities are ambiguous), do NOT guess \u2014 record the metric in the results report with\n  the original YAML and the suggested new shape, and move on.\n- After editing, run `dbt parse`. On a metric/semantic-model validation error, re-read it;\n  reverting to legacy form is NOT an option (it won't parse in 1.6) \u2014 instead leave the\n  semantic_model skeleton and flag it manual.\n- Remove `dbt_metrics` / `metrics.calculate` usages and flag them as requiring the\n  MetricFlow / Semantic Layer migration (out of scope for parse)."
+      },
+      "_path": "kb/core/1_5_001.yaml"
+    },
+    {
+      "issue_id": "1_5_002",
+      "sort_order": 3020,
+      "change": "Duplicate node names allowed across packages",
+      "action": "Disambiguate cross-package references with two-argument ref('package_name', 'model_name')",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.5 a flat manifest dict raised DuplicateResourceNameError; in 1.6 names are stored per-package, so a project and an installed package can legitimately share a model name. Single-argument ref() to a name that exists in more than one package becomes ambiguous (AmbiguousAliasError / wrong node).",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant if packages.yml / dependencies.yml declares packages.\n- Build the set of model/seed/snapshot names defined in the local project (models/**/*.sql,\n  seeds/**/*.csv, snapshots/**/*.sql).\n- Where available, add the names exposed by installed packages under dbt_packages/*/models.\n- Grep all .sql/.yml for single-argument `ref('name')` / `ref(\"name\")` whose `name` collides\n  with a name present in BOTH the local project and a package (or in two packages) \u2014 those are\n  the ambiguous refs.\n- If no packages are installed, mark skipped-not-present.",
+        "fixing": "- For each ambiguous single-arg ref, rewrite to the two-argument form\n  `ref('<package_name>', '<model_name>')`.\n- Choose the package the author intended; default to the local project's own model unless the\n  surrounding SQL clearly consumes the package's version.\n- Example: `ref('customers')` -> `ref('my_project', 'customers')` or\n  `ref('dbt_utils', 'customers')`. Leave unambiguous refs untouched.\n- After edits run `dbt parse`; a remaining AmbiguousAliasError names the offending ref and node.\n- If you cannot determine which package is intended, record it in the results report\n  rather than guessing \u2014 picking the wrong package silently changes lineage."
+      },
+      "_path": "kb/core/1_5_002.yaml"
+    },
+    {
+      "issue_id": "1_5_003",
+      "sort_order": 3030,
+      "change": "collect_freshness macro return type changed",
+      "action": "Update any custom collect_freshness macro override to return the full result object (table + response) instead of just the table",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.6 core's default collect_freshness returns a dict-like {table, response} object; a custom override that returns only the agate table triggers a deprecation warning and will break source freshness in later versions.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/**/*.sql for a macro named `collect_freshness` (i.e. `{% macro collect_freshness(`\n  or `{% macro <adapter>__collect_freshness(`).\n- If none exists, the project uses core's implementation \u2014 mark skipped-not-present.\n- If one exists, inspect its final `{{ return(...) }}` and flag it if it returns the query\n  result table directly (e.g. `return(load_result('collect_freshness').table)` or\n  `return(table)`) rather than the full result object.",
+        "fixing": "- Change the macro to capture the full result and return an object exposing both the table and\n  the adapter response.\n- Pattern: `{% set result = run_query(...) %}` then\n  `{{ return({'table': result.table, 'response': result.response}) }}`.\n- Mirror core's 1.6 signature: it returns `load_result('collect_freshness')`, which already has\n  `.table` and `.response`.\n- Simplest safe fix, if the override only existed to tweak the SQL: align the return statement\n  with core 1.6's macro body.\n- After editing run `dbt parse`.\n- If the override is complex or the intended response object is unclear, record it in the\n  results report with a pointer to core's 1.6 collect_freshness for reference."
+      },
+      "_path": "kb/core/1_5_003.yaml"
+    },
+    {
+      "issue_id": "1_5_006",
+      "sort_order": 3060,
+      "change": "sslmode behavior changed; require/allow/prefer now map to verify-ca",
+      "action": "Review and update sslmode in profiles.yml (advisory)",
+      "category": "Breaking",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "In 1.6 the redshift_connector sslmode mapping changed: require/allow/prefer are treated as verify-ca, so connections that relied on the looser semantics may fail without a CA certificate.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": true,
+      "context": {
+        "detection": "- Connection-profile concern, not visible to dbt parse.\n- Look for `sslmode:` under a redshift target in profiles.yml (usually ~/.dbt/profiles.yml, but\n  also any in-repo profiles.yml or profiles template).\n- Flag values `require`, `allow`, or `prefer`.\n- If profiles.yml is not in the repo, this can only be advised, not edited.",
+        "fixing": "- ADVISORY \u2014 do not open a warehouse connection.\n- If an in-repo profiles.yml exists, note (do not silently rewrite auth) that require/allow/prefer\n  now behave as verify-ca.\n- Advise the user to either provide a CA cert (`sslrootcert`) or set the intended sslmode\n  explicitly (e.g. `disable` / `verify-ca` / `verify-full`) to match their security posture.\n- Record in the results report with the target name and current sslmode value.\n- Excluded from the dbt parse verify loop (connection behavior is not exercised by parse)."
+      },
+      "_path": "kb/redshift/1_5_006.yaml"
+    },
+    {
+      "issue_id": "1_5_007",
+      "sort_order": 3070,
+      "change": "Autocommit enabled by default (autocommit: True)",
+      "action": "Set autocommit: false in profiles.yml if you relied on 1.5's transactional behavior (advisory)",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "1.6 restores pre-1.5 semantics: autocommit defaults to True, so DDL and standalone statements auto-commit. Projects that depended on 1.5's implicit transaction wrapping (e.g. multi-statement hooks meant to roll back together) change behavior.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": true,
+      "context": {
+        "detection": "- Connection-profile concern, not visible to dbt parse.\n- Check the redshift target(s) in profiles.yml for an explicit `autocommit:` key.\n- Grep macros/**/*.sql and models for pre-hook/post-hook/on-run-* blocks containing explicit\n  BEGIN/COMMIT/ROLLBACK \u2014 these suggest the project relied on transactional grouping.\n- If neither profiles.yml is available nor transactional hooks exist, mark skipped-not-present.",
+        "fixing": "- ADVISORY \u2014 do not connect to the warehouse.\n- If the project shows reliance on transactional behavior, advise setting `autocommit: false` on\n  the redshift target in profiles.yml and record it in the results report (with target\n  name).\n- Do not blanket-add autocommit:false \u2014 the 1.6 default is intentional for most projects.\n- Excluded from the dbt parse verify loop."
+      },
+      "_path": "kb/redshift/1_5_007.yaml"
+    },
+    {
+      "issue_id": "1_5_008",
+      "sort_order": 3080,
+      "change": "list_relations_without_caching rewritten with Redshift-native SQL",
+      "action": "Review the macro if you override it; edge-case results may differ",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "1.6 replaces the Postgres-based relation listing with Redshift-native SQL. Projects that override redshift__list_relations_without_caching may diverge from the new base behavior on edge cases (late-binding views, external schemas).",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/**/*.sql for an override named `list_relations_without_caching`,\n  `redshift__list_relations_without_caching`, or `postgres__list_relations_without_caching`\n  used by the redshift adapter.\n- If no override exists, mark skipped-not-present \u2014 core's new implementation applies\n  automatically and needs no code change.",
+        "fixing": "- If an override exists, compare it against dbt-redshift 1.6's\n  redshift__list_relations_without_caching.\n- If the override only reproduced the old Postgres query, recommend removing it to inherit the\n  fixed native version.\n- If it adds project-specific logic, port that logic onto the 1.6 base query.\n- This is behavioral (warehouse-executed), so `dbt parse` passes regardless \u2014 record a\n  manual-actions note asking the user to validate relation listing against a live Redshift.\n- If unsure whether the override is still needed, flag it rather than deleting it."
+      },
+      "_path": "kb/redshift/1_5_008.yaml"
+    },
+    {
+      "issue_id": "1_6_011",
+      "sort_order": 4005,
+      "change": "dbt clean errors when clean-targets include source paths or paths outside the project",
+      "action": "Remove source paths (e.g. models/, macros/) and any path outside the project directory from clean-targets in dbt_project.yml",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "dbt clean now raises an error instead of silently deleting the wrong directories when clean-targets references source paths or paths outside the project root",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml's clean-targets list.\n- Flag any entry that resolves (relative to the project root) to a configured source path\n  (model-paths, seed-paths, macro-paths, etc.) or that resolves outside the project directory\n  (e.g. ../shared, /absolute/path).",
+        "fixing": "- Remove the offending entries from clean-targets, keeping only build/output directories\n  (e.g. target, dbt_packages, logs).\n- Re-run dbt clean to confirm it no longer errors."
+      },
+      "_path": "kb/core/1_6_011.yaml"
+    },
+    {
+      "issue_id": "1_6_001",
+      "sort_order": 4010,
+      "change": "New warning when --state and --target point to the same directory",
+      "action": "Fix --state/--target configuration so they reference distinct directories",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "WarnStateTargetEqual raised (informational) for previously silent misconfiguration; fatal under --warn-error",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- This is a runtime CLI/job configuration issue, not a repo-source issue, so `dbt parse` cannot\n  surface it. Detect by scanning invocation sites, not models.\n- Grep the repo for `--state` and `--target` / `--target-path` in shell scripts, Makefiles, and\n  `scripts/**/*.sh`.\n- Also grep CI configs: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `tox.ini`.\n- Check `dbt_project.yml` for a `target-path:` key (deprecated since 1.5 but may still be present).\n- Check for `DBT_STATE` / `DBT_TARGET_PATH` env vars in CI.\n- Flag any invocation where `--state` and `--target`/`--target-path` resolve to the same directory\n  (commonly both set to `target/`).\n- Note the value is frequently supplied outside the repo (dbt platform job definitions,\n  orchestration tools), which parse cannot see.",
+        "fixing": "- Point `--state` at a directory separate from the run's `--target` \u2014 e.g. keep run output in\n  `target/` and the comparison manifest in a distinct dir such as `state/` or `prod-artifacts/`.\n- Concretely, in the offending script/CI step change the duplicated paths so a command like\n  `dbt build --state ./state --target-path ./target` uses different dirs, and populate the state\n  artifacts there.\n- If the same-directory usage lives outside the repo (a dbt platform job command, an orchestration\n  tool), it cannot be edited from the repo.\n- For that out-of-repo case: record it in the results artifact (target/dbt_migration_results.json)\n  as manual-required with the issue_id, the invocation location if known, and the suggested command\n  change, then prompt the user.\n- This change never requires a repo edit to pass `dbt parse`; it is advisory / out-of-repo only."
+      },
+      "_path": "kb/core/1_6_001.yaml"
+    },
+    {
+      "issue_id": "1_6_002",
+      "sort_order": 4020,
+      "change": "Breaking contract changes on unversioned models now warn instead of error",
+      "action": "Add --warn-error (or version the models) to retain the previous hard-error behavior on breaking contract changes",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Unversioned models with a breaking schema/contract change warn via warn_or_error() instead of erroring; CI that relied on the error to block may now pass silently",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan schema YAML (`models/**/*.yml`, `models/**/*.yaml`) for models declaring `contract:` with\n  `enforced: true` that do NOT declare a `version:` / `versions:` block (i.e. unversioned).\n- Those unversioned enforced-contract models are the ones whose breaking contract changes now only\n  warn.\n- Also detect reliance on the old error behavior: grep CI/scripts for `dbt build` / `dbt run`\n  invocations that lack `--warn-error` or `--warn-error-options`.\n- Those flags are what previously turned the contract breakage into a hard failure.\n- This is a behavior/policy change; `dbt parse` stays clean either way, so detection is about intent,\n  not parse errors.",
+        "fixing": "- Preferred: preserve strict behavior by adding `--warn-error` (or a scoped `--warn-error-options`\n  targeting contract deprecations) to the relevant dbt invocation.\n- If that invocation is defined outside the repo (dbt platform job command, orchestration tool), it\n  cannot be edited here: record it in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the suggested flag, and prompt the user.\n- Alternative in-repo fix: add a `version:` to the affected models \u2014 versioning makes breaking\n  contract changes error again.\n- But versioning reshapes ref() resolution and downstream references, so only do it when the user\n  explicitly wants versioned models; note that trade-off in the results report rather than silently\n  versioning.\n- No edit is required for `dbt parse` to succeed."
+      },
+      "_path": "kb/core/1_6_002.yaml"
+    },
+    {
+      "issue_id": "1_6_003",
+      "sort_order": 4030,
+      "change": "New warning for contracted models with bare numeric columns (no precision/scale)",
+      "action": "Add explicit precision and scale to numeric column data_types in enforced contracts (e.g. numeric(38,3))",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with 'data_type: numeric' (or 'decimal') and no precision/scale in an enforced contract now emit a warning at parse time in 1.7",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- In schema YAML (`models/**/*.yml`, `models/**/*.yaml`), find models with `contract:`\n  `enforced: true` and columns whose `data_type` is a bare numeric type with no precision/scale.\n- Match the data_type value (case-insensitive) against `^(numeric|decimal|number)$` (no parentheses).\n- Types that already include `(p,s)` like `numeric(38,3)` are fine and must be left alone.\n- Only columns inside enforced-contract models trigger the warning; bare numeric on non-contracted\n  models is not affected.",
+        "fixing": "- For each flagged column, replace the bare type with an explicit precision/scale, e.g.\n  `data_type: numeric` -> `data_type: numeric(38,3)`.\n- Choose precision/scale from evidence in this order:\n- (1) an existing cast in the model SQL (e.g. `cast(x as numeric(18,2))`) \u2014 match it;\n- (2) the warehouse's documented default for unqualified numeric if the model is already built\n  (Snowflake NUMBER default is (38,0); Redshift/Postgres NUMERIC default is (38,0));\n- (3) if unknown, use a safe wide default `numeric(38,6)` and note the assumption in the results\n  report.\n- Preserve YAML quoting/style.\n- After editing, run `dbt parse`; if it fails, the likely cause is a mismatched type name for the\n  adapter (e.g. Snowflake prefers `number(38,3)`) \u2014 retry with the adapter-native spelling.\n- If the correct precision genuinely cannot be determined, leave the column and record it in the\n  results artifact (target/dbt_migration_results.json) as manual-required for the user to confirm."
+      },
+      "_path": "kb/core/1_6_003.yaml"
+    },
+    {
+      "issue_id": "1_6_004",
+      "sort_order": 4040,
+      "change": "merge_exclude_columns bug fix: excluded columns now correctly inserted in WHEN NOT MATCHED",
+      "action": "Review incremental models using merge_exclude_columns; excluded columns are now populated on new-row inserts",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "Incremental merge with merge_exclude_columns now inserts ALL columns for new rows (previously excluded columns were omitted on INSERT); resulting table data changes",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep model config for `merge_exclude_columns` in `models/**/*.sql` config() blocks (e.g.\n  `config(materialized='incremental', ... merge_exclude_columns=[...])`) and in schema YAML\n  `config:` blocks.\n- Only relevant when `materialized='incremental'` with the default `merge` strategy on the Redshift\n  adapter.\n- This is a behavior/warehouse change invisible to `dbt parse`; nothing makes parse fail.",
+        "fixing": "- No source edit is required to reach 1.8 or pass parse \u2014 the fix was in the adapter. The migration\n  action is to flag semantics.\n- For each model using merge_exclude_columns, new rows (WHEN NOT MATCHED) will now have the\n  previously-excluded columns inserted with their source values instead of being left null/default.\n- If the user intentionally relied on those columns being unset on insert, that assumption breaks.\n- Record each occurrence in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the issue_id, the model path, the merge_exclude_columns list, and a note to\n  verify the new insert behavior is acceptable.\n- Real validation happens in the warehouse build-green test layer, not here.\n- Do not modify the model unless the user confirms a semantic change is needed."
+      },
+      "_path": "kb/redshift/1_6_004.yaml"
+    },
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_004",
+      "sort_order": 5040,
+      "change": "Redshift catalog query macros restructured and split into multiple files",
+      "action": "Update custom overrides of redshift__get_base_catalog / catalog macros to match the new 1.8 structure",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "Custom overrides of redshift__get_catalog / redshift__get_base_catalog (and related catalog SQL) may break or silently diverge because the macro was split across a catalog/ directory in dbt-redshift 1.8",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant if the project (or an installed package) overrides Redshift catalog macros.\n- Grep macros/**/*.sql and packages' macros for definitions named `redshift__get_catalog`,\n  `redshift__get_base_catalog`, `redshift__get_catalog_relations`, or any\n  `{% macro redshift__...catalog...%}`.\n- If no such override exists, the change is not present (docs generate keeps working on the\n  built-in macros).\n- If an override exists, it likely mirrors the old single-file catalog.sql shape and will not\n  align with the 1.8 split.",
+        "fixing": "- If an override is found, compare it against the dbt-redshift 1.8 catalog macros (now under an\n  adapter catalog/ directory, split into base-catalog and relations pieces).\n- Re-implement the override on the new macro seams: typically split a monolithic\n  `redshift__get_catalog` override into `redshift__get_base_catalog` plus the relation-scoped\n  variant, matching the new signatures.\n- Invisible to `dbt parse` (catalog macros only compile when catalog generation runs), so parse\n  cannot validate correctness.\n- After adjusting, note that `dbt docs generate` against a warehouse is the real check (harness\n  build-green layer, not in-skill).\n- If the override's intent is unclear or reproducing the split is risky, record a manual-actions\n  entry pointing at the overriding macro and the dbt-redshift 1.8 catalog macro source."
+      },
+      "_path": "kb/redshift/1_7_004.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_3_snowflake.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_3_snowflake.json
@@ -1,0 +1,952 @@
+{
+  "from_version": "1.3",
+  "warehouse": "snowflake",
+  "target_version": "1.12",
+  "count": 44,
+  "issues": [
+    {
+      "issue_id": "1_3_001",
+      "sort_order": 1010,
+      "change": "Python model default materialization changed from view to table",
+      "action": "Set materialized='view' explicitly on Python models that relied on the old view default",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Python models without an explicit materialized config now create tables instead of views, changing storage/cost and downstream freshness expectations",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Enumerate Python models: models/**/*.py containing `def model(dbt, session)`.\n- Determine each model's effective materialization, in precedence order:\n  - an inline `dbt.config(materialized=...)` call inside model(dbt, session);\n  - a config() block;\n  - the matching model's YAML config in models/**/*.yml;\n  - the models: tree in dbt_project.yml (path-scoped config).\n- A model is affected if NONE of these set materialized: it defaulted to view, now defaults\n  to table.\n- SQL models are unaffected (their default was already view and is unchanged).",
+        "fixing": "- Only change models where the prior view behavior was actually intended (thin passthrough,\n  or a downstream tool expects a view).\n- For those, add materialized='view' at the most local level that already carries config:\n  prefer `dbt.config(materialized='view')` inside the function, else `materialized: view` in\n  the model's YAML, else under dbt_project.yml models:.\n- Do NOT blanket-force every Python model to view \u2014 the new table default is usually desirable;\n  flag ambiguous ones in the results report rather than guessing.\n- After editing run dbt parse; if it fails because dbt.config was placed outside the function,\n  move the call to the first statement inside def model(...)."
+      },
+      "_path": "kb/core/1_3_001.yaml"
+    },
+    {
+      "issue_id": "1_3_002",
+      "sort_order": 1020,
+      "change": "on-run-start / on-run-end hooks no longer halt execution on failure",
+      "action": "Find alternative approaches if hooks were used as guards/circuit-breakers that must abort a run",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start/on-run-end hook now appends an error result and continues instead of raising; guard/circuit-breaker hooks no longer abort the run",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for on-run-start: and on-run-end: keys (string or list).\n- Also scan these keys in any vendored package dbt_project.yml.\n- Flag hooks whose SQL acts as a precondition/guard:\n  - a SELECT that RAISES/THROWS, or calls an assertion macro;\n  - `{% if ... %}{{ exceptions.raise_compiler_error(...) }}{% endif %}`;\n  - SQL that intentionally errors (divide-by-zero, invalid cast) to stop a run.\n- Purely side-effecting hooks (grants, logging, audit inserts) are NOT affected.",
+        "fixing": "- Behavior change dbt parse cannot validate, so it is advisory.\n- For guard hooks: document that they no longer abort the run in 1.4+, and recommend moving the\n  precondition into a pre-flight step outside the run (a separate `dbt run-operation` gate in\n  CI, or a data test CI checks before proceeding).\n- Do not rewrite the hook's SQL automatically.\n- Record each guard-style hook in the results report with issue_id, the dbt_project.yml\n  location, and the suggested CI-gate alternative.\n- No parse impact expected; run dbt parse only to confirm no YAML was broken by edits."
+      },
+      "_path": "kb/core/1_3_002.yaml"
+    },
+    {
+      "issue_id": "1_3_003",
+      "sort_order": 1030,
+      "change": "pre_hook / post_hook (underscore form) now properly late-rendered",
+      "action": "Verify hook behavior if using underscore-form hooks that contain Jinja evaluated at parse time",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Hooks written with the underscore form (pre_hook/post_hook) that contain Jinja now render at runtime instead of parse time, matching the hyphen form; values resolved at parse time may differ",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Search the underscore spellings pre_hook and post_hook (NOT pre-hook/post-hook) across\n  models/**/*.sql config() blocks, models/**/*.yml, and dbt_project.yml.\n- Regex: `(pre_hook|post_hook)\\s*[:=]`.\n- Of those, flag hooks whose value contains Jinja ({{ ... }} or {% ... %}) whose result depends\n  on parse-vs-runtime timing: {{ this }}, {{ run_started_at }}, runtime var()/env_var(), or the\n  result of a statement/run_query.\n- Static string hooks are unaffected.",
+        "fixing": "- Advisory/verification change \u2014 late rendering generally makes underscore hooks behave\n  correctly, so most projects need no edit.\n- Only intervene if a hook relied on the old parse-time rendering (rare).\n- Where behavior matters, note it in the results report and suggest confirming the hook still\n  produces the intended SQL at runtime.\n- Optionally normalize underscore hooks to the canonical hyphen form (pre-hook/post-hook) for\n  clarity, but this is cosmetic.\n- Run dbt parse after any edit; if a config() edit breaks parse, revert to the original key\n  spelling."
+      },
+      "_path": "kb/core/1_3_003.yaml"
+    },
+    {
+      "issue_id": "1_3_013",
+      "sort_order": 1130,
+      "change": "Metric attributes sql / type / type: expression deprecation warnings updated",
+      "action": "Migrate metric attrs to expression, calculation_method, and calculation_method: derived",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Legacy metric attribute names emit deprecation warnings; slated for removal",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan models/**/*.yml for `metrics:` blocks using legacy attrs `sql:`, `type:`, or\n  `type: expression`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (attribute rename to expression/calculation_method).\n- Review the autofix diff and confirm each metric was rewritten.\n- NOTE: this is the 1.3->1.4 attribute rename only; the full MetricFlow rewrite is the separate\n  1.5->1.6 issue 1_5_001.\n- Manual fallback: apply the attribute renames yourself if autofix skipped any."
+      },
+      "_path": "kb/core/1_3_013.yaml"
+    },
+    {
+      "issue_id": "1_3_014",
+      "sort_order": 1140,
+      "change": "Merge SQL predicates wrapped in parens; predicates kwarg renamed to incremental_predicates",
+      "action": "Update custom incremental strategy macros using arg_dict['predicates'] to incremental_predicates",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Custom strategy macros reading arg_dict['predicates'] break; generated merge SQL wraps predicates in parens",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/ for custom incremental/merge macros referencing `predicates`\n  (e.g. `arg_dict['predicates']`, `config.get('predicates')`).",
+        "fixing": "- Handled by `dbt-autofix deprecations` where applicable (rename `predicates` ->\n  `incremental_predicates`).\n- Review the diff.\n- Manual fallback: rename the kwarg in any custom macro autofix did not touch.\n- Behavior/warehouse effect (paren-wrapping) is validated in the build-green layer, not parse."
+      },
+      "_path": "kb/core/1_3_014.yaml"
+    },
+    {
+      "issue_id": "1_3_015",
+      "sort_order": 1150,
+      "change": "Incremental predicates dict key renamed from predicates to incremental_predicates (Snowflake)",
+      "action": "Update custom macros overriding snowflake__get_merge_sql to use incremental_predicates",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "snowflake",
+      "impact": "Custom macros overriding snowflake__get_merge_sql using the old 'predicates' key break",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/ for overrides of `snowflake__get_merge_sql` or references to the `predicates`\n  merge key in Snowflake-specific macros.",
+        "fixing": "- Handled by `dbt-autofix deprecations` where applicable.\n- Review the diff for `predicates` -> `incremental_predicates`.\n- Manual fallback: rename in any custom Snowflake merge macro autofix missed."
+      },
+      "_path": "kb/snowflake/1_3_015.yaml"
+    },
+    {
+      "issue_id": "1_4_001",
+      "sort_order": 2010,
+      "change": "--select/--exclude now accumulate when passed multiple times (argparse -> Click)",
+      "action": "Review scripts/jobs passing --select or --exclude more than once; collapse to a single flag with the intended union",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Scripts relying on last-wins override now see both selections combined, selecting more nodes than intended",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep in-repo invocation sites for repeated selection flags on a single command: shell scripts\n  (*.sh), Makefiles, CI YAML (.github/**, .gitlab-ci.yml, azure-pipelines.yml), tox.ini, and dbt\n  wrapper scripts.\n- Pattern: one dbt command containing two or more `--select`/`-s` or `--exclude` tokens (regex\n  `(--select|--exclude|-s)\\b.*\\b(--select|--exclude|-s)\\b`).\n- The real risk lives OUTSIDE the repo in dbt platform job definitions, so in-repo presence may be\n  zero even when the project is affected.",
+        "fixing": "- For each in-repo command with duplicated selection flags, decide intent: pre-1.5 was last-wins (only\n  the final flag applied); 1.5+ is union (all applied).\n- If the old intent was 'use only the last selection', delete the earlier occurrences. If a union was\n  intended, it already works \u2014 leave it.\n- Example: `dbt run --select tag:nightly --select my_model` (1.4 ran only my_model) -> `dbt run\n  --select my_model`.\n- Not visible to dbt parse.\n- ALWAYS add a results entry (manual-required): dbt platform job commands and orchestration outside\n  this repo may pass the flags multiple times; list the affected in-repo sites and tell the user to\n  audit job definitions."
+      },
+      "_path": "kb/core/1_4_001.yaml"
+    },
+    {
+      "issue_id": "1_4_002",
+      "sort_order": 2020,
+      "change": "Duplicate CLI flags before and after the subcommand now raise an error",
+      "action": "Ensure each CLI flag appears only once per dbt invocation",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands like `dbt --flag run --flag` now fail instead of silently taking one value",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan in-repo dbt invocation sites (shell scripts, Makefiles, CI YAML, tox.ini, wrapper scripts) for\n  a single dbt command repeating the same flag, especially placed both before and after the\n  subcommand.\n- Examples: `dbt --debug run --debug`, or a repeated `--profiles-dir` / `--target` / `--vars`.\n- Likeliest offenders: global flags (--debug, --profiles-dir, --project-dir, --target, --log-format)\n  appearing twice.\n- As with selection flags, the primary risk is in dbt platform job commands outside the repo.",
+        "fixing": "- Remove the duplicate occurrence, keeping the one with the intended value (pre-1.5 resolved to a\n  single value, so pick that).\n- Example: `dbt --target prod run --target prod` -> `dbt run --target prod`.\n- If two occurrences carry DIFFERENT values it was already ambiguous \u2014 keep the value the user\n  confirms and record the resolution in the migration log.\n- Not visible to dbt parse.\n- Add a results entry (manual-required) directing the user to audit external job/orchestration\n  commands for duplicated flags, since those now hard-error."
+      },
+      "_path": "kb/core/1_4_002.yaml"
+    },
+    {
+      "issue_id": "1_4_003",
+      "sort_order": 2030,
+      "change": "log-path in dbt_project.yml deprecated",
+      "action": "Move log-path out of dbt_project.yml to the --log-path CLI flag or DBT_LOG_PATH env var",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning at parse time; becomes fatal under --warn-error",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for a top-level `log-path:` key (regex `^\\s*log-path\\s*:`). Present if the key\n  exists with any value.\n- Only one location to check.",
+        "fixing": "- Remove the `log-path:` key from dbt_project.yml.\n- Re-provision out-of-repo: either the `--log-path <dir>` CLI flag on dbt invocations or the\n  `DBT_LOG_PATH` env var.\n- Because the effective destination now lives in job commands / env config outside this repo, add a\n  results entry recording the old value and telling the user to set --log-path/DBT_LOG_PATH wherever\n  dbt is invoked (CI, dbt platform jobs).\n- After removing the key, run dbt parse; the deprecation warning should be gone.\n- If parse still warns, confirm no other config file (a profiles-level or imported yml) re-declares\n  log-path."
+      },
+      "_path": "kb/core/1_4_003.yaml"
+    },
+    {
+      "issue_id": "1_4_004",
+      "sort_order": 2040,
+      "change": "target-path in dbt_project.yml deprecated",
+      "action": "Move target-path out of dbt_project.yml to the --target-path CLI flag or DBT_TARGET_PATH env var",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning at parse time; becomes fatal under --warn-error",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for a top-level `target-path:` key (regex `^\\s*target-path\\s*:`). Present if\n  the key exists.",
+        "fixing": "- Remove the `target-path:` key from dbt_project.yml.\n- Re-provision via the `--target-path <dir>` CLI flag or `DBT_TARGET_PATH` env var wherever dbt runs.\n- Add a results entry recording the old value and directing the user to set\n  --target-path/DBT_TARGET_PATH in job commands / CI / dbt platform, since anything reading generated\n  artifacts (manifest.json, run_results.json) from the custom path must be pointed at the new\n  location.\n- After removal, run dbt parse to confirm the warning is cleared."
+      },
+      "_path": "kb/core/1_4_004.yaml"
+    },
+    {
+      "issue_id": "1_4_005",
+      "sort_order": 2050,
+      "change": "DBT_NO_PRINT environment variable deprecated in favor of DBT_PRINT",
+      "action": "Replace DBT_NO_PRINT=true with DBT_PRINT=false",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for the literal `DBT_NO_PRINT` in CI YAML (.github/**, .gitlab-ci.yml, etc.),\n  Dockerfiles, .env / *.env files, shell scripts, Makefiles, and tox.ini. Present if the token appears\n  anywhere.\n- The variable is frequently set in orchestration outside the repo, so an in-repo miss does not mean\n  the project is clear.",
+        "fixing": "- Translate the value: DBT_NO_PRINT=true (suppress prints) becomes DBT_PRINT=false; DBT_NO_PRINT=false\n  becomes DBT_PRINT=true.\n- Update every in-repo occurrence found.\n- This is an env-var rename, not a Python-environment change, so it is a normal advisory edit (not\n  environment_change) and is not verified by dbt parse.\n- Add a results entry telling the user to replace DBT_NO_PRINT in external CI / dbt platform\n  environment settings with DBT_PRINT (inverted value)."
+      },
+      "_path": "kb/core/1_4_005.yaml"
+    },
+    {
+      "issue_id": "1_4_006",
+      "sort_order": 2060,
+      "change": "DBT_ARTIFACT_STATE_PATH environment variable deprecated in favor of DBT_STATE",
+      "action": "Replace DBT_ARTIFACT_STATE_PATH with DBT_STATE",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_ARTIFACT_STATE_PATH` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Commonly used in Slim CI / state-deferral setups that live in orchestration outside the repo.",
+        "fixing": "- Rename the variable to `DBT_STATE`, keeping the same value (path to the state/manifest directory).\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry telling the user to rename DBT_ARTIFACT_STATE_PATH to DBT_STATE in external CI\n  and dbt platform job environments used for state:modified / --defer selection."
+      },
+      "_path": "kb/core/1_4_006.yaml"
+    },
+    {
+      "issue_id": "1_4_007",
+      "sort_order": 2070,
+      "change": "DBT_FAVOR_STATE_MODE environment variable deprecated in favor of DBT_FAVOR_STATE",
+      "action": "Replace DBT_FAVOR_STATE_MODE with DBT_FAVOR_STATE",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_FAVOR_STATE_MODE` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Typically set in state-based CI selection outside the repo.",
+        "fixing": "- Rename to `DBT_FAVOR_STATE`, preserving the value.\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry directing the user to rename this variable in external CI / dbt platform\n  environments."
+      },
+      "_path": "kb/core/1_4_007.yaml"
+    },
+    {
+      "issue_id": "1_4_008",
+      "sort_order": 2080,
+      "change": "DBT_DEFER_TO_STATE environment variable deprecated in favor of DBT_DEFER",
+      "action": "Replace DBT_DEFER_TO_STATE with DBT_DEFER",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_DEFER_TO_STATE` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Used in --defer based CI workflows that usually live outside the repo.",
+        "fixing": "- Rename to `DBT_DEFER`, preserving the boolean value.\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry directing the user to rename DBT_DEFER_TO_STATE to DBT_DEFER in external CI /\n  dbt platform environments."
+      },
+      "_path": "kb/core/1_4_008.yaml"
+    },
+    {
+      "issue_id": "1_4_009",
+      "sort_order": 2090,
+      "change": "Isolated BEGIN/COMMIT statements now produce a warning",
+      "action": "Review custom macros/hooks that issue standalone BEGIN/COMMIT and remove or restructure them",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "snowflake",
+      "impact": "Standalone transactional keywords trigger a warning; transaction handling is managed by dbt",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/**/*.sql, models/**/*.sql (hooks embedded via config), and dbt_project.yml / model\n  configs for pre-hook / post-hook / on-run-start / on-run-end entries and macro bodies with a\n  standalone `BEGIN;`, `COMMIT;`, or `begin transaction` / `commit` not inside a stored-procedure\n  body.\n- Regex (case-insensitive): `(^|\\n)\\s*(begin|commit)\\s*;`.\n- Present when such isolated statements exist in Snowflake-targeted code.",
+        "fixing": "- Remove standalone BEGIN/COMMIT from hooks and custom macros; dbt manages transactions itself, so\n  these are redundant and now warn.\n- If the intent was to wrap several statements atomically, move that logic into a single statement or\n  a Snowflake stored procedure / scripting block rather than emitting bare transactional keywords.\n- Warehouse-behavior change invisible to dbt parse; parse passing does not confirm the warning is\n  gone.\n- Verify by grepping that no isolated BEGIN/COMMIT remain.\n- If a hook genuinely must control transactions, record it in the results report for user review."
+      },
+      "_path": "kb/snowflake/1_4_009.yaml"
+    },
+    {
+      "issue_id": "1_5_001",
+      "sort_order": 3010,
+      "change": "Metric YAML schema completely rewritten for MetricFlow",
+      "action": "Rewrite all metric definitions using the new type/type_params/filter format",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "All existing metric YAML definitions fail to parse in 1.6; the pre-1.6 UnparsedMetric fields (calculation_method, expression, sql, model, type: expression) and the rename_metric_attr compatibility shim were removed.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Search every YAML file under models/ and any schema-file globs declared in dbt_project.yml\n  (models/**/*.yml, models/**/*.yaml, plus any top-level metrics/ dir) for a `metrics:` block.\n- Flag a metric as legacy (pre-1.6) if its entry uses ANY of these keys: `calculation_method`,\n  `expression`, `sql`, `type: expression`, a top-level `type:` with the old enum\n  (`count`/`sum`/...), `model:`, `timestamp:`, `time_grains:`, `dimensions:` directly on the\n  metric, or `filters:` (the list-of-dict old form).\n- The new MetricFlow schema instead uses `type:` with values simple|ratio|cumulative|derived\n  plus a `type_params:` block. If a metric already has `type_params:`, it is migrated \u2014 skip it.\n- Also grep packages.yml for `dbt_metrics` usage and models for `metrics.calculate(` /\n  `metrics.develop(` macro calls \u2014 those depend on the old package and must be flagged too.",
+        "fixing": "- Rewrite each legacy metric into the new schema. Attribute mapping:\n  - `calculation_method` -> `type`: sum/average/min/max/count/count_distinct/median become\n    `type: simple` with `type_params.measure`; derived/expression become `type: derived` with\n    `type_params.expr` and `type_params.metrics`.\n  - `expression`/`sql` -> `type_params.measure` (the semantic measure name), or\n    `type_params.expr` for a derived metric.\n  - `model:` -> moves into a `semantic_models:` definition (see example below).\n  - `filters:` -> `filter:` (a single `{{ Dimension(...) }}` string, or keep the WHERE fragment).\n- Concrete before/after:\n  BEFORE (1.5):\n    metrics:\n      - name: total_revenue\n        calculation_method: sum\n        expression: amount\n        model: ref('orders')\n        timestamp: order_date\n        time_grains: [day, month]\n        dimensions: [status]\n  AFTER (1.6, MetricFlow):\n    semantic_models:\n      - name: orders\n        model: ref('orders')\n        defaults:\n          agg_time_dimension: order_date\n        entities:\n          - name: order\n            type: primary\n        dimensions:\n          - name: order_date\n            type: time\n            type_params: {time_granularity: day}\n          - name: status\n            type: categorical\n        measures:\n          - name: amount\n            agg: sum\n            agg_time_dimension: order_date\n    metrics:\n      - name: total_revenue\n        type: simple\n        type_params:\n          measure: amount\n- Derived example: `calculation_method: derived` + `expression: revenue - cost` becomes\n  `type: derived` with `type_params: {expr: 'revenue - cost', metrics: [{name: revenue},\n  {name: cost}]}`.\n- Judgment-heavy: 1.6 requires a `semantic_models:` layer that did not exist in 1.5, so the\n  measure/entity/dimension split cannot always be inferred mechanically.\n- If you cannot confidently reconstruct the semantic model (e.g. the source model's grain or\n  entities are ambiguous), do NOT guess \u2014 record the metric in the results report with\n  the original YAML and the suggested new shape, and move on.\n- After editing, run `dbt parse`. On a metric/semantic-model validation error, re-read it;\n  reverting to legacy form is NOT an option (it won't parse in 1.6) \u2014 instead leave the\n  semantic_model skeleton and flag it manual.\n- Remove `dbt_metrics` / `metrics.calculate` usages and flag them as requiring the\n  MetricFlow / Semantic Layer migration (out of scope for parse)."
+      },
+      "_path": "kb/core/1_5_001.yaml"
+    },
+    {
+      "issue_id": "1_5_002",
+      "sort_order": 3020,
+      "change": "Duplicate node names allowed across packages",
+      "action": "Disambiguate cross-package references with two-argument ref('package_name', 'model_name')",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.5 a flat manifest dict raised DuplicateResourceNameError; in 1.6 names are stored per-package, so a project and an installed package can legitimately share a model name. Single-argument ref() to a name that exists in more than one package becomes ambiguous (AmbiguousAliasError / wrong node).",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant if packages.yml / dependencies.yml declares packages.\n- Build the set of model/seed/snapshot names defined in the local project (models/**/*.sql,\n  seeds/**/*.csv, snapshots/**/*.sql).\n- Where available, add the names exposed by installed packages under dbt_packages/*/models.\n- Grep all .sql/.yml for single-argument `ref('name')` / `ref(\"name\")` whose `name` collides\n  with a name present in BOTH the local project and a package (or in two packages) \u2014 those are\n  the ambiguous refs.\n- If no packages are installed, mark skipped-not-present.",
+        "fixing": "- For each ambiguous single-arg ref, rewrite to the two-argument form\n  `ref('<package_name>', '<model_name>')`.\n- Choose the package the author intended; default to the local project's own model unless the\n  surrounding SQL clearly consumes the package's version.\n- Example: `ref('customers')` -> `ref('my_project', 'customers')` or\n  `ref('dbt_utils', 'customers')`. Leave unambiguous refs untouched.\n- After edits run `dbt parse`; a remaining AmbiguousAliasError names the offending ref and node.\n- If you cannot determine which package is intended, record it in the results report\n  rather than guessing \u2014 picking the wrong package silently changes lineage."
+      },
+      "_path": "kb/core/1_5_002.yaml"
+    },
+    {
+      "issue_id": "1_5_003",
+      "sort_order": 3030,
+      "change": "collect_freshness macro return type changed",
+      "action": "Update any custom collect_freshness macro override to return the full result object (table + response) instead of just the table",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.6 core's default collect_freshness returns a dict-like {table, response} object; a custom override that returns only the agate table triggers a deprecation warning and will break source freshness in later versions.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/**/*.sql for a macro named `collect_freshness` (i.e. `{% macro collect_freshness(`\n  or `{% macro <adapter>__collect_freshness(`).\n- If none exists, the project uses core's implementation \u2014 mark skipped-not-present.\n- If one exists, inspect its final `{{ return(...) }}` and flag it if it returns the query\n  result table directly (e.g. `return(load_result('collect_freshness').table)` or\n  `return(table)`) rather than the full result object.",
+        "fixing": "- Change the macro to capture the full result and return an object exposing both the table and\n  the adapter response.\n- Pattern: `{% set result = run_query(...) %}` then\n  `{{ return({'table': result.table, 'response': result.response}) }}`.\n- Mirror core's 1.6 signature: it returns `load_result('collect_freshness')`, which already has\n  `.table` and `.response`.\n- Simplest safe fix, if the override only existed to tweak the SQL: align the return statement\n  with core 1.6's macro body.\n- After editing run `dbt parse`.\n- If the override is complex or the intended response object is unclear, record it in the\n  results report with a pointer to core's 1.6 collect_freshness for reference."
+      },
+      "_path": "kb/core/1_5_003.yaml"
+    },
+    {
+      "issue_id": "1_6_011",
+      "sort_order": 4005,
+      "change": "dbt clean errors when clean-targets include source paths or paths outside the project",
+      "action": "Remove source paths (e.g. models/, macros/) and any path outside the project directory from clean-targets in dbt_project.yml",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "dbt clean now raises an error instead of silently deleting the wrong directories when clean-targets references source paths or paths outside the project root",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml's clean-targets list.\n- Flag any entry that resolves (relative to the project root) to a configured source path\n  (model-paths, seed-paths, macro-paths, etc.) or that resolves outside the project directory\n  (e.g. ../shared, /absolute/path).",
+        "fixing": "- Remove the offending entries from clean-targets, keeping only build/output directories\n  (e.g. target, dbt_packages, logs).\n- Re-run dbt clean to confirm it no longer errors."
+      },
+      "_path": "kb/core/1_6_011.yaml"
+    },
+    {
+      "issue_id": "1_6_001",
+      "sort_order": 4010,
+      "change": "New warning when --state and --target point to the same directory",
+      "action": "Fix --state/--target configuration so they reference distinct directories",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "WarnStateTargetEqual raised (informational) for previously silent misconfiguration; fatal under --warn-error",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- This is a runtime CLI/job configuration issue, not a repo-source issue, so `dbt parse` cannot\n  surface it. Detect by scanning invocation sites, not models.\n- Grep the repo for `--state` and `--target` / `--target-path` in shell scripts, Makefiles, and\n  `scripts/**/*.sh`.\n- Also grep CI configs: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `tox.ini`.\n- Check `dbt_project.yml` for a `target-path:` key (deprecated since 1.5 but may still be present).\n- Check for `DBT_STATE` / `DBT_TARGET_PATH` env vars in CI.\n- Flag any invocation where `--state` and `--target`/`--target-path` resolve to the same directory\n  (commonly both set to `target/`).\n- Note the value is frequently supplied outside the repo (dbt platform job definitions,\n  orchestration tools), which parse cannot see.",
+        "fixing": "- Point `--state` at a directory separate from the run's `--target` \u2014 e.g. keep run output in\n  `target/` and the comparison manifest in a distinct dir such as `state/` or `prod-artifacts/`.\n- Concretely, in the offending script/CI step change the duplicated paths so a command like\n  `dbt build --state ./state --target-path ./target` uses different dirs, and populate the state\n  artifacts there.\n- If the same-directory usage lives outside the repo (a dbt platform job command, an orchestration\n  tool), it cannot be edited from the repo.\n- For that out-of-repo case: record it in the results artifact (target/dbt_migration_results.json)\n  as manual-required with the issue_id, the invocation location if known, and the suggested command\n  change, then prompt the user.\n- This change never requires a repo edit to pass `dbt parse`; it is advisory / out-of-repo only."
+      },
+      "_path": "kb/core/1_6_001.yaml"
+    },
+    {
+      "issue_id": "1_6_002",
+      "sort_order": 4020,
+      "change": "Breaking contract changes on unversioned models now warn instead of error",
+      "action": "Add --warn-error (or version the models) to retain the previous hard-error behavior on breaking contract changes",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Unversioned models with a breaking schema/contract change warn via warn_or_error() instead of erroring; CI that relied on the error to block may now pass silently",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan schema YAML (`models/**/*.yml`, `models/**/*.yaml`) for models declaring `contract:` with\n  `enforced: true` that do NOT declare a `version:` / `versions:` block (i.e. unversioned).\n- Those unversioned enforced-contract models are the ones whose breaking contract changes now only\n  warn.\n- Also detect reliance on the old error behavior: grep CI/scripts for `dbt build` / `dbt run`\n  invocations that lack `--warn-error` or `--warn-error-options`.\n- Those flags are what previously turned the contract breakage into a hard failure.\n- This is a behavior/policy change; `dbt parse` stays clean either way, so detection is about intent,\n  not parse errors.",
+        "fixing": "- Preferred: preserve strict behavior by adding `--warn-error` (or a scoped `--warn-error-options`\n  targeting contract deprecations) to the relevant dbt invocation.\n- If that invocation is defined outside the repo (dbt platform job command, orchestration tool), it\n  cannot be edited here: record it in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the suggested flag, and prompt the user.\n- Alternative in-repo fix: add a `version:` to the affected models \u2014 versioning makes breaking\n  contract changes error again.\n- But versioning reshapes ref() resolution and downstream references, so only do it when the user\n  explicitly wants versioned models; note that trade-off in the results report rather than silently\n  versioning.\n- No edit is required for `dbt parse` to succeed."
+      },
+      "_path": "kb/core/1_6_002.yaml"
+    },
+    {
+      "issue_id": "1_6_003",
+      "sort_order": 4030,
+      "change": "New warning for contracted models with bare numeric columns (no precision/scale)",
+      "action": "Add explicit precision and scale to numeric column data_types in enforced contracts (e.g. numeric(38,3))",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with 'data_type: numeric' (or 'decimal') and no precision/scale in an enforced contract now emit a warning at parse time in 1.7",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- In schema YAML (`models/**/*.yml`, `models/**/*.yaml`), find models with `contract:`\n  `enforced: true` and columns whose `data_type` is a bare numeric type with no precision/scale.\n- Match the data_type value (case-insensitive) against `^(numeric|decimal|number)$` (no parentheses).\n- Types that already include `(p,s)` like `numeric(38,3)` are fine and must be left alone.\n- Only columns inside enforced-contract models trigger the warning; bare numeric on non-contracted\n  models is not affected.",
+        "fixing": "- For each flagged column, replace the bare type with an explicit precision/scale, e.g.\n  `data_type: numeric` -> `data_type: numeric(38,3)`.\n- Choose precision/scale from evidence in this order:\n- (1) an existing cast in the model SQL (e.g. `cast(x as numeric(18,2))`) \u2014 match it;\n- (2) the warehouse's documented default for unqualified numeric if the model is already built\n  (Snowflake NUMBER default is (38,0); Redshift/Postgres NUMERIC default is (38,0));\n- (3) if unknown, use a safe wide default `numeric(38,6)` and note the assumption in the results\n  report.\n- Preserve YAML quoting/style.\n- After editing, run `dbt parse`; if it fails, the likely cause is a mismatched type name for the\n  adapter (e.g. Snowflake prefers `number(38,3)`) \u2014 retry with the adapter-native spelling.\n- If the correct precision genuinely cannot be determined, leave the column and record it in the\n  results artifact (target/dbt_migration_results.json) as manual-required for the user to confirm."
+      },
+      "_path": "kb/core/1_6_003.yaml"
+    },
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_3_spark.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_3_spark.json
@@ -1,0 +1,972 @@
+{
+  "from_version": "1.3",
+  "warehouse": "spark",
+  "target_version": "1.12",
+  "count": 45,
+  "issues": [
+    {
+      "issue_id": "1_3_001",
+      "sort_order": 1010,
+      "change": "Python model default materialization changed from view to table",
+      "action": "Set materialized='view' explicitly on Python models that relied on the old view default",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Python models without an explicit materialized config now create tables instead of views, changing storage/cost and downstream freshness expectations",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Enumerate Python models: models/**/*.py containing `def model(dbt, session)`.\n- Determine each model's effective materialization, in precedence order:\n  - an inline `dbt.config(materialized=...)` call inside model(dbt, session);\n  - a config() block;\n  - the matching model's YAML config in models/**/*.yml;\n  - the models: tree in dbt_project.yml (path-scoped config).\n- A model is affected if NONE of these set materialized: it defaulted to view, now defaults\n  to table.\n- SQL models are unaffected (their default was already view and is unchanged).",
+        "fixing": "- Only change models where the prior view behavior was actually intended (thin passthrough,\n  or a downstream tool expects a view).\n- For those, add materialized='view' at the most local level that already carries config:\n  prefer `dbt.config(materialized='view')` inside the function, else `materialized: view` in\n  the model's YAML, else under dbt_project.yml models:.\n- Do NOT blanket-force every Python model to view \u2014 the new table default is usually desirable;\n  flag ambiguous ones in the results report rather than guessing.\n- After editing run dbt parse; if it fails because dbt.config was placed outside the function,\n  move the call to the first statement inside def model(...)."
+      },
+      "_path": "kb/core/1_3_001.yaml"
+    },
+    {
+      "issue_id": "1_3_002",
+      "sort_order": 1020,
+      "change": "on-run-start / on-run-end hooks no longer halt execution on failure",
+      "action": "Find alternative approaches if hooks were used as guards/circuit-breakers that must abort a run",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start/on-run-end hook now appends an error result and continues instead of raising; guard/circuit-breaker hooks no longer abort the run",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for on-run-start: and on-run-end: keys (string or list).\n- Also scan these keys in any vendored package dbt_project.yml.\n- Flag hooks whose SQL acts as a precondition/guard:\n  - a SELECT that RAISES/THROWS, or calls an assertion macro;\n  - `{% if ... %}{{ exceptions.raise_compiler_error(...) }}{% endif %}`;\n  - SQL that intentionally errors (divide-by-zero, invalid cast) to stop a run.\n- Purely side-effecting hooks (grants, logging, audit inserts) are NOT affected.",
+        "fixing": "- Behavior change dbt parse cannot validate, so it is advisory.\n- For guard hooks: document that they no longer abort the run in 1.4+, and recommend moving the\n  precondition into a pre-flight step outside the run (a separate `dbt run-operation` gate in\n  CI, or a data test CI checks before proceeding).\n- Do not rewrite the hook's SQL automatically.\n- Record each guard-style hook in the results report with issue_id, the dbt_project.yml\n  location, and the suggested CI-gate alternative.\n- No parse impact expected; run dbt parse only to confirm no YAML was broken by edits."
+      },
+      "_path": "kb/core/1_3_002.yaml"
+    },
+    {
+      "issue_id": "1_3_003",
+      "sort_order": 1030,
+      "change": "pre_hook / post_hook (underscore form) now properly late-rendered",
+      "action": "Verify hook behavior if using underscore-form hooks that contain Jinja evaluated at parse time",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Hooks written with the underscore form (pre_hook/post_hook) that contain Jinja now render at runtime instead of parse time, matching the hyphen form; values resolved at parse time may differ",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Search the underscore spellings pre_hook and post_hook (NOT pre-hook/post-hook) across\n  models/**/*.sql config() blocks, models/**/*.yml, and dbt_project.yml.\n- Regex: `(pre_hook|post_hook)\\s*[:=]`.\n- Of those, flag hooks whose value contains Jinja ({{ ... }} or {% ... %}) whose result depends\n  on parse-vs-runtime timing: {{ this }}, {{ run_started_at }}, runtime var()/env_var(), or the\n  result of a statement/run_query.\n- Static string hooks are unaffected.",
+        "fixing": "- Advisory/verification change \u2014 late rendering generally makes underscore hooks behave\n  correctly, so most projects need no edit.\n- Only intervene if a hook relied on the old parse-time rendering (rare).\n- Where behavior matters, note it in the results report and suggest confirming the hook still\n  produces the intended SQL at runtime.\n- Optionally normalize underscore hooks to the canonical hyphen form (pre-hook/post-hook) for\n  clarity, but this is cosmetic.\n- Run dbt parse after any edit; if a config() edit breaks parse, revert to the original key\n  spelling."
+      },
+      "_path": "kb/core/1_3_003.yaml"
+    },
+    {
+      "issue_id": "1_3_010",
+      "sort_order": 1100,
+      "change": "escape_single_quotes macro uses backslash escaping instead of double-quoting",
+      "action": "Review models/seeds with apostrophes and remove manual escaping workarounds",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "spark",
+      "impact": "Seed data and string literals containing single quotes now produce backslash-escaped SQL; models that manually doubled quotes to work around the old behavior may now double-escape",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two footprints:\n  - macros/**/*.sql that override escape_single_quotes or reimplement quote-doubling for Spark\n    (grep escape_single_quotes and manual '' doubling);\n  - models/**/*.sql and seeds/**/*.csv containing string literals with apostrophes where the\n    author pre-escaped by doubling ('') to satisfy the old double-quoting behavior.\n- Look for suspicious '' inside seed values or dbt.string_literal / literal-building macros.",
+        "fixing": "- If the project overrides escape_single_quotes to the old double-quoting approach, remove the\n  override so the core backslash-escaping macro is used (unless the target Spark/SQL dialect\n  truly needs doubling \u2014 verify against the warehouse layer).\n- For seeds/models that manually doubled quotes as a workaround, revert them to single\n  apostrophes and let the macro escape.\n- Warehouse-observable and invisible to parse: run dbt parse to confirm compilation, note\n  affected files in the results report, and rely on the build-green layer to confirm escaped\n  literals load correctly.\n- If unsure whether a '' was genuine data or a workaround, flag it in the results report rather\n  than editing seed data."
+      },
+      "_path": "kb/spark/1_3_010.yaml"
+    },
+    {
+      "issue_id": "1_3_011",
+      "sort_order": 1110,
+      "change": "LDAP/thrift password now correctly passed to the Spark server",
+      "action": "Verify LDAP/thrift connections that previously failed silently",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "spark",
+      "impact": "Users with LDAP auth whose password was previously dropped (silent auth failure) may now authenticate successfully; behavior of the connection changes",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Connection/profiles concern with no in-repo model footprint.\n- Inspect profiles.yml spark output(s) for method: thrift (or LDAP-style auth) with a\n  user/password.\n- Previously the password field was not forwarded; in 1.4 it is.\n- If the project does not use thrift/LDAP auth (e.g. http/odbc/session), mark\n  skipped-not-present.",
+        "fixing": "- ADVISORY ONLY: do not modify credentials or attempt to connect.\n- Correctness improvement: recommend the user verify thrift/LDAP connections still behave as\n  expected now that the password is actually sent (a connection that previously 'worked' by\n  ignoring a wrong password will now fail correctly).\n- Record the verification step in the results report with the target name (status\n  manual-required).\n- Not verifiable by dbt parse and touches connection config outside the repo; no repo files are\n  changed."
+      },
+      "_path": "kb/spark/1_3_011.yaml"
+    },
+    {
+      "issue_id": "1_3_013",
+      "sort_order": 1130,
+      "change": "Metric attributes sql / type / type: expression deprecation warnings updated",
+      "action": "Migrate metric attrs to expression, calculation_method, and calculation_method: derived",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Legacy metric attribute names emit deprecation warnings; slated for removal",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan models/**/*.yml for `metrics:` blocks using legacy attrs `sql:`, `type:`, or\n  `type: expression`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (attribute rename to expression/calculation_method).\n- Review the autofix diff and confirm each metric was rewritten.\n- NOTE: this is the 1.3->1.4 attribute rename only; the full MetricFlow rewrite is the separate\n  1.5->1.6 issue 1_5_001.\n- Manual fallback: apply the attribute renames yourself if autofix skipped any."
+      },
+      "_path": "kb/core/1_3_013.yaml"
+    },
+    {
+      "issue_id": "1_3_014",
+      "sort_order": 1140,
+      "change": "Merge SQL predicates wrapped in parens; predicates kwarg renamed to incremental_predicates",
+      "action": "Update custom incremental strategy macros using arg_dict['predicates'] to incremental_predicates",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Custom strategy macros reading arg_dict['predicates'] break; generated merge SQL wraps predicates in parens",
+      "from_version": "1.3",
+      "to_version": "1.4",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/ for custom incremental/merge macros referencing `predicates`\n  (e.g. `arg_dict['predicates']`, `config.get('predicates')`).",
+        "fixing": "- Handled by `dbt-autofix deprecations` where applicable (rename `predicates` ->\n  `incremental_predicates`).\n- Review the diff.\n- Manual fallback: rename the kwarg in any custom macro autofix did not touch.\n- Behavior/warehouse effect (paren-wrapping) is validated in the build-green layer, not parse."
+      },
+      "_path": "kb/core/1_3_014.yaml"
+    },
+    {
+      "issue_id": "1_4_001",
+      "sort_order": 2010,
+      "change": "--select/--exclude now accumulate when passed multiple times (argparse -> Click)",
+      "action": "Review scripts/jobs passing --select or --exclude more than once; collapse to a single flag with the intended union",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Scripts relying on last-wins override now see both selections combined, selecting more nodes than intended",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep in-repo invocation sites for repeated selection flags on a single command: shell scripts\n  (*.sh), Makefiles, CI YAML (.github/**, .gitlab-ci.yml, azure-pipelines.yml), tox.ini, and dbt\n  wrapper scripts.\n- Pattern: one dbt command containing two or more `--select`/`-s` or `--exclude` tokens (regex\n  `(--select|--exclude|-s)\\b.*\\b(--select|--exclude|-s)\\b`).\n- The real risk lives OUTSIDE the repo in dbt platform job definitions, so in-repo presence may be\n  zero even when the project is affected.",
+        "fixing": "- For each in-repo command with duplicated selection flags, decide intent: pre-1.5 was last-wins (only\n  the final flag applied); 1.5+ is union (all applied).\n- If the old intent was 'use only the last selection', delete the earlier occurrences. If a union was\n  intended, it already works \u2014 leave it.\n- Example: `dbt run --select tag:nightly --select my_model` (1.4 ran only my_model) -> `dbt run\n  --select my_model`.\n- Not visible to dbt parse.\n- ALWAYS add a results entry (manual-required): dbt platform job commands and orchestration outside\n  this repo may pass the flags multiple times; list the affected in-repo sites and tell the user to\n  audit job definitions."
+      },
+      "_path": "kb/core/1_4_001.yaml"
+    },
+    {
+      "issue_id": "1_4_002",
+      "sort_order": 2020,
+      "change": "Duplicate CLI flags before and after the subcommand now raise an error",
+      "action": "Ensure each CLI flag appears only once per dbt invocation",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands like `dbt --flag run --flag` now fail instead of silently taking one value",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan in-repo dbt invocation sites (shell scripts, Makefiles, CI YAML, tox.ini, wrapper scripts) for\n  a single dbt command repeating the same flag, especially placed both before and after the\n  subcommand.\n- Examples: `dbt --debug run --debug`, or a repeated `--profiles-dir` / `--target` / `--vars`.\n- Likeliest offenders: global flags (--debug, --profiles-dir, --project-dir, --target, --log-format)\n  appearing twice.\n- As with selection flags, the primary risk is in dbt platform job commands outside the repo.",
+        "fixing": "- Remove the duplicate occurrence, keeping the one with the intended value (pre-1.5 resolved to a\n  single value, so pick that).\n- Example: `dbt --target prod run --target prod` -> `dbt run --target prod`.\n- If two occurrences carry DIFFERENT values it was already ambiguous \u2014 keep the value the user\n  confirms and record the resolution in the migration log.\n- Not visible to dbt parse.\n- Add a results entry (manual-required) directing the user to audit external job/orchestration\n  commands for duplicated flags, since those now hard-error."
+      },
+      "_path": "kb/core/1_4_002.yaml"
+    },
+    {
+      "issue_id": "1_4_003",
+      "sort_order": 2030,
+      "change": "log-path in dbt_project.yml deprecated",
+      "action": "Move log-path out of dbt_project.yml to the --log-path CLI flag or DBT_LOG_PATH env var",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning at parse time; becomes fatal under --warn-error",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for a top-level `log-path:` key (regex `^\\s*log-path\\s*:`). Present if the key\n  exists with any value.\n- Only one location to check.",
+        "fixing": "- Remove the `log-path:` key from dbt_project.yml.\n- Re-provision out-of-repo: either the `--log-path <dir>` CLI flag on dbt invocations or the\n  `DBT_LOG_PATH` env var.\n- Because the effective destination now lives in job commands / env config outside this repo, add a\n  results entry recording the old value and telling the user to set --log-path/DBT_LOG_PATH wherever\n  dbt is invoked (CI, dbt platform jobs).\n- After removing the key, run dbt parse; the deprecation warning should be gone.\n- If parse still warns, confirm no other config file (a profiles-level or imported yml) re-declares\n  log-path."
+      },
+      "_path": "kb/core/1_4_003.yaml"
+    },
+    {
+      "issue_id": "1_4_004",
+      "sort_order": 2040,
+      "change": "target-path in dbt_project.yml deprecated",
+      "action": "Move target-path out of dbt_project.yml to the --target-path CLI flag or DBT_TARGET_PATH env var",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning at parse time; becomes fatal under --warn-error",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for a top-level `target-path:` key (regex `^\\s*target-path\\s*:`). Present if\n  the key exists.",
+        "fixing": "- Remove the `target-path:` key from dbt_project.yml.\n- Re-provision via the `--target-path <dir>` CLI flag or `DBT_TARGET_PATH` env var wherever dbt runs.\n- Add a results entry recording the old value and directing the user to set\n  --target-path/DBT_TARGET_PATH in job commands / CI / dbt platform, since anything reading generated\n  artifacts (manifest.json, run_results.json) from the custom path must be pointed at the new\n  location.\n- After removal, run dbt parse to confirm the warning is cleared."
+      },
+      "_path": "kb/core/1_4_004.yaml"
+    },
+    {
+      "issue_id": "1_4_005",
+      "sort_order": 2050,
+      "change": "DBT_NO_PRINT environment variable deprecated in favor of DBT_PRINT",
+      "action": "Replace DBT_NO_PRINT=true with DBT_PRINT=false",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for the literal `DBT_NO_PRINT` in CI YAML (.github/**, .gitlab-ci.yml, etc.),\n  Dockerfiles, .env / *.env files, shell scripts, Makefiles, and tox.ini. Present if the token appears\n  anywhere.\n- The variable is frequently set in orchestration outside the repo, so an in-repo miss does not mean\n  the project is clear.",
+        "fixing": "- Translate the value: DBT_NO_PRINT=true (suppress prints) becomes DBT_PRINT=false; DBT_NO_PRINT=false\n  becomes DBT_PRINT=true.\n- Update every in-repo occurrence found.\n- This is an env-var rename, not a Python-environment change, so it is a normal advisory edit (not\n  environment_change) and is not verified by dbt parse.\n- Add a results entry telling the user to replace DBT_NO_PRINT in external CI / dbt platform\n  environment settings with DBT_PRINT (inverted value)."
+      },
+      "_path": "kb/core/1_4_005.yaml"
+    },
+    {
+      "issue_id": "1_4_006",
+      "sort_order": 2060,
+      "change": "DBT_ARTIFACT_STATE_PATH environment variable deprecated in favor of DBT_STATE",
+      "action": "Replace DBT_ARTIFACT_STATE_PATH with DBT_STATE",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_ARTIFACT_STATE_PATH` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Commonly used in Slim CI / state-deferral setups that live in orchestration outside the repo.",
+        "fixing": "- Rename the variable to `DBT_STATE`, keeping the same value (path to the state/manifest directory).\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry telling the user to rename DBT_ARTIFACT_STATE_PATH to DBT_STATE in external CI\n  and dbt platform job environments used for state:modified / --defer selection."
+      },
+      "_path": "kb/core/1_4_006.yaml"
+    },
+    {
+      "issue_id": "1_4_007",
+      "sort_order": 2070,
+      "change": "DBT_FAVOR_STATE_MODE environment variable deprecated in favor of DBT_FAVOR_STATE",
+      "action": "Replace DBT_FAVOR_STATE_MODE with DBT_FAVOR_STATE",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_FAVOR_STATE_MODE` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Typically set in state-based CI selection outside the repo.",
+        "fixing": "- Rename to `DBT_FAVOR_STATE`, preserving the value.\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry directing the user to rename this variable in external CI / dbt platform\n  environments."
+      },
+      "_path": "kb/core/1_4_007.yaml"
+    },
+    {
+      "issue_id": "1_4_008",
+      "sort_order": 2080,
+      "change": "DBT_DEFER_TO_STATE environment variable deprecated in favor of DBT_DEFER",
+      "action": "Replace DBT_DEFER_TO_STATE with DBT_DEFER",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_DEFER_TO_STATE` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Used in --defer based CI workflows that usually live outside the repo.",
+        "fixing": "- Rename to `DBT_DEFER`, preserving the boolean value.\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry directing the user to rename DBT_DEFER_TO_STATE to DBT_DEFER in external CI /\n  dbt platform environments."
+      },
+      "_path": "kb/core/1_4_008.yaml"
+    },
+    {
+      "issue_id": "1_5_001",
+      "sort_order": 3010,
+      "change": "Metric YAML schema completely rewritten for MetricFlow",
+      "action": "Rewrite all metric definitions using the new type/type_params/filter format",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "All existing metric YAML definitions fail to parse in 1.6; the pre-1.6 UnparsedMetric fields (calculation_method, expression, sql, model, type: expression) and the rename_metric_attr compatibility shim were removed.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Search every YAML file under models/ and any schema-file globs declared in dbt_project.yml\n  (models/**/*.yml, models/**/*.yaml, plus any top-level metrics/ dir) for a `metrics:` block.\n- Flag a metric as legacy (pre-1.6) if its entry uses ANY of these keys: `calculation_method`,\n  `expression`, `sql`, `type: expression`, a top-level `type:` with the old enum\n  (`count`/`sum`/...), `model:`, `timestamp:`, `time_grains:`, `dimensions:` directly on the\n  metric, or `filters:` (the list-of-dict old form).\n- The new MetricFlow schema instead uses `type:` with values simple|ratio|cumulative|derived\n  plus a `type_params:` block. If a metric already has `type_params:`, it is migrated \u2014 skip it.\n- Also grep packages.yml for `dbt_metrics` usage and models for `metrics.calculate(` /\n  `metrics.develop(` macro calls \u2014 those depend on the old package and must be flagged too.",
+        "fixing": "- Rewrite each legacy metric into the new schema. Attribute mapping:\n  - `calculation_method` -> `type`: sum/average/min/max/count/count_distinct/median become\n    `type: simple` with `type_params.measure`; derived/expression become `type: derived` with\n    `type_params.expr` and `type_params.metrics`.\n  - `expression`/`sql` -> `type_params.measure` (the semantic measure name), or\n    `type_params.expr` for a derived metric.\n  - `model:` -> moves into a `semantic_models:` definition (see example below).\n  - `filters:` -> `filter:` (a single `{{ Dimension(...) }}` string, or keep the WHERE fragment).\n- Concrete before/after:\n  BEFORE (1.5):\n    metrics:\n      - name: total_revenue\n        calculation_method: sum\n        expression: amount\n        model: ref('orders')\n        timestamp: order_date\n        time_grains: [day, month]\n        dimensions: [status]\n  AFTER (1.6, MetricFlow):\n    semantic_models:\n      - name: orders\n        model: ref('orders')\n        defaults:\n          agg_time_dimension: order_date\n        entities:\n          - name: order\n            type: primary\n        dimensions:\n          - name: order_date\n            type: time\n            type_params: {time_granularity: day}\n          - name: status\n            type: categorical\n        measures:\n          - name: amount\n            agg: sum\n            agg_time_dimension: order_date\n    metrics:\n      - name: total_revenue\n        type: simple\n        type_params:\n          measure: amount\n- Derived example: `calculation_method: derived` + `expression: revenue - cost` becomes\n  `type: derived` with `type_params: {expr: 'revenue - cost', metrics: [{name: revenue},\n  {name: cost}]}`.\n- Judgment-heavy: 1.6 requires a `semantic_models:` layer that did not exist in 1.5, so the\n  measure/entity/dimension split cannot always be inferred mechanically.\n- If you cannot confidently reconstruct the semantic model (e.g. the source model's grain or\n  entities are ambiguous), do NOT guess \u2014 record the metric in the results report with\n  the original YAML and the suggested new shape, and move on.\n- After editing, run `dbt parse`. On a metric/semantic-model validation error, re-read it;\n  reverting to legacy form is NOT an option (it won't parse in 1.6) \u2014 instead leave the\n  semantic_model skeleton and flag it manual.\n- Remove `dbt_metrics` / `metrics.calculate` usages and flag them as requiring the\n  MetricFlow / Semantic Layer migration (out of scope for parse)."
+      },
+      "_path": "kb/core/1_5_001.yaml"
+    },
+    {
+      "issue_id": "1_5_002",
+      "sort_order": 3020,
+      "change": "Duplicate node names allowed across packages",
+      "action": "Disambiguate cross-package references with two-argument ref('package_name', 'model_name')",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.5 a flat manifest dict raised DuplicateResourceNameError; in 1.6 names are stored per-package, so a project and an installed package can legitimately share a model name. Single-argument ref() to a name that exists in more than one package becomes ambiguous (AmbiguousAliasError / wrong node).",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant if packages.yml / dependencies.yml declares packages.\n- Build the set of model/seed/snapshot names defined in the local project (models/**/*.sql,\n  seeds/**/*.csv, snapshots/**/*.sql).\n- Where available, add the names exposed by installed packages under dbt_packages/*/models.\n- Grep all .sql/.yml for single-argument `ref('name')` / `ref(\"name\")` whose `name` collides\n  with a name present in BOTH the local project and a package (or in two packages) \u2014 those are\n  the ambiguous refs.\n- If no packages are installed, mark skipped-not-present.",
+        "fixing": "- For each ambiguous single-arg ref, rewrite to the two-argument form\n  `ref('<package_name>', '<model_name>')`.\n- Choose the package the author intended; default to the local project's own model unless the\n  surrounding SQL clearly consumes the package's version.\n- Example: `ref('customers')` -> `ref('my_project', 'customers')` or\n  `ref('dbt_utils', 'customers')`. Leave unambiguous refs untouched.\n- After edits run `dbt parse`; a remaining AmbiguousAliasError names the offending ref and node.\n- If you cannot determine which package is intended, record it in the results report\n  rather than guessing \u2014 picking the wrong package silently changes lineage."
+      },
+      "_path": "kb/core/1_5_002.yaml"
+    },
+    {
+      "issue_id": "1_5_003",
+      "sort_order": 3030,
+      "change": "collect_freshness macro return type changed",
+      "action": "Update any custom collect_freshness macro override to return the full result object (table + response) instead of just the table",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.6 core's default collect_freshness returns a dict-like {table, response} object; a custom override that returns only the agate table triggers a deprecation warning and will break source freshness in later versions.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/**/*.sql for a macro named `collect_freshness` (i.e. `{% macro collect_freshness(`\n  or `{% macro <adapter>__collect_freshness(`).\n- If none exists, the project uses core's implementation \u2014 mark skipped-not-present.\n- If one exists, inspect its final `{{ return(...) }}` and flag it if it returns the query\n  result table directly (e.g. `return(load_result('collect_freshness').table)` or\n  `return(table)`) rather than the full result object.",
+        "fixing": "- Change the macro to capture the full result and return an object exposing both the table and\n  the adapter response.\n- Pattern: `{% set result = run_query(...) %}` then\n  `{{ return({'table': result.table, 'response': result.response}) }}`.\n- Mirror core's 1.6 signature: it returns `load_result('collect_freshness')`, which already has\n  `.table` and `.response`.\n- Simplest safe fix, if the override only existed to tweak the SQL: align the return statement\n  with core 1.6's macro body.\n- After editing run `dbt parse`.\n- If the override is complex or the intended response object is unclear, record it in the\n  results report with a pointer to core's 1.6 collect_freshness for reference."
+      },
+      "_path": "kb/core/1_5_003.yaml"
+    },
+    {
+      "issue_id": "1_6_011",
+      "sort_order": 4005,
+      "change": "dbt clean errors when clean-targets include source paths or paths outside the project",
+      "action": "Remove source paths (e.g. models/, macros/) and any path outside the project directory from clean-targets in dbt_project.yml",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "dbt clean now raises an error instead of silently deleting the wrong directories when clean-targets references source paths or paths outside the project root",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml's clean-targets list.\n- Flag any entry that resolves (relative to the project root) to a configured source path\n  (model-paths, seed-paths, macro-paths, etc.) or that resolves outside the project directory\n  (e.g. ../shared, /absolute/path).",
+        "fixing": "- Remove the offending entries from clean-targets, keeping only build/output directories\n  (e.g. target, dbt_packages, logs).\n- Re-run dbt clean to confirm it no longer errors."
+      },
+      "_path": "kb/core/1_6_011.yaml"
+    },
+    {
+      "issue_id": "1_6_001",
+      "sort_order": 4010,
+      "change": "New warning when --state and --target point to the same directory",
+      "action": "Fix --state/--target configuration so they reference distinct directories",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "WarnStateTargetEqual raised (informational) for previously silent misconfiguration; fatal under --warn-error",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- This is a runtime CLI/job configuration issue, not a repo-source issue, so `dbt parse` cannot\n  surface it. Detect by scanning invocation sites, not models.\n- Grep the repo for `--state` and `--target` / `--target-path` in shell scripts, Makefiles, and\n  `scripts/**/*.sh`.\n- Also grep CI configs: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `tox.ini`.\n- Check `dbt_project.yml` for a `target-path:` key (deprecated since 1.5 but may still be present).\n- Check for `DBT_STATE` / `DBT_TARGET_PATH` env vars in CI.\n- Flag any invocation where `--state` and `--target`/`--target-path` resolve to the same directory\n  (commonly both set to `target/`).\n- Note the value is frequently supplied outside the repo (dbt platform job definitions,\n  orchestration tools), which parse cannot see.",
+        "fixing": "- Point `--state` at a directory separate from the run's `--target` \u2014 e.g. keep run output in\n  `target/` and the comparison manifest in a distinct dir such as `state/` or `prod-artifacts/`.\n- Concretely, in the offending script/CI step change the duplicated paths so a command like\n  `dbt build --state ./state --target-path ./target` uses different dirs, and populate the state\n  artifacts there.\n- If the same-directory usage lives outside the repo (a dbt platform job command, an orchestration\n  tool), it cannot be edited from the repo.\n- For that out-of-repo case: record it in the results artifact (target/dbt_migration_results.json)\n  as manual-required with the issue_id, the invocation location if known, and the suggested command\n  change, then prompt the user.\n- This change never requires a repo edit to pass `dbt parse`; it is advisory / out-of-repo only."
+      },
+      "_path": "kb/core/1_6_001.yaml"
+    },
+    {
+      "issue_id": "1_6_002",
+      "sort_order": 4020,
+      "change": "Breaking contract changes on unversioned models now warn instead of error",
+      "action": "Add --warn-error (or version the models) to retain the previous hard-error behavior on breaking contract changes",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Unversioned models with a breaking schema/contract change warn via warn_or_error() instead of erroring; CI that relied on the error to block may now pass silently",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan schema YAML (`models/**/*.yml`, `models/**/*.yaml`) for models declaring `contract:` with\n  `enforced: true` that do NOT declare a `version:` / `versions:` block (i.e. unversioned).\n- Those unversioned enforced-contract models are the ones whose breaking contract changes now only\n  warn.\n- Also detect reliance on the old error behavior: grep CI/scripts for `dbt build` / `dbt run`\n  invocations that lack `--warn-error` or `--warn-error-options`.\n- Those flags are what previously turned the contract breakage into a hard failure.\n- This is a behavior/policy change; `dbt parse` stays clean either way, so detection is about intent,\n  not parse errors.",
+        "fixing": "- Preferred: preserve strict behavior by adding `--warn-error` (or a scoped `--warn-error-options`\n  targeting contract deprecations) to the relevant dbt invocation.\n- If that invocation is defined outside the repo (dbt platform job command, orchestration tool), it\n  cannot be edited here: record it in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the suggested flag, and prompt the user.\n- Alternative in-repo fix: add a `version:` to the affected models \u2014 versioning makes breaking\n  contract changes error again.\n- But versioning reshapes ref() resolution and downstream references, so only do it when the user\n  explicitly wants versioned models; note that trade-off in the results report rather than silently\n  versioning.\n- No edit is required for `dbt parse` to succeed."
+      },
+      "_path": "kb/core/1_6_002.yaml"
+    },
+    {
+      "issue_id": "1_6_003",
+      "sort_order": 4030,
+      "change": "New warning for contracted models with bare numeric columns (no precision/scale)",
+      "action": "Add explicit precision and scale to numeric column data_types in enforced contracts (e.g. numeric(38,3))",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with 'data_type: numeric' (or 'decimal') and no precision/scale in an enforced contract now emit a warning at parse time in 1.7",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- In schema YAML (`models/**/*.yml`, `models/**/*.yaml`), find models with `contract:`\n  `enforced: true` and columns whose `data_type` is a bare numeric type with no precision/scale.\n- Match the data_type value (case-insensitive) against `^(numeric|decimal|number)$` (no parentheses).\n- Types that already include `(p,s)` like `numeric(38,3)` are fine and must be left alone.\n- Only columns inside enforced-contract models trigger the warning; bare numeric on non-contracted\n  models is not affected.",
+        "fixing": "- For each flagged column, replace the bare type with an explicit precision/scale, e.g.\n  `data_type: numeric` -> `data_type: numeric(38,3)`.\n- Choose precision/scale from evidence in this order:\n- (1) an existing cast in the model SQL (e.g. `cast(x as numeric(18,2))`) \u2014 match it;\n- (2) the warehouse's documented default for unqualified numeric if the model is already built\n  (Snowflake NUMBER default is (38,0); Redshift/Postgres NUMERIC default is (38,0));\n- (3) if unknown, use a safe wide default `numeric(38,6)` and note the assumption in the results\n  report.\n- Preserve YAML quoting/style.\n- After editing, run `dbt parse`; if it fails, the likely cause is a mismatched type name for the\n  adapter (e.g. Snowflake prefers `number(38,3)`) \u2014 retry with the adapter-native spelling.\n- If the correct precision genuinely cannot be determined, leave the column and record it in the\n  results artifact (target/dbt_migration_results.json) as manual-required for the user to confirm."
+      },
+      "_path": "kb/core/1_6_003.yaml"
+    },
+    {
+      "issue_id": "1_6_010",
+      "sort_order": 4100,
+      "change": "server_side_parameters values coerced to strings",
+      "action": "Review server_side_parameters that use non-string values; they are now str()-coerced (e.g. True -> \"True\")",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "spark",
+      "impact": "server_side_parameters is now typed Dict[str, str] with str() coercion; non-string values are converted, so booleans/ints render as their Python str form (True -> \"True\" with a capital T, 1 -> \"1\")",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep for `server_side_parameters` in `profiles.yml` (`outputs.<target>`), `dbt_project.yml`,\n  model config() blocks, and schema YAML `config:` blocks.\n- Inspect the mapped values: flag any value that is not already a quoted string \u2014 YAML bare\n  `true`/`false` (parsed as booleans), bare integers/floats, or Jinja expressions producing\n  non-strings.\n- String values are unaffected.",
+        "fixing": "- This is a behavior change with no parse impact.\n- For each non-string value, decide the intended wire value and make it an explicit string so the\n  coercion is predictable.\n- Example: if Spark expects lowercase `true`, write `'true'` as a quoted string rather than YAML\n  boolean `true` (which str()-coerces to `\"True\"` with a capital T and may be rejected by Spark).\n- Edit the value in place (quote it / normalize case) and record in the results report.\n- Where the config lives in `profiles.yml` outside the repo, record the recommendation in the\n  results artifact (target/dbt_migration_results.json) as manual-required instead.\n- If unsure of the exact string Spark expects for a given parameter, leave it and flag it for the\n  user rather than guessing.\n- Real effect is validated in the warehouse build-green layer."
+      },
+      "_path": "kb/spark/1_6_010.yaml"
+    },
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_4_bigquery.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_4_bigquery.json
@@ -1,0 +1,852 @@
+{
+  "from_version": "1.4",
+  "warehouse": "bigquery",
+  "target_version": "1.12",
+  "count": 39,
+  "issues": [
+    {
+      "issue_id": "1_4_001",
+      "sort_order": 2010,
+      "change": "--select/--exclude now accumulate when passed multiple times (argparse -> Click)",
+      "action": "Review scripts/jobs passing --select or --exclude more than once; collapse to a single flag with the intended union",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Scripts relying on last-wins override now see both selections combined, selecting more nodes than intended",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep in-repo invocation sites for repeated selection flags on a single command: shell scripts\n  (*.sh), Makefiles, CI YAML (.github/**, .gitlab-ci.yml, azure-pipelines.yml), tox.ini, and dbt\n  wrapper scripts.\n- Pattern: one dbt command containing two or more `--select`/`-s` or `--exclude` tokens (regex\n  `(--select|--exclude|-s)\\b.*\\b(--select|--exclude|-s)\\b`).\n- The real risk lives OUTSIDE the repo in dbt platform job definitions, so in-repo presence may be\n  zero even when the project is affected.",
+        "fixing": "- For each in-repo command with duplicated selection flags, decide intent: pre-1.5 was last-wins (only\n  the final flag applied); 1.5+ is union (all applied).\n- If the old intent was 'use only the last selection', delete the earlier occurrences. If a union was\n  intended, it already works \u2014 leave it.\n- Example: `dbt run --select tag:nightly --select my_model` (1.4 ran only my_model) -> `dbt run\n  --select my_model`.\n- Not visible to dbt parse.\n- ALWAYS add a results entry (manual-required): dbt platform job commands and orchestration outside\n  this repo may pass the flags multiple times; list the affected in-repo sites and tell the user to\n  audit job definitions."
+      },
+      "_path": "kb/core/1_4_001.yaml"
+    },
+    {
+      "issue_id": "1_4_002",
+      "sort_order": 2020,
+      "change": "Duplicate CLI flags before and after the subcommand now raise an error",
+      "action": "Ensure each CLI flag appears only once per dbt invocation",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands like `dbt --flag run --flag` now fail instead of silently taking one value",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan in-repo dbt invocation sites (shell scripts, Makefiles, CI YAML, tox.ini, wrapper scripts) for\n  a single dbt command repeating the same flag, especially placed both before and after the\n  subcommand.\n- Examples: `dbt --debug run --debug`, or a repeated `--profiles-dir` / `--target` / `--vars`.\n- Likeliest offenders: global flags (--debug, --profiles-dir, --project-dir, --target, --log-format)\n  appearing twice.\n- As with selection flags, the primary risk is in dbt platform job commands outside the repo.",
+        "fixing": "- Remove the duplicate occurrence, keeping the one with the intended value (pre-1.5 resolved to a\n  single value, so pick that).\n- Example: `dbt --target prod run --target prod` -> `dbt run --target prod`.\n- If two occurrences carry DIFFERENT values it was already ambiguous \u2014 keep the value the user\n  confirms and record the resolution in the migration log.\n- Not visible to dbt parse.\n- Add a results entry (manual-required) directing the user to audit external job/orchestration\n  commands for duplicated flags, since those now hard-error."
+      },
+      "_path": "kb/core/1_4_002.yaml"
+    },
+    {
+      "issue_id": "1_4_003",
+      "sort_order": 2030,
+      "change": "log-path in dbt_project.yml deprecated",
+      "action": "Move log-path out of dbt_project.yml to the --log-path CLI flag or DBT_LOG_PATH env var",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning at parse time; becomes fatal under --warn-error",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for a top-level `log-path:` key (regex `^\\s*log-path\\s*:`). Present if the key\n  exists with any value.\n- Only one location to check.",
+        "fixing": "- Remove the `log-path:` key from dbt_project.yml.\n- Re-provision out-of-repo: either the `--log-path <dir>` CLI flag on dbt invocations or the\n  `DBT_LOG_PATH` env var.\n- Because the effective destination now lives in job commands / env config outside this repo, add a\n  results entry recording the old value and telling the user to set --log-path/DBT_LOG_PATH wherever\n  dbt is invoked (CI, dbt platform jobs).\n- After removing the key, run dbt parse; the deprecation warning should be gone.\n- If parse still warns, confirm no other config file (a profiles-level or imported yml) re-declares\n  log-path."
+      },
+      "_path": "kb/core/1_4_003.yaml"
+    },
+    {
+      "issue_id": "1_4_004",
+      "sort_order": 2040,
+      "change": "target-path in dbt_project.yml deprecated",
+      "action": "Move target-path out of dbt_project.yml to the --target-path CLI flag or DBT_TARGET_PATH env var",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning at parse time; becomes fatal under --warn-error",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for a top-level `target-path:` key (regex `^\\s*target-path\\s*:`). Present if\n  the key exists.",
+        "fixing": "- Remove the `target-path:` key from dbt_project.yml.\n- Re-provision via the `--target-path <dir>` CLI flag or `DBT_TARGET_PATH` env var wherever dbt runs.\n- Add a results entry recording the old value and directing the user to set\n  --target-path/DBT_TARGET_PATH in job commands / CI / dbt platform, since anything reading generated\n  artifacts (manifest.json, run_results.json) from the custom path must be pointed at the new\n  location.\n- After removal, run dbt parse to confirm the warning is cleared."
+      },
+      "_path": "kb/core/1_4_004.yaml"
+    },
+    {
+      "issue_id": "1_4_005",
+      "sort_order": 2050,
+      "change": "DBT_NO_PRINT environment variable deprecated in favor of DBT_PRINT",
+      "action": "Replace DBT_NO_PRINT=true with DBT_PRINT=false",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for the literal `DBT_NO_PRINT` in CI YAML (.github/**, .gitlab-ci.yml, etc.),\n  Dockerfiles, .env / *.env files, shell scripts, Makefiles, and tox.ini. Present if the token appears\n  anywhere.\n- The variable is frequently set in orchestration outside the repo, so an in-repo miss does not mean\n  the project is clear.",
+        "fixing": "- Translate the value: DBT_NO_PRINT=true (suppress prints) becomes DBT_PRINT=false; DBT_NO_PRINT=false\n  becomes DBT_PRINT=true.\n- Update every in-repo occurrence found.\n- This is an env-var rename, not a Python-environment change, so it is a normal advisory edit (not\n  environment_change) and is not verified by dbt parse.\n- Add a results entry telling the user to replace DBT_NO_PRINT in external CI / dbt platform\n  environment settings with DBT_PRINT (inverted value)."
+      },
+      "_path": "kb/core/1_4_005.yaml"
+    },
+    {
+      "issue_id": "1_4_006",
+      "sort_order": 2060,
+      "change": "DBT_ARTIFACT_STATE_PATH environment variable deprecated in favor of DBT_STATE",
+      "action": "Replace DBT_ARTIFACT_STATE_PATH with DBT_STATE",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_ARTIFACT_STATE_PATH` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Commonly used in Slim CI / state-deferral setups that live in orchestration outside the repo.",
+        "fixing": "- Rename the variable to `DBT_STATE`, keeping the same value (path to the state/manifest directory).\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry telling the user to rename DBT_ARTIFACT_STATE_PATH to DBT_STATE in external CI\n  and dbt platform job environments used for state:modified / --defer selection."
+      },
+      "_path": "kb/core/1_4_006.yaml"
+    },
+    {
+      "issue_id": "1_4_007",
+      "sort_order": 2070,
+      "change": "DBT_FAVOR_STATE_MODE environment variable deprecated in favor of DBT_FAVOR_STATE",
+      "action": "Replace DBT_FAVOR_STATE_MODE with DBT_FAVOR_STATE",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_FAVOR_STATE_MODE` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Typically set in state-based CI selection outside the repo.",
+        "fixing": "- Rename to `DBT_FAVOR_STATE`, preserving the value.\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry directing the user to rename this variable in external CI / dbt platform\n  environments."
+      },
+      "_path": "kb/core/1_4_007.yaml"
+    },
+    {
+      "issue_id": "1_4_008",
+      "sort_order": 2080,
+      "change": "DBT_DEFER_TO_STATE environment variable deprecated in favor of DBT_DEFER",
+      "action": "Replace DBT_DEFER_TO_STATE with DBT_DEFER",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_DEFER_TO_STATE` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Used in --defer based CI workflows that usually live outside the repo.",
+        "fixing": "- Rename to `DBT_DEFER`, preserving the boolean value.\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry directing the user to rename DBT_DEFER_TO_STATE to DBT_DEFER in external CI /\n  dbt platform environments."
+      },
+      "_path": "kb/core/1_4_008.yaml"
+    },
+    {
+      "issue_id": "1_4_015",
+      "sort_order": 2150,
+      "change": "insert_overwrite partition collection now adds IGNORE NULLS",
+      "action": "Review incremental models with insert_overwrite that may have NULL partition values",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "bigquery",
+      "impact": "Rows whose partition column is NULL no longer trigger partition overwrites under insert_overwrite",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Find BigQuery incremental models using insert_overwrite with dynamic partitions: models/**/*.sql\n  with `materialized='incremental'` (or YAML config) AND `incremental_strategy='insert_overwrite'` AND\n  a `partition_by=` config, where `partitions` is not statically supplied.\n- The behavior change matters only if the partitioning column can be NULL for some rows.\n- Grep model SQL for the partition column and assess whether NULLs are possible (no NOT NULL\n  guarantee, nullable source).",
+        "fixing": "- Usually NO code change is required \u2014 this is a correctness improvement (NULL-partition rows\n  previously overwrote partitions unexpectedly).\n- Action is to REVIEW: if a model legitimately relies on a NULL/`__NULL__` partition being\n  overwritten, coalesce the partition column to a sentinel non-NULL value before partitioning, or\n  handle those rows explicitly.\n- Invisible to dbt parse and not warehouse-verifiable here.\n- For any model where NULL partition rows are plausible and behavior could change, record a results\n  entry naming the model and column so the user can confirm against real data; otherwise mark\n  skipped-not-present."
+      },
+      "_path": "kb/bigquery/1_4_015.yaml"
+    },
+    {
+      "issue_id": "1_5_001",
+      "sort_order": 3010,
+      "change": "Metric YAML schema completely rewritten for MetricFlow",
+      "action": "Rewrite all metric definitions using the new type/type_params/filter format",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "All existing metric YAML definitions fail to parse in 1.6; the pre-1.6 UnparsedMetric fields (calculation_method, expression, sql, model, type: expression) and the rename_metric_attr compatibility shim were removed.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Search every YAML file under models/ and any schema-file globs declared in dbt_project.yml\n  (models/**/*.yml, models/**/*.yaml, plus any top-level metrics/ dir) for a `metrics:` block.\n- Flag a metric as legacy (pre-1.6) if its entry uses ANY of these keys: `calculation_method`,\n  `expression`, `sql`, `type: expression`, a top-level `type:` with the old enum\n  (`count`/`sum`/...), `model:`, `timestamp:`, `time_grains:`, `dimensions:` directly on the\n  metric, or `filters:` (the list-of-dict old form).\n- The new MetricFlow schema instead uses `type:` with values simple|ratio|cumulative|derived\n  plus a `type_params:` block. If a metric already has `type_params:`, it is migrated \u2014 skip it.\n- Also grep packages.yml for `dbt_metrics` usage and models for `metrics.calculate(` /\n  `metrics.develop(` macro calls \u2014 those depend on the old package and must be flagged too.",
+        "fixing": "- Rewrite each legacy metric into the new schema. Attribute mapping:\n  - `calculation_method` -> `type`: sum/average/min/max/count/count_distinct/median become\n    `type: simple` with `type_params.measure`; derived/expression become `type: derived` with\n    `type_params.expr` and `type_params.metrics`.\n  - `expression`/`sql` -> `type_params.measure` (the semantic measure name), or\n    `type_params.expr` for a derived metric.\n  - `model:` -> moves into a `semantic_models:` definition (see example below).\n  - `filters:` -> `filter:` (a single `{{ Dimension(...) }}` string, or keep the WHERE fragment).\n- Concrete before/after:\n  BEFORE (1.5):\n    metrics:\n      - name: total_revenue\n        calculation_method: sum\n        expression: amount\n        model: ref('orders')\n        timestamp: order_date\n        time_grains: [day, month]\n        dimensions: [status]\n  AFTER (1.6, MetricFlow):\n    semantic_models:\n      - name: orders\n        model: ref('orders')\n        defaults:\n          agg_time_dimension: order_date\n        entities:\n          - name: order\n            type: primary\n        dimensions:\n          - name: order_date\n            type: time\n            type_params: {time_granularity: day}\n          - name: status\n            type: categorical\n        measures:\n          - name: amount\n            agg: sum\n            agg_time_dimension: order_date\n    metrics:\n      - name: total_revenue\n        type: simple\n        type_params:\n          measure: amount\n- Derived example: `calculation_method: derived` + `expression: revenue - cost` becomes\n  `type: derived` with `type_params: {expr: 'revenue - cost', metrics: [{name: revenue},\n  {name: cost}]}`.\n- Judgment-heavy: 1.6 requires a `semantic_models:` layer that did not exist in 1.5, so the\n  measure/entity/dimension split cannot always be inferred mechanically.\n- If you cannot confidently reconstruct the semantic model (e.g. the source model's grain or\n  entities are ambiguous), do NOT guess \u2014 record the metric in the results report with\n  the original YAML and the suggested new shape, and move on.\n- After editing, run `dbt parse`. On a metric/semantic-model validation error, re-read it;\n  reverting to legacy form is NOT an option (it won't parse in 1.6) \u2014 instead leave the\n  semantic_model skeleton and flag it manual.\n- Remove `dbt_metrics` / `metrics.calculate` usages and flag them as requiring the\n  MetricFlow / Semantic Layer migration (out of scope for parse)."
+      },
+      "_path": "kb/core/1_5_001.yaml"
+    },
+    {
+      "issue_id": "1_5_002",
+      "sort_order": 3020,
+      "change": "Duplicate node names allowed across packages",
+      "action": "Disambiguate cross-package references with two-argument ref('package_name', 'model_name')",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.5 a flat manifest dict raised DuplicateResourceNameError; in 1.6 names are stored per-package, so a project and an installed package can legitimately share a model name. Single-argument ref() to a name that exists in more than one package becomes ambiguous (AmbiguousAliasError / wrong node).",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant if packages.yml / dependencies.yml declares packages.\n- Build the set of model/seed/snapshot names defined in the local project (models/**/*.sql,\n  seeds/**/*.csv, snapshots/**/*.sql).\n- Where available, add the names exposed by installed packages under dbt_packages/*/models.\n- Grep all .sql/.yml for single-argument `ref('name')` / `ref(\"name\")` whose `name` collides\n  with a name present in BOTH the local project and a package (or in two packages) \u2014 those are\n  the ambiguous refs.\n- If no packages are installed, mark skipped-not-present.",
+        "fixing": "- For each ambiguous single-arg ref, rewrite to the two-argument form\n  `ref('<package_name>', '<model_name>')`.\n- Choose the package the author intended; default to the local project's own model unless the\n  surrounding SQL clearly consumes the package's version.\n- Example: `ref('customers')` -> `ref('my_project', 'customers')` or\n  `ref('dbt_utils', 'customers')`. Leave unambiguous refs untouched.\n- After edits run `dbt parse`; a remaining AmbiguousAliasError names the offending ref and node.\n- If you cannot determine which package is intended, record it in the results report\n  rather than guessing \u2014 picking the wrong package silently changes lineage."
+      },
+      "_path": "kb/core/1_5_002.yaml"
+    },
+    {
+      "issue_id": "1_5_003",
+      "sort_order": 3030,
+      "change": "collect_freshness macro return type changed",
+      "action": "Update any custom collect_freshness macro override to return the full result object (table + response) instead of just the table",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.6 core's default collect_freshness returns a dict-like {table, response} object; a custom override that returns only the agate table triggers a deprecation warning and will break source freshness in later versions.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/**/*.sql for a macro named `collect_freshness` (i.e. `{% macro collect_freshness(`\n  or `{% macro <adapter>__collect_freshness(`).\n- If none exists, the project uses core's implementation \u2014 mark skipped-not-present.\n- If one exists, inspect its final `{{ return(...) }}` and flag it if it returns the query\n  result table directly (e.g. `return(load_result('collect_freshness').table)` or\n  `return(table)`) rather than the full result object.",
+        "fixing": "- Change the macro to capture the full result and return an object exposing both the table and\n  the adapter response.\n- Pattern: `{% set result = run_query(...) %}` then\n  `{{ return({'table': result.table, 'response': result.response}) }}`.\n- Mirror core's 1.6 signature: it returns `load_result('collect_freshness')`, which already has\n  `.table` and `.response`.\n- Simplest safe fix, if the override only existed to tweak the SQL: align the return statement\n  with core 1.6's macro body.\n- After editing run `dbt parse`.\n- If the override is complex or the intended response object is unclear, record it in the\n  results report with a pointer to core's 1.6 collect_freshness for reference."
+      },
+      "_path": "kb/core/1_5_003.yaml"
+    },
+    {
+      "issue_id": "1_6_011",
+      "sort_order": 4005,
+      "change": "dbt clean errors when clean-targets include source paths or paths outside the project",
+      "action": "Remove source paths (e.g. models/, macros/) and any path outside the project directory from clean-targets in dbt_project.yml",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "dbt clean now raises an error instead of silently deleting the wrong directories when clean-targets references source paths or paths outside the project root",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml's clean-targets list.\n- Flag any entry that resolves (relative to the project root) to a configured source path\n  (model-paths, seed-paths, macro-paths, etc.) or that resolves outside the project directory\n  (e.g. ../shared, /absolute/path).",
+        "fixing": "- Remove the offending entries from clean-targets, keeping only build/output directories\n  (e.g. target, dbt_packages, logs).\n- Re-run dbt clean to confirm it no longer errors."
+      },
+      "_path": "kb/core/1_6_011.yaml"
+    },
+    {
+      "issue_id": "1_6_001",
+      "sort_order": 4010,
+      "change": "New warning when --state and --target point to the same directory",
+      "action": "Fix --state/--target configuration so they reference distinct directories",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "WarnStateTargetEqual raised (informational) for previously silent misconfiguration; fatal under --warn-error",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- This is a runtime CLI/job configuration issue, not a repo-source issue, so `dbt parse` cannot\n  surface it. Detect by scanning invocation sites, not models.\n- Grep the repo for `--state` and `--target` / `--target-path` in shell scripts, Makefiles, and\n  `scripts/**/*.sh`.\n- Also grep CI configs: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `tox.ini`.\n- Check `dbt_project.yml` for a `target-path:` key (deprecated since 1.5 but may still be present).\n- Check for `DBT_STATE` / `DBT_TARGET_PATH` env vars in CI.\n- Flag any invocation where `--state` and `--target`/`--target-path` resolve to the same directory\n  (commonly both set to `target/`).\n- Note the value is frequently supplied outside the repo (dbt platform job definitions,\n  orchestration tools), which parse cannot see.",
+        "fixing": "- Point `--state` at a directory separate from the run's `--target` \u2014 e.g. keep run output in\n  `target/` and the comparison manifest in a distinct dir such as `state/` or `prod-artifacts/`.\n- Concretely, in the offending script/CI step change the duplicated paths so a command like\n  `dbt build --state ./state --target-path ./target` uses different dirs, and populate the state\n  artifacts there.\n- If the same-directory usage lives outside the repo (a dbt platform job command, an orchestration\n  tool), it cannot be edited from the repo.\n- For that out-of-repo case: record it in the results artifact (target/dbt_migration_results.json)\n  as manual-required with the issue_id, the invocation location if known, and the suggested command\n  change, then prompt the user.\n- This change never requires a repo edit to pass `dbt parse`; it is advisory / out-of-repo only."
+      },
+      "_path": "kb/core/1_6_001.yaml"
+    },
+    {
+      "issue_id": "1_6_002",
+      "sort_order": 4020,
+      "change": "Breaking contract changes on unversioned models now warn instead of error",
+      "action": "Add --warn-error (or version the models) to retain the previous hard-error behavior on breaking contract changes",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Unversioned models with a breaking schema/contract change warn via warn_or_error() instead of erroring; CI that relied on the error to block may now pass silently",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan schema YAML (`models/**/*.yml`, `models/**/*.yaml`) for models declaring `contract:` with\n  `enforced: true` that do NOT declare a `version:` / `versions:` block (i.e. unversioned).\n- Those unversioned enforced-contract models are the ones whose breaking contract changes now only\n  warn.\n- Also detect reliance on the old error behavior: grep CI/scripts for `dbt build` / `dbt run`\n  invocations that lack `--warn-error` or `--warn-error-options`.\n- Those flags are what previously turned the contract breakage into a hard failure.\n- This is a behavior/policy change; `dbt parse` stays clean either way, so detection is about intent,\n  not parse errors.",
+        "fixing": "- Preferred: preserve strict behavior by adding `--warn-error` (or a scoped `--warn-error-options`\n  targeting contract deprecations) to the relevant dbt invocation.\n- If that invocation is defined outside the repo (dbt platform job command, orchestration tool), it\n  cannot be edited here: record it in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the suggested flag, and prompt the user.\n- Alternative in-repo fix: add a `version:` to the affected models \u2014 versioning makes breaking\n  contract changes error again.\n- But versioning reshapes ref() resolution and downstream references, so only do it when the user\n  explicitly wants versioned models; note that trade-off in the results report rather than silently\n  versioning.\n- No edit is required for `dbt parse` to succeed."
+      },
+      "_path": "kb/core/1_6_002.yaml"
+    },
+    {
+      "issue_id": "1_6_003",
+      "sort_order": 4030,
+      "change": "New warning for contracted models with bare numeric columns (no precision/scale)",
+      "action": "Add explicit precision and scale to numeric column data_types in enforced contracts (e.g. numeric(38,3))",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with 'data_type: numeric' (or 'decimal') and no precision/scale in an enforced contract now emit a warning at parse time in 1.7",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- In schema YAML (`models/**/*.yml`, `models/**/*.yaml`), find models with `contract:`\n  `enforced: true` and columns whose `data_type` is a bare numeric type with no precision/scale.\n- Match the data_type value (case-insensitive) against `^(numeric|decimal|number)$` (no parentheses).\n- Types that already include `(p,s)` like `numeric(38,3)` are fine and must be left alone.\n- Only columns inside enforced-contract models trigger the warning; bare numeric on non-contracted\n  models is not affected.",
+        "fixing": "- For each flagged column, replace the bare type with an explicit precision/scale, e.g.\n  `data_type: numeric` -> `data_type: numeric(38,3)`.\n- Choose precision/scale from evidence in this order:\n- (1) an existing cast in the model SQL (e.g. `cast(x as numeric(18,2))`) \u2014 match it;\n- (2) the warehouse's documented default for unqualified numeric if the model is already built\n  (Snowflake NUMBER default is (38,0); Redshift/Postgres NUMERIC default is (38,0));\n- (3) if unknown, use a safe wide default `numeric(38,6)` and note the assumption in the results\n  report.\n- Preserve YAML quoting/style.\n- After editing, run `dbt parse`; if it fails, the likely cause is a mismatched type name for the\n  adapter (e.g. Snowflake prefers `number(38,3)`) \u2014 retry with the adapter-native spelling.\n- If the correct precision genuinely cannot be determined, leave the column and record it in the\n  results artifact (target/dbt_migration_results.json) as manual-required for the user to confirm."
+      },
+      "_path": "kb/core/1_6_003.yaml"
+    },
+    {
+      "issue_id": "1_6_006",
+      "sort_order": 4060,
+      "change": "job_execution_timeout now actually cancels queries via asyncio",
+      "action": "Review all job_execution_timeout_seconds values and increase them where legitimate long-running queries could now be cancelled",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "bigquery",
+      "impact": "Queries exceeding job_execution_timeout_seconds are now actually cancelled and error; previously the timeout was passed but not enforced, so long queries silently ran to completion",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep for `job_execution_timeout_seconds` across the project: `profiles.yml`\n  (`outputs.<target>`), `dbt_project.yml` (`models:` config), model config() blocks, and schema\n  YAML `config:` blocks.\n- Any value set low relative to real query runtimes is now a live cancellation risk.\n- This is a runtime/behavior change invisible to `dbt parse`.",
+        "fixing": "- No edit is needed to pass parse or reach 1.8. The action is protective.\n- For each configured job_execution_timeout_seconds, assess whether real models run longer than the\n  value; if so, raise it (e.g. comfortably above observed p99 runtime) in the same location it is\n  configured.\n- Where the value lives in `profiles.yml` outside the repo, record the recommendation in the\n  results artifact (target/dbt_migration_results.json) as manual-required instead of editing.\n- If no timeout is set anywhere, BigQuery's own default applies and there is nothing to change \u2014\n  note it and move on.\n- Do not lower any timeouts. True impact is only observable in the warehouse build-green layer."
+      },
+      "_path": "kb/bigquery/1_6_006.yaml"
+    },
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_4_core.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_4_core.json
@@ -1,0 +1,812 @@
+{
+  "from_version": "1.4",
+  "warehouse": "core",
+  "target_version": "1.12",
+  "count": 37,
+  "issues": [
+    {
+      "issue_id": "1_4_001",
+      "sort_order": 2010,
+      "change": "--select/--exclude now accumulate when passed multiple times (argparse -> Click)",
+      "action": "Review scripts/jobs passing --select or --exclude more than once; collapse to a single flag with the intended union",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Scripts relying on last-wins override now see both selections combined, selecting more nodes than intended",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep in-repo invocation sites for repeated selection flags on a single command: shell scripts\n  (*.sh), Makefiles, CI YAML (.github/**, .gitlab-ci.yml, azure-pipelines.yml), tox.ini, and dbt\n  wrapper scripts.\n- Pattern: one dbt command containing two or more `--select`/`-s` or `--exclude` tokens (regex\n  `(--select|--exclude|-s)\\b.*\\b(--select|--exclude|-s)\\b`).\n- The real risk lives OUTSIDE the repo in dbt platform job definitions, so in-repo presence may be\n  zero even when the project is affected.",
+        "fixing": "- For each in-repo command with duplicated selection flags, decide intent: pre-1.5 was last-wins (only\n  the final flag applied); 1.5+ is union (all applied).\n- If the old intent was 'use only the last selection', delete the earlier occurrences. If a union was\n  intended, it already works \u2014 leave it.\n- Example: `dbt run --select tag:nightly --select my_model` (1.4 ran only my_model) -> `dbt run\n  --select my_model`.\n- Not visible to dbt parse.\n- ALWAYS add a results entry (manual-required): dbt platform job commands and orchestration outside\n  this repo may pass the flags multiple times; list the affected in-repo sites and tell the user to\n  audit job definitions."
+      },
+      "_path": "kb/core/1_4_001.yaml"
+    },
+    {
+      "issue_id": "1_4_002",
+      "sort_order": 2020,
+      "change": "Duplicate CLI flags before and after the subcommand now raise an error",
+      "action": "Ensure each CLI flag appears only once per dbt invocation",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands like `dbt --flag run --flag` now fail instead of silently taking one value",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan in-repo dbt invocation sites (shell scripts, Makefiles, CI YAML, tox.ini, wrapper scripts) for\n  a single dbt command repeating the same flag, especially placed both before and after the\n  subcommand.\n- Examples: `dbt --debug run --debug`, or a repeated `--profiles-dir` / `--target` / `--vars`.\n- Likeliest offenders: global flags (--debug, --profiles-dir, --project-dir, --target, --log-format)\n  appearing twice.\n- As with selection flags, the primary risk is in dbt platform job commands outside the repo.",
+        "fixing": "- Remove the duplicate occurrence, keeping the one with the intended value (pre-1.5 resolved to a\n  single value, so pick that).\n- Example: `dbt --target prod run --target prod` -> `dbt run --target prod`.\n- If two occurrences carry DIFFERENT values it was already ambiguous \u2014 keep the value the user\n  confirms and record the resolution in the migration log.\n- Not visible to dbt parse.\n- Add a results entry (manual-required) directing the user to audit external job/orchestration\n  commands for duplicated flags, since those now hard-error."
+      },
+      "_path": "kb/core/1_4_002.yaml"
+    },
+    {
+      "issue_id": "1_4_003",
+      "sort_order": 2030,
+      "change": "log-path in dbt_project.yml deprecated",
+      "action": "Move log-path out of dbt_project.yml to the --log-path CLI flag or DBT_LOG_PATH env var",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning at parse time; becomes fatal under --warn-error",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for a top-level `log-path:` key (regex `^\\s*log-path\\s*:`). Present if the key\n  exists with any value.\n- Only one location to check.",
+        "fixing": "- Remove the `log-path:` key from dbt_project.yml.\n- Re-provision out-of-repo: either the `--log-path <dir>` CLI flag on dbt invocations or the\n  `DBT_LOG_PATH` env var.\n- Because the effective destination now lives in job commands / env config outside this repo, add a\n  results entry recording the old value and telling the user to set --log-path/DBT_LOG_PATH wherever\n  dbt is invoked (CI, dbt platform jobs).\n- After removing the key, run dbt parse; the deprecation warning should be gone.\n- If parse still warns, confirm no other config file (a profiles-level or imported yml) re-declares\n  log-path."
+      },
+      "_path": "kb/core/1_4_003.yaml"
+    },
+    {
+      "issue_id": "1_4_004",
+      "sort_order": 2040,
+      "change": "target-path in dbt_project.yml deprecated",
+      "action": "Move target-path out of dbt_project.yml to the --target-path CLI flag or DBT_TARGET_PATH env var",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning at parse time; becomes fatal under --warn-error",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for a top-level `target-path:` key (regex `^\\s*target-path\\s*:`). Present if\n  the key exists.",
+        "fixing": "- Remove the `target-path:` key from dbt_project.yml.\n- Re-provision via the `--target-path <dir>` CLI flag or `DBT_TARGET_PATH` env var wherever dbt runs.\n- Add a results entry recording the old value and directing the user to set\n  --target-path/DBT_TARGET_PATH in job commands / CI / dbt platform, since anything reading generated\n  artifacts (manifest.json, run_results.json) from the custom path must be pointed at the new\n  location.\n- After removal, run dbt parse to confirm the warning is cleared."
+      },
+      "_path": "kb/core/1_4_004.yaml"
+    },
+    {
+      "issue_id": "1_4_005",
+      "sort_order": 2050,
+      "change": "DBT_NO_PRINT environment variable deprecated in favor of DBT_PRINT",
+      "action": "Replace DBT_NO_PRINT=true with DBT_PRINT=false",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for the literal `DBT_NO_PRINT` in CI YAML (.github/**, .gitlab-ci.yml, etc.),\n  Dockerfiles, .env / *.env files, shell scripts, Makefiles, and tox.ini. Present if the token appears\n  anywhere.\n- The variable is frequently set in orchestration outside the repo, so an in-repo miss does not mean\n  the project is clear.",
+        "fixing": "- Translate the value: DBT_NO_PRINT=true (suppress prints) becomes DBT_PRINT=false; DBT_NO_PRINT=false\n  becomes DBT_PRINT=true.\n- Update every in-repo occurrence found.\n- This is an env-var rename, not a Python-environment change, so it is a normal advisory edit (not\n  environment_change) and is not verified by dbt parse.\n- Add a results entry telling the user to replace DBT_NO_PRINT in external CI / dbt platform\n  environment settings with DBT_PRINT (inverted value)."
+      },
+      "_path": "kb/core/1_4_005.yaml"
+    },
+    {
+      "issue_id": "1_4_006",
+      "sort_order": 2060,
+      "change": "DBT_ARTIFACT_STATE_PATH environment variable deprecated in favor of DBT_STATE",
+      "action": "Replace DBT_ARTIFACT_STATE_PATH with DBT_STATE",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_ARTIFACT_STATE_PATH` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Commonly used in Slim CI / state-deferral setups that live in orchestration outside the repo.",
+        "fixing": "- Rename the variable to `DBT_STATE`, keeping the same value (path to the state/manifest directory).\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry telling the user to rename DBT_ARTIFACT_STATE_PATH to DBT_STATE in external CI\n  and dbt platform job environments used for state:modified / --defer selection."
+      },
+      "_path": "kb/core/1_4_006.yaml"
+    },
+    {
+      "issue_id": "1_4_007",
+      "sort_order": 2070,
+      "change": "DBT_FAVOR_STATE_MODE environment variable deprecated in favor of DBT_FAVOR_STATE",
+      "action": "Replace DBT_FAVOR_STATE_MODE with DBT_FAVOR_STATE",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_FAVOR_STATE_MODE` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Typically set in state-based CI selection outside the repo.",
+        "fixing": "- Rename to `DBT_FAVOR_STATE`, preserving the value.\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry directing the user to rename this variable in external CI / dbt platform\n  environments."
+      },
+      "_path": "kb/core/1_4_007.yaml"
+    },
+    {
+      "issue_id": "1_4_008",
+      "sort_order": 2080,
+      "change": "DBT_DEFER_TO_STATE environment variable deprecated in favor of DBT_DEFER",
+      "action": "Replace DBT_DEFER_TO_STATE with DBT_DEFER",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_DEFER_TO_STATE` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Used in --defer based CI workflows that usually live outside the repo.",
+        "fixing": "- Rename to `DBT_DEFER`, preserving the boolean value.\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry directing the user to rename DBT_DEFER_TO_STATE to DBT_DEFER in external CI /\n  dbt platform environments."
+      },
+      "_path": "kb/core/1_4_008.yaml"
+    },
+    {
+      "issue_id": "1_5_001",
+      "sort_order": 3010,
+      "change": "Metric YAML schema completely rewritten for MetricFlow",
+      "action": "Rewrite all metric definitions using the new type/type_params/filter format",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "All existing metric YAML definitions fail to parse in 1.6; the pre-1.6 UnparsedMetric fields (calculation_method, expression, sql, model, type: expression) and the rename_metric_attr compatibility shim were removed.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Search every YAML file under models/ and any schema-file globs declared in dbt_project.yml\n  (models/**/*.yml, models/**/*.yaml, plus any top-level metrics/ dir) for a `metrics:` block.\n- Flag a metric as legacy (pre-1.6) if its entry uses ANY of these keys: `calculation_method`,\n  `expression`, `sql`, `type: expression`, a top-level `type:` with the old enum\n  (`count`/`sum`/...), `model:`, `timestamp:`, `time_grains:`, `dimensions:` directly on the\n  metric, or `filters:` (the list-of-dict old form).\n- The new MetricFlow schema instead uses `type:` with values simple|ratio|cumulative|derived\n  plus a `type_params:` block. If a metric already has `type_params:`, it is migrated \u2014 skip it.\n- Also grep packages.yml for `dbt_metrics` usage and models for `metrics.calculate(` /\n  `metrics.develop(` macro calls \u2014 those depend on the old package and must be flagged too.",
+        "fixing": "- Rewrite each legacy metric into the new schema. Attribute mapping:\n  - `calculation_method` -> `type`: sum/average/min/max/count/count_distinct/median become\n    `type: simple` with `type_params.measure`; derived/expression become `type: derived` with\n    `type_params.expr` and `type_params.metrics`.\n  - `expression`/`sql` -> `type_params.measure` (the semantic measure name), or\n    `type_params.expr` for a derived metric.\n  - `model:` -> moves into a `semantic_models:` definition (see example below).\n  - `filters:` -> `filter:` (a single `{{ Dimension(...) }}` string, or keep the WHERE fragment).\n- Concrete before/after:\n  BEFORE (1.5):\n    metrics:\n      - name: total_revenue\n        calculation_method: sum\n        expression: amount\n        model: ref('orders')\n        timestamp: order_date\n        time_grains: [day, month]\n        dimensions: [status]\n  AFTER (1.6, MetricFlow):\n    semantic_models:\n      - name: orders\n        model: ref('orders')\n        defaults:\n          agg_time_dimension: order_date\n        entities:\n          - name: order\n            type: primary\n        dimensions:\n          - name: order_date\n            type: time\n            type_params: {time_granularity: day}\n          - name: status\n            type: categorical\n        measures:\n          - name: amount\n            agg: sum\n            agg_time_dimension: order_date\n    metrics:\n      - name: total_revenue\n        type: simple\n        type_params:\n          measure: amount\n- Derived example: `calculation_method: derived` + `expression: revenue - cost` becomes\n  `type: derived` with `type_params: {expr: 'revenue - cost', metrics: [{name: revenue},\n  {name: cost}]}`.\n- Judgment-heavy: 1.6 requires a `semantic_models:` layer that did not exist in 1.5, so the\n  measure/entity/dimension split cannot always be inferred mechanically.\n- If you cannot confidently reconstruct the semantic model (e.g. the source model's grain or\n  entities are ambiguous), do NOT guess \u2014 record the metric in the results report with\n  the original YAML and the suggested new shape, and move on.\n- After editing, run `dbt parse`. On a metric/semantic-model validation error, re-read it;\n  reverting to legacy form is NOT an option (it won't parse in 1.6) \u2014 instead leave the\n  semantic_model skeleton and flag it manual.\n- Remove `dbt_metrics` / `metrics.calculate` usages and flag them as requiring the\n  MetricFlow / Semantic Layer migration (out of scope for parse)."
+      },
+      "_path": "kb/core/1_5_001.yaml"
+    },
+    {
+      "issue_id": "1_5_002",
+      "sort_order": 3020,
+      "change": "Duplicate node names allowed across packages",
+      "action": "Disambiguate cross-package references with two-argument ref('package_name', 'model_name')",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.5 a flat manifest dict raised DuplicateResourceNameError; in 1.6 names are stored per-package, so a project and an installed package can legitimately share a model name. Single-argument ref() to a name that exists in more than one package becomes ambiguous (AmbiguousAliasError / wrong node).",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant if packages.yml / dependencies.yml declares packages.\n- Build the set of model/seed/snapshot names defined in the local project (models/**/*.sql,\n  seeds/**/*.csv, snapshots/**/*.sql).\n- Where available, add the names exposed by installed packages under dbt_packages/*/models.\n- Grep all .sql/.yml for single-argument `ref('name')` / `ref(\"name\")` whose `name` collides\n  with a name present in BOTH the local project and a package (or in two packages) \u2014 those are\n  the ambiguous refs.\n- If no packages are installed, mark skipped-not-present.",
+        "fixing": "- For each ambiguous single-arg ref, rewrite to the two-argument form\n  `ref('<package_name>', '<model_name>')`.\n- Choose the package the author intended; default to the local project's own model unless the\n  surrounding SQL clearly consumes the package's version.\n- Example: `ref('customers')` -> `ref('my_project', 'customers')` or\n  `ref('dbt_utils', 'customers')`. Leave unambiguous refs untouched.\n- After edits run `dbt parse`; a remaining AmbiguousAliasError names the offending ref and node.\n- If you cannot determine which package is intended, record it in the results report\n  rather than guessing \u2014 picking the wrong package silently changes lineage."
+      },
+      "_path": "kb/core/1_5_002.yaml"
+    },
+    {
+      "issue_id": "1_5_003",
+      "sort_order": 3030,
+      "change": "collect_freshness macro return type changed",
+      "action": "Update any custom collect_freshness macro override to return the full result object (table + response) instead of just the table",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.6 core's default collect_freshness returns a dict-like {table, response} object; a custom override that returns only the agate table triggers a deprecation warning and will break source freshness in later versions.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/**/*.sql for a macro named `collect_freshness` (i.e. `{% macro collect_freshness(`\n  or `{% macro <adapter>__collect_freshness(`).\n- If none exists, the project uses core's implementation \u2014 mark skipped-not-present.\n- If one exists, inspect its final `{{ return(...) }}` and flag it if it returns the query\n  result table directly (e.g. `return(load_result('collect_freshness').table)` or\n  `return(table)`) rather than the full result object.",
+        "fixing": "- Change the macro to capture the full result and return an object exposing both the table and\n  the adapter response.\n- Pattern: `{% set result = run_query(...) %}` then\n  `{{ return({'table': result.table, 'response': result.response}) }}`.\n- Mirror core's 1.6 signature: it returns `load_result('collect_freshness')`, which already has\n  `.table` and `.response`.\n- Simplest safe fix, if the override only existed to tweak the SQL: align the return statement\n  with core 1.6's macro body.\n- After editing run `dbt parse`.\n- If the override is complex or the intended response object is unclear, record it in the\n  results report with a pointer to core's 1.6 collect_freshness for reference."
+      },
+      "_path": "kb/core/1_5_003.yaml"
+    },
+    {
+      "issue_id": "1_6_011",
+      "sort_order": 4005,
+      "change": "dbt clean errors when clean-targets include source paths or paths outside the project",
+      "action": "Remove source paths (e.g. models/, macros/) and any path outside the project directory from clean-targets in dbt_project.yml",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "dbt clean now raises an error instead of silently deleting the wrong directories when clean-targets references source paths or paths outside the project root",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml's clean-targets list.\n- Flag any entry that resolves (relative to the project root) to a configured source path\n  (model-paths, seed-paths, macro-paths, etc.) or that resolves outside the project directory\n  (e.g. ../shared, /absolute/path).",
+        "fixing": "- Remove the offending entries from clean-targets, keeping only build/output directories\n  (e.g. target, dbt_packages, logs).\n- Re-run dbt clean to confirm it no longer errors."
+      },
+      "_path": "kb/core/1_6_011.yaml"
+    },
+    {
+      "issue_id": "1_6_001",
+      "sort_order": 4010,
+      "change": "New warning when --state and --target point to the same directory",
+      "action": "Fix --state/--target configuration so they reference distinct directories",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "WarnStateTargetEqual raised (informational) for previously silent misconfiguration; fatal under --warn-error",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- This is a runtime CLI/job configuration issue, not a repo-source issue, so `dbt parse` cannot\n  surface it. Detect by scanning invocation sites, not models.\n- Grep the repo for `--state` and `--target` / `--target-path` in shell scripts, Makefiles, and\n  `scripts/**/*.sh`.\n- Also grep CI configs: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `tox.ini`.\n- Check `dbt_project.yml` for a `target-path:` key (deprecated since 1.5 but may still be present).\n- Check for `DBT_STATE` / `DBT_TARGET_PATH` env vars in CI.\n- Flag any invocation where `--state` and `--target`/`--target-path` resolve to the same directory\n  (commonly both set to `target/`).\n- Note the value is frequently supplied outside the repo (dbt platform job definitions,\n  orchestration tools), which parse cannot see.",
+        "fixing": "- Point `--state` at a directory separate from the run's `--target` \u2014 e.g. keep run output in\n  `target/` and the comparison manifest in a distinct dir such as `state/` or `prod-artifacts/`.\n- Concretely, in the offending script/CI step change the duplicated paths so a command like\n  `dbt build --state ./state --target-path ./target` uses different dirs, and populate the state\n  artifacts there.\n- If the same-directory usage lives outside the repo (a dbt platform job command, an orchestration\n  tool), it cannot be edited from the repo.\n- For that out-of-repo case: record it in the results artifact (target/dbt_migration_results.json)\n  as manual-required with the issue_id, the invocation location if known, and the suggested command\n  change, then prompt the user.\n- This change never requires a repo edit to pass `dbt parse`; it is advisory / out-of-repo only."
+      },
+      "_path": "kb/core/1_6_001.yaml"
+    },
+    {
+      "issue_id": "1_6_002",
+      "sort_order": 4020,
+      "change": "Breaking contract changes on unversioned models now warn instead of error",
+      "action": "Add --warn-error (or version the models) to retain the previous hard-error behavior on breaking contract changes",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Unversioned models with a breaking schema/contract change warn via warn_or_error() instead of erroring; CI that relied on the error to block may now pass silently",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan schema YAML (`models/**/*.yml`, `models/**/*.yaml`) for models declaring `contract:` with\n  `enforced: true` that do NOT declare a `version:` / `versions:` block (i.e. unversioned).\n- Those unversioned enforced-contract models are the ones whose breaking contract changes now only\n  warn.\n- Also detect reliance on the old error behavior: grep CI/scripts for `dbt build` / `dbt run`\n  invocations that lack `--warn-error` or `--warn-error-options`.\n- Those flags are what previously turned the contract breakage into a hard failure.\n- This is a behavior/policy change; `dbt parse` stays clean either way, so detection is about intent,\n  not parse errors.",
+        "fixing": "- Preferred: preserve strict behavior by adding `--warn-error` (or a scoped `--warn-error-options`\n  targeting contract deprecations) to the relevant dbt invocation.\n- If that invocation is defined outside the repo (dbt platform job command, orchestration tool), it\n  cannot be edited here: record it in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the suggested flag, and prompt the user.\n- Alternative in-repo fix: add a `version:` to the affected models \u2014 versioning makes breaking\n  contract changes error again.\n- But versioning reshapes ref() resolution and downstream references, so only do it when the user\n  explicitly wants versioned models; note that trade-off in the results report rather than silently\n  versioning.\n- No edit is required for `dbt parse` to succeed."
+      },
+      "_path": "kb/core/1_6_002.yaml"
+    },
+    {
+      "issue_id": "1_6_003",
+      "sort_order": 4030,
+      "change": "New warning for contracted models with bare numeric columns (no precision/scale)",
+      "action": "Add explicit precision and scale to numeric column data_types in enforced contracts (e.g. numeric(38,3))",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with 'data_type: numeric' (or 'decimal') and no precision/scale in an enforced contract now emit a warning at parse time in 1.7",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- In schema YAML (`models/**/*.yml`, `models/**/*.yaml`), find models with `contract:`\n  `enforced: true` and columns whose `data_type` is a bare numeric type with no precision/scale.\n- Match the data_type value (case-insensitive) against `^(numeric|decimal|number)$` (no parentheses).\n- Types that already include `(p,s)` like `numeric(38,3)` are fine and must be left alone.\n- Only columns inside enforced-contract models trigger the warning; bare numeric on non-contracted\n  models is not affected.",
+        "fixing": "- For each flagged column, replace the bare type with an explicit precision/scale, e.g.\n  `data_type: numeric` -> `data_type: numeric(38,3)`.\n- Choose precision/scale from evidence in this order:\n- (1) an existing cast in the model SQL (e.g. `cast(x as numeric(18,2))`) \u2014 match it;\n- (2) the warehouse's documented default for unqualified numeric if the model is already built\n  (Snowflake NUMBER default is (38,0); Redshift/Postgres NUMERIC default is (38,0));\n- (3) if unknown, use a safe wide default `numeric(38,6)` and note the assumption in the results\n  report.\n- Preserve YAML quoting/style.\n- After editing, run `dbt parse`; if it fails, the likely cause is a mismatched type name for the\n  adapter (e.g. Snowflake prefers `number(38,3)`) \u2014 retry with the adapter-native spelling.\n- If the correct precision genuinely cannot be determined, leave the column and record it in the\n  results artifact (target/dbt_migration_results.json) as manual-required for the user to confirm."
+      },
+      "_path": "kb/core/1_6_003.yaml"
+    },
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_4_databricks.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_4_databricks.json
@@ -1,0 +1,852 @@
+{
+  "from_version": "1.4",
+  "warehouse": "databricks",
+  "target_version": "1.12",
+  "count": 39,
+  "issues": [
+    {
+      "issue_id": "1_4_001",
+      "sort_order": 2010,
+      "change": "--select/--exclude now accumulate when passed multiple times (argparse -> Click)",
+      "action": "Review scripts/jobs passing --select or --exclude more than once; collapse to a single flag with the intended union",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Scripts relying on last-wins override now see both selections combined, selecting more nodes than intended",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep in-repo invocation sites for repeated selection flags on a single command: shell scripts\n  (*.sh), Makefiles, CI YAML (.github/**, .gitlab-ci.yml, azure-pipelines.yml), tox.ini, and dbt\n  wrapper scripts.\n- Pattern: one dbt command containing two or more `--select`/`-s` or `--exclude` tokens (regex\n  `(--select|--exclude|-s)\\b.*\\b(--select|--exclude|-s)\\b`).\n- The real risk lives OUTSIDE the repo in dbt platform job definitions, so in-repo presence may be\n  zero even when the project is affected.",
+        "fixing": "- For each in-repo command with duplicated selection flags, decide intent: pre-1.5 was last-wins (only\n  the final flag applied); 1.5+ is union (all applied).\n- If the old intent was 'use only the last selection', delete the earlier occurrences. If a union was\n  intended, it already works \u2014 leave it.\n- Example: `dbt run --select tag:nightly --select my_model` (1.4 ran only my_model) -> `dbt run\n  --select my_model`.\n- Not visible to dbt parse.\n- ALWAYS add a results entry (manual-required): dbt platform job commands and orchestration outside\n  this repo may pass the flags multiple times; list the affected in-repo sites and tell the user to\n  audit job definitions."
+      },
+      "_path": "kb/core/1_4_001.yaml"
+    },
+    {
+      "issue_id": "1_4_002",
+      "sort_order": 2020,
+      "change": "Duplicate CLI flags before and after the subcommand now raise an error",
+      "action": "Ensure each CLI flag appears only once per dbt invocation",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands like `dbt --flag run --flag` now fail instead of silently taking one value",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan in-repo dbt invocation sites (shell scripts, Makefiles, CI YAML, tox.ini, wrapper scripts) for\n  a single dbt command repeating the same flag, especially placed both before and after the\n  subcommand.\n- Examples: `dbt --debug run --debug`, or a repeated `--profiles-dir` / `--target` / `--vars`.\n- Likeliest offenders: global flags (--debug, --profiles-dir, --project-dir, --target, --log-format)\n  appearing twice.\n- As with selection flags, the primary risk is in dbt platform job commands outside the repo.",
+        "fixing": "- Remove the duplicate occurrence, keeping the one with the intended value (pre-1.5 resolved to a\n  single value, so pick that).\n- Example: `dbt --target prod run --target prod` -> `dbt run --target prod`.\n- If two occurrences carry DIFFERENT values it was already ambiguous \u2014 keep the value the user\n  confirms and record the resolution in the migration log.\n- Not visible to dbt parse.\n- Add a results entry (manual-required) directing the user to audit external job/orchestration\n  commands for duplicated flags, since those now hard-error."
+      },
+      "_path": "kb/core/1_4_002.yaml"
+    },
+    {
+      "issue_id": "1_4_003",
+      "sort_order": 2030,
+      "change": "log-path in dbt_project.yml deprecated",
+      "action": "Move log-path out of dbt_project.yml to the --log-path CLI flag or DBT_LOG_PATH env var",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning at parse time; becomes fatal under --warn-error",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for a top-level `log-path:` key (regex `^\\s*log-path\\s*:`). Present if the key\n  exists with any value.\n- Only one location to check.",
+        "fixing": "- Remove the `log-path:` key from dbt_project.yml.\n- Re-provision out-of-repo: either the `--log-path <dir>` CLI flag on dbt invocations or the\n  `DBT_LOG_PATH` env var.\n- Because the effective destination now lives in job commands / env config outside this repo, add a\n  results entry recording the old value and telling the user to set --log-path/DBT_LOG_PATH wherever\n  dbt is invoked (CI, dbt platform jobs).\n- After removing the key, run dbt parse; the deprecation warning should be gone.\n- If parse still warns, confirm no other config file (a profiles-level or imported yml) re-declares\n  log-path."
+      },
+      "_path": "kb/core/1_4_003.yaml"
+    },
+    {
+      "issue_id": "1_4_004",
+      "sort_order": 2040,
+      "change": "target-path in dbt_project.yml deprecated",
+      "action": "Move target-path out of dbt_project.yml to the --target-path CLI flag or DBT_TARGET_PATH env var",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning at parse time; becomes fatal under --warn-error",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for a top-level `target-path:` key (regex `^\\s*target-path\\s*:`). Present if\n  the key exists.",
+        "fixing": "- Remove the `target-path:` key from dbt_project.yml.\n- Re-provision via the `--target-path <dir>` CLI flag or `DBT_TARGET_PATH` env var wherever dbt runs.\n- Add a results entry recording the old value and directing the user to set\n  --target-path/DBT_TARGET_PATH in job commands / CI / dbt platform, since anything reading generated\n  artifacts (manifest.json, run_results.json) from the custom path must be pointed at the new\n  location.\n- After removal, run dbt parse to confirm the warning is cleared."
+      },
+      "_path": "kb/core/1_4_004.yaml"
+    },
+    {
+      "issue_id": "1_4_005",
+      "sort_order": 2050,
+      "change": "DBT_NO_PRINT environment variable deprecated in favor of DBT_PRINT",
+      "action": "Replace DBT_NO_PRINT=true with DBT_PRINT=false",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for the literal `DBT_NO_PRINT` in CI YAML (.github/**, .gitlab-ci.yml, etc.),\n  Dockerfiles, .env / *.env files, shell scripts, Makefiles, and tox.ini. Present if the token appears\n  anywhere.\n- The variable is frequently set in orchestration outside the repo, so an in-repo miss does not mean\n  the project is clear.",
+        "fixing": "- Translate the value: DBT_NO_PRINT=true (suppress prints) becomes DBT_PRINT=false; DBT_NO_PRINT=false\n  becomes DBT_PRINT=true.\n- Update every in-repo occurrence found.\n- This is an env-var rename, not a Python-environment change, so it is a normal advisory edit (not\n  environment_change) and is not verified by dbt parse.\n- Add a results entry telling the user to replace DBT_NO_PRINT in external CI / dbt platform\n  environment settings with DBT_PRINT (inverted value)."
+      },
+      "_path": "kb/core/1_4_005.yaml"
+    },
+    {
+      "issue_id": "1_4_006",
+      "sort_order": 2060,
+      "change": "DBT_ARTIFACT_STATE_PATH environment variable deprecated in favor of DBT_STATE",
+      "action": "Replace DBT_ARTIFACT_STATE_PATH with DBT_STATE",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_ARTIFACT_STATE_PATH` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Commonly used in Slim CI / state-deferral setups that live in orchestration outside the repo.",
+        "fixing": "- Rename the variable to `DBT_STATE`, keeping the same value (path to the state/manifest directory).\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry telling the user to rename DBT_ARTIFACT_STATE_PATH to DBT_STATE in external CI\n  and dbt platform job environments used for state:modified / --defer selection."
+      },
+      "_path": "kb/core/1_4_006.yaml"
+    },
+    {
+      "issue_id": "1_4_007",
+      "sort_order": 2070,
+      "change": "DBT_FAVOR_STATE_MODE environment variable deprecated in favor of DBT_FAVOR_STATE",
+      "action": "Replace DBT_FAVOR_STATE_MODE with DBT_FAVOR_STATE",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_FAVOR_STATE_MODE` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Typically set in state-based CI selection outside the repo.",
+        "fixing": "- Rename to `DBT_FAVOR_STATE`, preserving the value.\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry directing the user to rename this variable in external CI / dbt platform\n  environments."
+      },
+      "_path": "kb/core/1_4_007.yaml"
+    },
+    {
+      "issue_id": "1_4_008",
+      "sort_order": 2080,
+      "change": "DBT_DEFER_TO_STATE environment variable deprecated in favor of DBT_DEFER",
+      "action": "Replace DBT_DEFER_TO_STATE with DBT_DEFER",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_DEFER_TO_STATE` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Used in --defer based CI workflows that usually live outside the repo.",
+        "fixing": "- Rename to `DBT_DEFER`, preserving the boolean value.\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry directing the user to rename DBT_DEFER_TO_STATE to DBT_DEFER in external CI /\n  dbt platform environments."
+      },
+      "_path": "kb/core/1_4_008.yaml"
+    },
+    {
+      "issue_id": "1_5_001",
+      "sort_order": 3010,
+      "change": "Metric YAML schema completely rewritten for MetricFlow",
+      "action": "Rewrite all metric definitions using the new type/type_params/filter format",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "All existing metric YAML definitions fail to parse in 1.6; the pre-1.6 UnparsedMetric fields (calculation_method, expression, sql, model, type: expression) and the rename_metric_attr compatibility shim were removed.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Search every YAML file under models/ and any schema-file globs declared in dbt_project.yml\n  (models/**/*.yml, models/**/*.yaml, plus any top-level metrics/ dir) for a `metrics:` block.\n- Flag a metric as legacy (pre-1.6) if its entry uses ANY of these keys: `calculation_method`,\n  `expression`, `sql`, `type: expression`, a top-level `type:` with the old enum\n  (`count`/`sum`/...), `model:`, `timestamp:`, `time_grains:`, `dimensions:` directly on the\n  metric, or `filters:` (the list-of-dict old form).\n- The new MetricFlow schema instead uses `type:` with values simple|ratio|cumulative|derived\n  plus a `type_params:` block. If a metric already has `type_params:`, it is migrated \u2014 skip it.\n- Also grep packages.yml for `dbt_metrics` usage and models for `metrics.calculate(` /\n  `metrics.develop(` macro calls \u2014 those depend on the old package and must be flagged too.",
+        "fixing": "- Rewrite each legacy metric into the new schema. Attribute mapping:\n  - `calculation_method` -> `type`: sum/average/min/max/count/count_distinct/median become\n    `type: simple` with `type_params.measure`; derived/expression become `type: derived` with\n    `type_params.expr` and `type_params.metrics`.\n  - `expression`/`sql` -> `type_params.measure` (the semantic measure name), or\n    `type_params.expr` for a derived metric.\n  - `model:` -> moves into a `semantic_models:` definition (see example below).\n  - `filters:` -> `filter:` (a single `{{ Dimension(...) }}` string, or keep the WHERE fragment).\n- Concrete before/after:\n  BEFORE (1.5):\n    metrics:\n      - name: total_revenue\n        calculation_method: sum\n        expression: amount\n        model: ref('orders')\n        timestamp: order_date\n        time_grains: [day, month]\n        dimensions: [status]\n  AFTER (1.6, MetricFlow):\n    semantic_models:\n      - name: orders\n        model: ref('orders')\n        defaults:\n          agg_time_dimension: order_date\n        entities:\n          - name: order\n            type: primary\n        dimensions:\n          - name: order_date\n            type: time\n            type_params: {time_granularity: day}\n          - name: status\n            type: categorical\n        measures:\n          - name: amount\n            agg: sum\n            agg_time_dimension: order_date\n    metrics:\n      - name: total_revenue\n        type: simple\n        type_params:\n          measure: amount\n- Derived example: `calculation_method: derived` + `expression: revenue - cost` becomes\n  `type: derived` with `type_params: {expr: 'revenue - cost', metrics: [{name: revenue},\n  {name: cost}]}`.\n- Judgment-heavy: 1.6 requires a `semantic_models:` layer that did not exist in 1.5, so the\n  measure/entity/dimension split cannot always be inferred mechanically.\n- If you cannot confidently reconstruct the semantic model (e.g. the source model's grain or\n  entities are ambiguous), do NOT guess \u2014 record the metric in the results report with\n  the original YAML and the suggested new shape, and move on.\n- After editing, run `dbt parse`. On a metric/semantic-model validation error, re-read it;\n  reverting to legacy form is NOT an option (it won't parse in 1.6) \u2014 instead leave the\n  semantic_model skeleton and flag it manual.\n- Remove `dbt_metrics` / `metrics.calculate` usages and flag them as requiring the\n  MetricFlow / Semantic Layer migration (out of scope for parse)."
+      },
+      "_path": "kb/core/1_5_001.yaml"
+    },
+    {
+      "issue_id": "1_5_002",
+      "sort_order": 3020,
+      "change": "Duplicate node names allowed across packages",
+      "action": "Disambiguate cross-package references with two-argument ref('package_name', 'model_name')",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.5 a flat manifest dict raised DuplicateResourceNameError; in 1.6 names are stored per-package, so a project and an installed package can legitimately share a model name. Single-argument ref() to a name that exists in more than one package becomes ambiguous (AmbiguousAliasError / wrong node).",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant if packages.yml / dependencies.yml declares packages.\n- Build the set of model/seed/snapshot names defined in the local project (models/**/*.sql,\n  seeds/**/*.csv, snapshots/**/*.sql).\n- Where available, add the names exposed by installed packages under dbt_packages/*/models.\n- Grep all .sql/.yml for single-argument `ref('name')` / `ref(\"name\")` whose `name` collides\n  with a name present in BOTH the local project and a package (or in two packages) \u2014 those are\n  the ambiguous refs.\n- If no packages are installed, mark skipped-not-present.",
+        "fixing": "- For each ambiguous single-arg ref, rewrite to the two-argument form\n  `ref('<package_name>', '<model_name>')`.\n- Choose the package the author intended; default to the local project's own model unless the\n  surrounding SQL clearly consumes the package's version.\n- Example: `ref('customers')` -> `ref('my_project', 'customers')` or\n  `ref('dbt_utils', 'customers')`. Leave unambiguous refs untouched.\n- After edits run `dbt parse`; a remaining AmbiguousAliasError names the offending ref and node.\n- If you cannot determine which package is intended, record it in the results report\n  rather than guessing \u2014 picking the wrong package silently changes lineage."
+      },
+      "_path": "kb/core/1_5_002.yaml"
+    },
+    {
+      "issue_id": "1_5_003",
+      "sort_order": 3030,
+      "change": "collect_freshness macro return type changed",
+      "action": "Update any custom collect_freshness macro override to return the full result object (table + response) instead of just the table",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.6 core's default collect_freshness returns a dict-like {table, response} object; a custom override that returns only the agate table triggers a deprecation warning and will break source freshness in later versions.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/**/*.sql for a macro named `collect_freshness` (i.e. `{% macro collect_freshness(`\n  or `{% macro <adapter>__collect_freshness(`).\n- If none exists, the project uses core's implementation \u2014 mark skipped-not-present.\n- If one exists, inspect its final `{{ return(...) }}` and flag it if it returns the query\n  result table directly (e.g. `return(load_result('collect_freshness').table)` or\n  `return(table)`) rather than the full result object.",
+        "fixing": "- Change the macro to capture the full result and return an object exposing both the table and\n  the adapter response.\n- Pattern: `{% set result = run_query(...) %}` then\n  `{{ return({'table': result.table, 'response': result.response}) }}`.\n- Mirror core's 1.6 signature: it returns `load_result('collect_freshness')`, which already has\n  `.table` and `.response`.\n- Simplest safe fix, if the override only existed to tweak the SQL: align the return statement\n  with core 1.6's macro body.\n- After editing run `dbt parse`.\n- If the override is complex or the intended response object is unclear, record it in the\n  results report with a pointer to core's 1.6 collect_freshness for reference."
+      },
+      "_path": "kb/core/1_5_003.yaml"
+    },
+    {
+      "issue_id": "1_5_010",
+      "sort_order": 3100,
+      "change": "Default socket timeout set to 180 seconds",
+      "action": "Adjust _socket_timeout in connection_parameters if long-idle connections time out",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "databricks",
+      "impact": "1.6 introduces a default socket timeout of 180s. Long-idle connections (e.g. warehouses that were paused/cold) may now time out where they previously waited indefinitely.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": true,
+      "context": {
+        "detection": "- Behavioral connection change invisible to `dbt parse`.\n- Check the databricks output in profiles.yml (usually out of repo) for a\n  `connect_timeout` / `_socket_timeout` / `connection_parameters` setting.\n- Risk signals: projects querying serverless / auto-stopping SQL warehouses with long cold-start\n  times, or long-running single statements exceeding 180s of socket idleness.",
+        "fixing": "- ADVISORY ONLY.\n- If timeouts are a risk, recommend setting `_socket_timeout` under `connection_parameters` in\n  the databricks profile to a higher value; otherwise no change.\n- profiles.yml is usually out of repo and this is warehouse behavior \u2014 add a manual-actions entry\n  noting the new 180s default and the tuning knob.\n- Excluded from the parse verify loop."
+      },
+      "_path": "kb/databricks/1_5_010.yaml"
+    },
+    {
+      "issue_id": "1_6_011",
+      "sort_order": 4005,
+      "change": "dbt clean errors when clean-targets include source paths or paths outside the project",
+      "action": "Remove source paths (e.g. models/, macros/) and any path outside the project directory from clean-targets in dbt_project.yml",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "dbt clean now raises an error instead of silently deleting the wrong directories when clean-targets references source paths or paths outside the project root",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml's clean-targets list.\n- Flag any entry that resolves (relative to the project root) to a configured source path\n  (model-paths, seed-paths, macro-paths, etc.) or that resolves outside the project directory\n  (e.g. ../shared, /absolute/path).",
+        "fixing": "- Remove the offending entries from clean-targets, keeping only build/output directories\n  (e.g. target, dbt_packages, logs).\n- Re-run dbt clean to confirm it no longer errors."
+      },
+      "_path": "kb/core/1_6_011.yaml"
+    },
+    {
+      "issue_id": "1_6_001",
+      "sort_order": 4010,
+      "change": "New warning when --state and --target point to the same directory",
+      "action": "Fix --state/--target configuration so they reference distinct directories",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "WarnStateTargetEqual raised (informational) for previously silent misconfiguration; fatal under --warn-error",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- This is a runtime CLI/job configuration issue, not a repo-source issue, so `dbt parse` cannot\n  surface it. Detect by scanning invocation sites, not models.\n- Grep the repo for `--state` and `--target` / `--target-path` in shell scripts, Makefiles, and\n  `scripts/**/*.sh`.\n- Also grep CI configs: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `tox.ini`.\n- Check `dbt_project.yml` for a `target-path:` key (deprecated since 1.5 but may still be present).\n- Check for `DBT_STATE` / `DBT_TARGET_PATH` env vars in CI.\n- Flag any invocation where `--state` and `--target`/`--target-path` resolve to the same directory\n  (commonly both set to `target/`).\n- Note the value is frequently supplied outside the repo (dbt platform job definitions,\n  orchestration tools), which parse cannot see.",
+        "fixing": "- Point `--state` at a directory separate from the run's `--target` \u2014 e.g. keep run output in\n  `target/` and the comparison manifest in a distinct dir such as `state/` or `prod-artifacts/`.\n- Concretely, in the offending script/CI step change the duplicated paths so a command like\n  `dbt build --state ./state --target-path ./target` uses different dirs, and populate the state\n  artifacts there.\n- If the same-directory usage lives outside the repo (a dbt platform job command, an orchestration\n  tool), it cannot be edited from the repo.\n- For that out-of-repo case: record it in the results artifact (target/dbt_migration_results.json)\n  as manual-required with the issue_id, the invocation location if known, and the suggested command\n  change, then prompt the user.\n- This change never requires a repo edit to pass `dbt parse`; it is advisory / out-of-repo only."
+      },
+      "_path": "kb/core/1_6_001.yaml"
+    },
+    {
+      "issue_id": "1_6_002",
+      "sort_order": 4020,
+      "change": "Breaking contract changes on unversioned models now warn instead of error",
+      "action": "Add --warn-error (or version the models) to retain the previous hard-error behavior on breaking contract changes",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Unversioned models with a breaking schema/contract change warn via warn_or_error() instead of erroring; CI that relied on the error to block may now pass silently",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan schema YAML (`models/**/*.yml`, `models/**/*.yaml`) for models declaring `contract:` with\n  `enforced: true` that do NOT declare a `version:` / `versions:` block (i.e. unversioned).\n- Those unversioned enforced-contract models are the ones whose breaking contract changes now only\n  warn.\n- Also detect reliance on the old error behavior: grep CI/scripts for `dbt build` / `dbt run`\n  invocations that lack `--warn-error` or `--warn-error-options`.\n- Those flags are what previously turned the contract breakage into a hard failure.\n- This is a behavior/policy change; `dbt parse` stays clean either way, so detection is about intent,\n  not parse errors.",
+        "fixing": "- Preferred: preserve strict behavior by adding `--warn-error` (or a scoped `--warn-error-options`\n  targeting contract deprecations) to the relevant dbt invocation.\n- If that invocation is defined outside the repo (dbt platform job command, orchestration tool), it\n  cannot be edited here: record it in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the suggested flag, and prompt the user.\n- Alternative in-repo fix: add a `version:` to the affected models \u2014 versioning makes breaking\n  contract changes error again.\n- But versioning reshapes ref() resolution and downstream references, so only do it when the user\n  explicitly wants versioned models; note that trade-off in the results report rather than silently\n  versioning.\n- No edit is required for `dbt parse` to succeed."
+      },
+      "_path": "kb/core/1_6_002.yaml"
+    },
+    {
+      "issue_id": "1_6_003",
+      "sort_order": 4030,
+      "change": "New warning for contracted models with bare numeric columns (no precision/scale)",
+      "action": "Add explicit precision and scale to numeric column data_types in enforced contracts (e.g. numeric(38,3))",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with 'data_type: numeric' (or 'decimal') and no precision/scale in an enforced contract now emit a warning at parse time in 1.7",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- In schema YAML (`models/**/*.yml`, `models/**/*.yaml`), find models with `contract:`\n  `enforced: true` and columns whose `data_type` is a bare numeric type with no precision/scale.\n- Match the data_type value (case-insensitive) against `^(numeric|decimal|number)$` (no parentheses).\n- Types that already include `(p,s)` like `numeric(38,3)` are fine and must be left alone.\n- Only columns inside enforced-contract models trigger the warning; bare numeric on non-contracted\n  models is not affected.",
+        "fixing": "- For each flagged column, replace the bare type with an explicit precision/scale, e.g.\n  `data_type: numeric` -> `data_type: numeric(38,3)`.\n- Choose precision/scale from evidence in this order:\n- (1) an existing cast in the model SQL (e.g. `cast(x as numeric(18,2))`) \u2014 match it;\n- (2) the warehouse's documented default for unqualified numeric if the model is already built\n  (Snowflake NUMBER default is (38,0); Redshift/Postgres NUMERIC default is (38,0));\n- (3) if unknown, use a safe wide default `numeric(38,6)` and note the assumption in the results\n  report.\n- Preserve YAML quoting/style.\n- After editing, run `dbt parse`; if it fails, the likely cause is a mismatched type name for the\n  adapter (e.g. Snowflake prefers `number(38,3)`) \u2014 retry with the adapter-native spelling.\n- If the correct precision genuinely cannot be determined, leave the column and record it in the\n  results artifact (target/dbt_migration_results.json) as manual-required for the user to confirm."
+      },
+      "_path": "kb/core/1_6_003.yaml"
+    },
+    {
+      "issue_id": "1_6_005",
+      "sort_order": 4050,
+      "change": "Default catalog set to hive_metastore when not specified",
+      "action": "Verify the default matches expectations; set catalog explicitly in profiles.yml if a different catalog is intended",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "databricks",
+      "impact": "Projects that did not set a catalog now explicitly resolve to hive_metastore; relations may be created/read in hive_metastore instead of a previously-implicit Unity Catalog default",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": true,
+      "context": {
+        "detection": "- This is a connection/environment default, not a repo-source change, so `dbt parse` cannot see it.\n- Inspect the Databricks connection config: `profiles.yml` (`outputs.<target>.catalog`) and any\n  `catalog:` / `database:` set in `dbt_project.yml` or model configs.\n- Flag the project if NO catalog/database is set anywhere for the Databricks target \u2014 those projects\n  now implicitly get `hive_metastore`.\n- If a catalog is already set explicitly, no action.\n- Note `profiles.yml` often lives outside the repo (`~/.dbt/` or dbt platform connection settings).",
+        "fixing": "- Advisory / environment change only \u2014 never mutate credentials or run anything.\n- If the workspace uses Unity Catalog and the user expects a UC catalog rather than the legacy\n  hive_metastore, add an explicit `catalog: <name>` to the Databricks output in `profiles.yml` (or\n  the platform connection).\n- If `profiles.yml` is inside the repo, apply the advisory edit and record it in the results report.\n- If it is outside the repo, record the recommended `catalog:` setting in the results artifact\n  (target/dbt_migration_results.json) as advisory and prompt the user to confirm the intended\n  catalog.\n- Exclude from the parse-verify loop (parse does not reflect connection settings)."
+      },
+      "_path": "kb/databricks/1_6_005.yaml"
+    },
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_4_redshift.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_4_redshift.json
@@ -1,0 +1,972 @@
+{
+  "from_version": "1.4",
+  "warehouse": "redshift",
+  "target_version": "1.12",
+  "count": 45,
+  "issues": [
+    {
+      "issue_id": "1_4_001",
+      "sort_order": 2010,
+      "change": "--select/--exclude now accumulate when passed multiple times (argparse -> Click)",
+      "action": "Review scripts/jobs passing --select or --exclude more than once; collapse to a single flag with the intended union",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Scripts relying on last-wins override now see both selections combined, selecting more nodes than intended",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep in-repo invocation sites for repeated selection flags on a single command: shell scripts\n  (*.sh), Makefiles, CI YAML (.github/**, .gitlab-ci.yml, azure-pipelines.yml), tox.ini, and dbt\n  wrapper scripts.\n- Pattern: one dbt command containing two or more `--select`/`-s` or `--exclude` tokens (regex\n  `(--select|--exclude|-s)\\b.*\\b(--select|--exclude|-s)\\b`).\n- The real risk lives OUTSIDE the repo in dbt platform job definitions, so in-repo presence may be\n  zero even when the project is affected.",
+        "fixing": "- For each in-repo command with duplicated selection flags, decide intent: pre-1.5 was last-wins (only\n  the final flag applied); 1.5+ is union (all applied).\n- If the old intent was 'use only the last selection', delete the earlier occurrences. If a union was\n  intended, it already works \u2014 leave it.\n- Example: `dbt run --select tag:nightly --select my_model` (1.4 ran only my_model) -> `dbt run\n  --select my_model`.\n- Not visible to dbt parse.\n- ALWAYS add a results entry (manual-required): dbt platform job commands and orchestration outside\n  this repo may pass the flags multiple times; list the affected in-repo sites and tell the user to\n  audit job definitions."
+      },
+      "_path": "kb/core/1_4_001.yaml"
+    },
+    {
+      "issue_id": "1_4_002",
+      "sort_order": 2020,
+      "change": "Duplicate CLI flags before and after the subcommand now raise an error",
+      "action": "Ensure each CLI flag appears only once per dbt invocation",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands like `dbt --flag run --flag` now fail instead of silently taking one value",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan in-repo dbt invocation sites (shell scripts, Makefiles, CI YAML, tox.ini, wrapper scripts) for\n  a single dbt command repeating the same flag, especially placed both before and after the\n  subcommand.\n- Examples: `dbt --debug run --debug`, or a repeated `--profiles-dir` / `--target` / `--vars`.\n- Likeliest offenders: global flags (--debug, --profiles-dir, --project-dir, --target, --log-format)\n  appearing twice.\n- As with selection flags, the primary risk is in dbt platform job commands outside the repo.",
+        "fixing": "- Remove the duplicate occurrence, keeping the one with the intended value (pre-1.5 resolved to a\n  single value, so pick that).\n- Example: `dbt --target prod run --target prod` -> `dbt run --target prod`.\n- If two occurrences carry DIFFERENT values it was already ambiguous \u2014 keep the value the user\n  confirms and record the resolution in the migration log.\n- Not visible to dbt parse.\n- Add a results entry (manual-required) directing the user to audit external job/orchestration\n  commands for duplicated flags, since those now hard-error."
+      },
+      "_path": "kb/core/1_4_002.yaml"
+    },
+    {
+      "issue_id": "1_4_003",
+      "sort_order": 2030,
+      "change": "log-path in dbt_project.yml deprecated",
+      "action": "Move log-path out of dbt_project.yml to the --log-path CLI flag or DBT_LOG_PATH env var",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning at parse time; becomes fatal under --warn-error",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for a top-level `log-path:` key (regex `^\\s*log-path\\s*:`). Present if the key\n  exists with any value.\n- Only one location to check.",
+        "fixing": "- Remove the `log-path:` key from dbt_project.yml.\n- Re-provision out-of-repo: either the `--log-path <dir>` CLI flag on dbt invocations or the\n  `DBT_LOG_PATH` env var.\n- Because the effective destination now lives in job commands / env config outside this repo, add a\n  results entry recording the old value and telling the user to set --log-path/DBT_LOG_PATH wherever\n  dbt is invoked (CI, dbt platform jobs).\n- After removing the key, run dbt parse; the deprecation warning should be gone.\n- If parse still warns, confirm no other config file (a profiles-level or imported yml) re-declares\n  log-path."
+      },
+      "_path": "kb/core/1_4_003.yaml"
+    },
+    {
+      "issue_id": "1_4_004",
+      "sort_order": 2040,
+      "change": "target-path in dbt_project.yml deprecated",
+      "action": "Move target-path out of dbt_project.yml to the --target-path CLI flag or DBT_TARGET_PATH env var",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning at parse time; becomes fatal under --warn-error",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for a top-level `target-path:` key (regex `^\\s*target-path\\s*:`). Present if\n  the key exists.",
+        "fixing": "- Remove the `target-path:` key from dbt_project.yml.\n- Re-provision via the `--target-path <dir>` CLI flag or `DBT_TARGET_PATH` env var wherever dbt runs.\n- Add a results entry recording the old value and directing the user to set\n  --target-path/DBT_TARGET_PATH in job commands / CI / dbt platform, since anything reading generated\n  artifacts (manifest.json, run_results.json) from the custom path must be pointed at the new\n  location.\n- After removal, run dbt parse to confirm the warning is cleared."
+      },
+      "_path": "kb/core/1_4_004.yaml"
+    },
+    {
+      "issue_id": "1_4_005",
+      "sort_order": 2050,
+      "change": "DBT_NO_PRINT environment variable deprecated in favor of DBT_PRINT",
+      "action": "Replace DBT_NO_PRINT=true with DBT_PRINT=false",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for the literal `DBT_NO_PRINT` in CI YAML (.github/**, .gitlab-ci.yml, etc.),\n  Dockerfiles, .env / *.env files, shell scripts, Makefiles, and tox.ini. Present if the token appears\n  anywhere.\n- The variable is frequently set in orchestration outside the repo, so an in-repo miss does not mean\n  the project is clear.",
+        "fixing": "- Translate the value: DBT_NO_PRINT=true (suppress prints) becomes DBT_PRINT=false; DBT_NO_PRINT=false\n  becomes DBT_PRINT=true.\n- Update every in-repo occurrence found.\n- This is an env-var rename, not a Python-environment change, so it is a normal advisory edit (not\n  environment_change) and is not verified by dbt parse.\n- Add a results entry telling the user to replace DBT_NO_PRINT in external CI / dbt platform\n  environment settings with DBT_PRINT (inverted value)."
+      },
+      "_path": "kb/core/1_4_005.yaml"
+    },
+    {
+      "issue_id": "1_4_006",
+      "sort_order": 2060,
+      "change": "DBT_ARTIFACT_STATE_PATH environment variable deprecated in favor of DBT_STATE",
+      "action": "Replace DBT_ARTIFACT_STATE_PATH with DBT_STATE",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_ARTIFACT_STATE_PATH` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Commonly used in Slim CI / state-deferral setups that live in orchestration outside the repo.",
+        "fixing": "- Rename the variable to `DBT_STATE`, keeping the same value (path to the state/manifest directory).\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry telling the user to rename DBT_ARTIFACT_STATE_PATH to DBT_STATE in external CI\n  and dbt platform job environments used for state:modified / --defer selection."
+      },
+      "_path": "kb/core/1_4_006.yaml"
+    },
+    {
+      "issue_id": "1_4_007",
+      "sort_order": 2070,
+      "change": "DBT_FAVOR_STATE_MODE environment variable deprecated in favor of DBT_FAVOR_STATE",
+      "action": "Replace DBT_FAVOR_STATE_MODE with DBT_FAVOR_STATE",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_FAVOR_STATE_MODE` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Typically set in state-based CI selection outside the repo.",
+        "fixing": "- Rename to `DBT_FAVOR_STATE`, preserving the value.\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry directing the user to rename this variable in external CI / dbt platform\n  environments."
+      },
+      "_path": "kb/core/1_4_007.yaml"
+    },
+    {
+      "issue_id": "1_4_008",
+      "sort_order": 2080,
+      "change": "DBT_DEFER_TO_STATE environment variable deprecated in favor of DBT_DEFER",
+      "action": "Replace DBT_DEFER_TO_STATE with DBT_DEFER",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_DEFER_TO_STATE` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Used in --defer based CI workflows that usually live outside the repo.",
+        "fixing": "- Rename to `DBT_DEFER`, preserving the boolean value.\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry directing the user to rename DBT_DEFER_TO_STATE to DBT_DEFER in external CI /\n  dbt platform environments."
+      },
+      "_path": "kb/core/1_4_008.yaml"
+    },
+    {
+      "issue_id": "1_4_011",
+      "sort_order": 2110,
+      "change": "RedshiftAdapter parent class changed from PostgresAdapter to SQLAdapter",
+      "action": "Update custom adapter/plugin code that subclasses or relies on RedshiftAdapter extending PostgresAdapter",
+      "category": "Breaking",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "Custom adapter plugins extending RedshiftAdapter, or code assuming Postgres-adapter methods, may break",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Affects only projects that ship CUSTOM Python adapter code.\n- Grep the repo's Python files for `from dbt.adapters.redshift` / `RedshiftAdapter`,\n  `PostgresAdapter`, or subclasses inheriting from these.\n- Also check macros overriding Postgres-inherited behavior (e.g. `redshift__` / `postgres__` macro\n  pairs in macros/**/*.sql where the Redshift path assumed Postgres defaults).\n- Most standard dbt projects have NO such code and are unaffected \u2014 report skipped-not-present.",
+        "fixing": "- For custom adapter classes: change the base from PostgresAdapter to SQLAdapter and re-implement any\n  Postgres-specific methods previously inherited (Redshift no longer gets them for free).\n- For overridden macros relying on postgres__ dispatch, provide explicit redshift__ implementations.\n- Python/plugin code is not exercised by dbt parse of the project models; parse cannot validate it.\n- If the project has no custom adapter code, mark skipped-not-present.\n- If custom code exists but the correct re-implementation is non-trivial, record a results entry\n  (manual-required) with the affected files."
+      },
+      "_path": "kb/redshift/1_4_011.yaml"
+    },
+    {
+      "issue_id": "1_4_013",
+      "sort_order": 2130,
+      "change": "connect_timeout default introduced at 30 seconds",
+      "action": "Set connect_timeout explicitly in the Redshift profile if 30s is insufficient",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "Connections without an explicit timeout now time out after 30 seconds",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": true,
+      "context": {
+        "detection": "- Inspect any in-repo profiles.yml or profile fixture for a Redshift output that does NOT set\n  `connect_timeout:`. Present when the field is absent (it now defaults to 30s).\n- If profiles.yml lives only in ~/.dbt (outside the repo), there is nothing to detect in-repo \u2014 treat\n  as advisory.",
+        "fixing": "- ADVISORY ONLY \u2014 this is a profiles.yml / connection change, never executed.\n- If an in-repo profile is present and 30s could be too short (high network latency, VPN), add\n  `connect_timeout: <seconds>` to the Redshift output. Otherwise record an advisory note only.\n- EXCLUDED from the dbt parse verify loop.\n- Add a results entry telling the user to set connect_timeout in their real profiles.yml if the\n  default 30s causes premature connection timeouts."
+      },
+      "_path": "kb/redshift/1_4_013.yaml"
+    },
+    {
+      "issue_id": "1_4_014",
+      "sort_order": 2140,
+      "change": "iam_duration_seconds, search_path, and keepalives_idle profile fields removed",
+      "action": "Remove these fields from the Redshift profile; reproduce search_path via a SET search_path pre-hook",
+      "category": "Breaking",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "Profiles still declaring iam_duration_seconds, search_path, or keepalives_idle error on connection",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": true,
+      "context": {
+        "detection": "- Search in-repo profiles.yml / profile fixtures for the keys `iam_duration_seconds:`, `search_path:`,\n  or `keepalives_idle:` under a Redshift output (regex\n  `^\\s*(iam_duration_seconds|search_path|keepalives_idle)\\s*:`).\n- These now cause a hard connection error.\n- profiles.yml commonly lives in ~/.dbt outside the repo, so the primary fix is out-of-repo.",
+        "fixing": "- Remove all three keys wherever they appear in an in-repo profile.\n- To preserve search_path behavior, add a pre-hook running `SET search_path TO <schemas>` \u2014 e.g. in\n  dbt_project.yml `on-run-start: \"SET search_path TO analytics, public\"` or a model-level pre_hook.\n- iam_duration_seconds and keepalives_idle have no direct replacement; drop them.\n- Not verified by dbt parse (connection-time error).\n- Because the authoritative profiles.yml is usually outside the repo, ALWAYS add a results entry\n  telling the user to remove these keys from their real profiles.yml and to add the SET search_path\n  pre-hook if they relied on a custom search_path."
+      },
+      "_path": "kb/redshift/1_4_014.yaml"
+    },
+    {
+      "issue_id": "1_5_001",
+      "sort_order": 3010,
+      "change": "Metric YAML schema completely rewritten for MetricFlow",
+      "action": "Rewrite all metric definitions using the new type/type_params/filter format",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "All existing metric YAML definitions fail to parse in 1.6; the pre-1.6 UnparsedMetric fields (calculation_method, expression, sql, model, type: expression) and the rename_metric_attr compatibility shim were removed.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Search every YAML file under models/ and any schema-file globs declared in dbt_project.yml\n  (models/**/*.yml, models/**/*.yaml, plus any top-level metrics/ dir) for a `metrics:` block.\n- Flag a metric as legacy (pre-1.6) if its entry uses ANY of these keys: `calculation_method`,\n  `expression`, `sql`, `type: expression`, a top-level `type:` with the old enum\n  (`count`/`sum`/...), `model:`, `timestamp:`, `time_grains:`, `dimensions:` directly on the\n  metric, or `filters:` (the list-of-dict old form).\n- The new MetricFlow schema instead uses `type:` with values simple|ratio|cumulative|derived\n  plus a `type_params:` block. If a metric already has `type_params:`, it is migrated \u2014 skip it.\n- Also grep packages.yml for `dbt_metrics` usage and models for `metrics.calculate(` /\n  `metrics.develop(` macro calls \u2014 those depend on the old package and must be flagged too.",
+        "fixing": "- Rewrite each legacy metric into the new schema. Attribute mapping:\n  - `calculation_method` -> `type`: sum/average/min/max/count/count_distinct/median become\n    `type: simple` with `type_params.measure`; derived/expression become `type: derived` with\n    `type_params.expr` and `type_params.metrics`.\n  - `expression`/`sql` -> `type_params.measure` (the semantic measure name), or\n    `type_params.expr` for a derived metric.\n  - `model:` -> moves into a `semantic_models:` definition (see example below).\n  - `filters:` -> `filter:` (a single `{{ Dimension(...) }}` string, or keep the WHERE fragment).\n- Concrete before/after:\n  BEFORE (1.5):\n    metrics:\n      - name: total_revenue\n        calculation_method: sum\n        expression: amount\n        model: ref('orders')\n        timestamp: order_date\n        time_grains: [day, month]\n        dimensions: [status]\n  AFTER (1.6, MetricFlow):\n    semantic_models:\n      - name: orders\n        model: ref('orders')\n        defaults:\n          agg_time_dimension: order_date\n        entities:\n          - name: order\n            type: primary\n        dimensions:\n          - name: order_date\n            type: time\n            type_params: {time_granularity: day}\n          - name: status\n            type: categorical\n        measures:\n          - name: amount\n            agg: sum\n            agg_time_dimension: order_date\n    metrics:\n      - name: total_revenue\n        type: simple\n        type_params:\n          measure: amount\n- Derived example: `calculation_method: derived` + `expression: revenue - cost` becomes\n  `type: derived` with `type_params: {expr: 'revenue - cost', metrics: [{name: revenue},\n  {name: cost}]}`.\n- Judgment-heavy: 1.6 requires a `semantic_models:` layer that did not exist in 1.5, so the\n  measure/entity/dimension split cannot always be inferred mechanically.\n- If you cannot confidently reconstruct the semantic model (e.g. the source model's grain or\n  entities are ambiguous), do NOT guess \u2014 record the metric in the results report with\n  the original YAML and the suggested new shape, and move on.\n- After editing, run `dbt parse`. On a metric/semantic-model validation error, re-read it;\n  reverting to legacy form is NOT an option (it won't parse in 1.6) \u2014 instead leave the\n  semantic_model skeleton and flag it manual.\n- Remove `dbt_metrics` / `metrics.calculate` usages and flag them as requiring the\n  MetricFlow / Semantic Layer migration (out of scope for parse)."
+      },
+      "_path": "kb/core/1_5_001.yaml"
+    },
+    {
+      "issue_id": "1_5_002",
+      "sort_order": 3020,
+      "change": "Duplicate node names allowed across packages",
+      "action": "Disambiguate cross-package references with two-argument ref('package_name', 'model_name')",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.5 a flat manifest dict raised DuplicateResourceNameError; in 1.6 names are stored per-package, so a project and an installed package can legitimately share a model name. Single-argument ref() to a name that exists in more than one package becomes ambiguous (AmbiguousAliasError / wrong node).",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant if packages.yml / dependencies.yml declares packages.\n- Build the set of model/seed/snapshot names defined in the local project (models/**/*.sql,\n  seeds/**/*.csv, snapshots/**/*.sql).\n- Where available, add the names exposed by installed packages under dbt_packages/*/models.\n- Grep all .sql/.yml for single-argument `ref('name')` / `ref(\"name\")` whose `name` collides\n  with a name present in BOTH the local project and a package (or in two packages) \u2014 those are\n  the ambiguous refs.\n- If no packages are installed, mark skipped-not-present.",
+        "fixing": "- For each ambiguous single-arg ref, rewrite to the two-argument form\n  `ref('<package_name>', '<model_name>')`.\n- Choose the package the author intended; default to the local project's own model unless the\n  surrounding SQL clearly consumes the package's version.\n- Example: `ref('customers')` -> `ref('my_project', 'customers')` or\n  `ref('dbt_utils', 'customers')`. Leave unambiguous refs untouched.\n- After edits run `dbt parse`; a remaining AmbiguousAliasError names the offending ref and node.\n- If you cannot determine which package is intended, record it in the results report\n  rather than guessing \u2014 picking the wrong package silently changes lineage."
+      },
+      "_path": "kb/core/1_5_002.yaml"
+    },
+    {
+      "issue_id": "1_5_003",
+      "sort_order": 3030,
+      "change": "collect_freshness macro return type changed",
+      "action": "Update any custom collect_freshness macro override to return the full result object (table + response) instead of just the table",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.6 core's default collect_freshness returns a dict-like {table, response} object; a custom override that returns only the agate table triggers a deprecation warning and will break source freshness in later versions.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/**/*.sql for a macro named `collect_freshness` (i.e. `{% macro collect_freshness(`\n  or `{% macro <adapter>__collect_freshness(`).\n- If none exists, the project uses core's implementation \u2014 mark skipped-not-present.\n- If one exists, inspect its final `{{ return(...) }}` and flag it if it returns the query\n  result table directly (e.g. `return(load_result('collect_freshness').table)` or\n  `return(table)`) rather than the full result object.",
+        "fixing": "- Change the macro to capture the full result and return an object exposing both the table and\n  the adapter response.\n- Pattern: `{% set result = run_query(...) %}` then\n  `{{ return({'table': result.table, 'response': result.response}) }}`.\n- Mirror core's 1.6 signature: it returns `load_result('collect_freshness')`, which already has\n  `.table` and `.response`.\n- Simplest safe fix, if the override only existed to tweak the SQL: align the return statement\n  with core 1.6's macro body.\n- After editing run `dbt parse`.\n- If the override is complex or the intended response object is unclear, record it in the\n  results report with a pointer to core's 1.6 collect_freshness for reference."
+      },
+      "_path": "kb/core/1_5_003.yaml"
+    },
+    {
+      "issue_id": "1_5_006",
+      "sort_order": 3060,
+      "change": "sslmode behavior changed; require/allow/prefer now map to verify-ca",
+      "action": "Review and update sslmode in profiles.yml (advisory)",
+      "category": "Breaking",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "In 1.6 the redshift_connector sslmode mapping changed: require/allow/prefer are treated as verify-ca, so connections that relied on the looser semantics may fail without a CA certificate.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": true,
+      "context": {
+        "detection": "- Connection-profile concern, not visible to dbt parse.\n- Look for `sslmode:` under a redshift target in profiles.yml (usually ~/.dbt/profiles.yml, but\n  also any in-repo profiles.yml or profiles template).\n- Flag values `require`, `allow`, or `prefer`.\n- If profiles.yml is not in the repo, this can only be advised, not edited.",
+        "fixing": "- ADVISORY \u2014 do not open a warehouse connection.\n- If an in-repo profiles.yml exists, note (do not silently rewrite auth) that require/allow/prefer\n  now behave as verify-ca.\n- Advise the user to either provide a CA cert (`sslrootcert`) or set the intended sslmode\n  explicitly (e.g. `disable` / `verify-ca` / `verify-full`) to match their security posture.\n- Record in the results report with the target name and current sslmode value.\n- Excluded from the dbt parse verify loop (connection behavior is not exercised by parse)."
+      },
+      "_path": "kb/redshift/1_5_006.yaml"
+    },
+    {
+      "issue_id": "1_5_007",
+      "sort_order": 3070,
+      "change": "Autocommit enabled by default (autocommit: True)",
+      "action": "Set autocommit: false in profiles.yml if you relied on 1.5's transactional behavior (advisory)",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "1.6 restores pre-1.5 semantics: autocommit defaults to True, so DDL and standalone statements auto-commit. Projects that depended on 1.5's implicit transaction wrapping (e.g. multi-statement hooks meant to roll back together) change behavior.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": true,
+      "context": {
+        "detection": "- Connection-profile concern, not visible to dbt parse.\n- Check the redshift target(s) in profiles.yml for an explicit `autocommit:` key.\n- Grep macros/**/*.sql and models for pre-hook/post-hook/on-run-* blocks containing explicit\n  BEGIN/COMMIT/ROLLBACK \u2014 these suggest the project relied on transactional grouping.\n- If neither profiles.yml is available nor transactional hooks exist, mark skipped-not-present.",
+        "fixing": "- ADVISORY \u2014 do not connect to the warehouse.\n- If the project shows reliance on transactional behavior, advise setting `autocommit: false` on\n  the redshift target in profiles.yml and record it in the results report (with target\n  name).\n- Do not blanket-add autocommit:false \u2014 the 1.6 default is intentional for most projects.\n- Excluded from the dbt parse verify loop."
+      },
+      "_path": "kb/redshift/1_5_007.yaml"
+    },
+    {
+      "issue_id": "1_5_008",
+      "sort_order": 3080,
+      "change": "list_relations_without_caching rewritten with Redshift-native SQL",
+      "action": "Review the macro if you override it; edge-case results may differ",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "1.6 replaces the Postgres-based relation listing with Redshift-native SQL. Projects that override redshift__list_relations_without_caching may diverge from the new base behavior on edge cases (late-binding views, external schemas).",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/**/*.sql for an override named `list_relations_without_caching`,\n  `redshift__list_relations_without_caching`, or `postgres__list_relations_without_caching`\n  used by the redshift adapter.\n- If no override exists, mark skipped-not-present \u2014 core's new implementation applies\n  automatically and needs no code change.",
+        "fixing": "- If an override exists, compare it against dbt-redshift 1.6's\n  redshift__list_relations_without_caching.\n- If the override only reproduced the old Postgres query, recommend removing it to inherit the\n  fixed native version.\n- If it adds project-specific logic, port that logic onto the 1.6 base query.\n- This is behavioral (warehouse-executed), so `dbt parse` passes regardless \u2014 record a\n  manual-actions note asking the user to validate relation listing against a live Redshift.\n- If unsure whether the override is still needed, flag it rather than deleting it."
+      },
+      "_path": "kb/redshift/1_5_008.yaml"
+    },
+    {
+      "issue_id": "1_6_011",
+      "sort_order": 4005,
+      "change": "dbt clean errors when clean-targets include source paths or paths outside the project",
+      "action": "Remove source paths (e.g. models/, macros/) and any path outside the project directory from clean-targets in dbt_project.yml",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "dbt clean now raises an error instead of silently deleting the wrong directories when clean-targets references source paths or paths outside the project root",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml's clean-targets list.\n- Flag any entry that resolves (relative to the project root) to a configured source path\n  (model-paths, seed-paths, macro-paths, etc.) or that resolves outside the project directory\n  (e.g. ../shared, /absolute/path).",
+        "fixing": "- Remove the offending entries from clean-targets, keeping only build/output directories\n  (e.g. target, dbt_packages, logs).\n- Re-run dbt clean to confirm it no longer errors."
+      },
+      "_path": "kb/core/1_6_011.yaml"
+    },
+    {
+      "issue_id": "1_6_001",
+      "sort_order": 4010,
+      "change": "New warning when --state and --target point to the same directory",
+      "action": "Fix --state/--target configuration so they reference distinct directories",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "WarnStateTargetEqual raised (informational) for previously silent misconfiguration; fatal under --warn-error",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- This is a runtime CLI/job configuration issue, not a repo-source issue, so `dbt parse` cannot\n  surface it. Detect by scanning invocation sites, not models.\n- Grep the repo for `--state` and `--target` / `--target-path` in shell scripts, Makefiles, and\n  `scripts/**/*.sh`.\n- Also grep CI configs: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `tox.ini`.\n- Check `dbt_project.yml` for a `target-path:` key (deprecated since 1.5 but may still be present).\n- Check for `DBT_STATE` / `DBT_TARGET_PATH` env vars in CI.\n- Flag any invocation where `--state` and `--target`/`--target-path` resolve to the same directory\n  (commonly both set to `target/`).\n- Note the value is frequently supplied outside the repo (dbt platform job definitions,\n  orchestration tools), which parse cannot see.",
+        "fixing": "- Point `--state` at a directory separate from the run's `--target` \u2014 e.g. keep run output in\n  `target/` and the comparison manifest in a distinct dir such as `state/` or `prod-artifacts/`.\n- Concretely, in the offending script/CI step change the duplicated paths so a command like\n  `dbt build --state ./state --target-path ./target` uses different dirs, and populate the state\n  artifacts there.\n- If the same-directory usage lives outside the repo (a dbt platform job command, an orchestration\n  tool), it cannot be edited from the repo.\n- For that out-of-repo case: record it in the results artifact (target/dbt_migration_results.json)\n  as manual-required with the issue_id, the invocation location if known, and the suggested command\n  change, then prompt the user.\n- This change never requires a repo edit to pass `dbt parse`; it is advisory / out-of-repo only."
+      },
+      "_path": "kb/core/1_6_001.yaml"
+    },
+    {
+      "issue_id": "1_6_002",
+      "sort_order": 4020,
+      "change": "Breaking contract changes on unversioned models now warn instead of error",
+      "action": "Add --warn-error (or version the models) to retain the previous hard-error behavior on breaking contract changes",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Unversioned models with a breaking schema/contract change warn via warn_or_error() instead of erroring; CI that relied on the error to block may now pass silently",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan schema YAML (`models/**/*.yml`, `models/**/*.yaml`) for models declaring `contract:` with\n  `enforced: true` that do NOT declare a `version:` / `versions:` block (i.e. unversioned).\n- Those unversioned enforced-contract models are the ones whose breaking contract changes now only\n  warn.\n- Also detect reliance on the old error behavior: grep CI/scripts for `dbt build` / `dbt run`\n  invocations that lack `--warn-error` or `--warn-error-options`.\n- Those flags are what previously turned the contract breakage into a hard failure.\n- This is a behavior/policy change; `dbt parse` stays clean either way, so detection is about intent,\n  not parse errors.",
+        "fixing": "- Preferred: preserve strict behavior by adding `--warn-error` (or a scoped `--warn-error-options`\n  targeting contract deprecations) to the relevant dbt invocation.\n- If that invocation is defined outside the repo (dbt platform job command, orchestration tool), it\n  cannot be edited here: record it in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the suggested flag, and prompt the user.\n- Alternative in-repo fix: add a `version:` to the affected models \u2014 versioning makes breaking\n  contract changes error again.\n- But versioning reshapes ref() resolution and downstream references, so only do it when the user\n  explicitly wants versioned models; note that trade-off in the results report rather than silently\n  versioning.\n- No edit is required for `dbt parse` to succeed."
+      },
+      "_path": "kb/core/1_6_002.yaml"
+    },
+    {
+      "issue_id": "1_6_003",
+      "sort_order": 4030,
+      "change": "New warning for contracted models with bare numeric columns (no precision/scale)",
+      "action": "Add explicit precision and scale to numeric column data_types in enforced contracts (e.g. numeric(38,3))",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with 'data_type: numeric' (or 'decimal') and no precision/scale in an enforced contract now emit a warning at parse time in 1.7",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- In schema YAML (`models/**/*.yml`, `models/**/*.yaml`), find models with `contract:`\n  `enforced: true` and columns whose `data_type` is a bare numeric type with no precision/scale.\n- Match the data_type value (case-insensitive) against `^(numeric|decimal|number)$` (no parentheses).\n- Types that already include `(p,s)` like `numeric(38,3)` are fine and must be left alone.\n- Only columns inside enforced-contract models trigger the warning; bare numeric on non-contracted\n  models is not affected.",
+        "fixing": "- For each flagged column, replace the bare type with an explicit precision/scale, e.g.\n  `data_type: numeric` -> `data_type: numeric(38,3)`.\n- Choose precision/scale from evidence in this order:\n- (1) an existing cast in the model SQL (e.g. `cast(x as numeric(18,2))`) \u2014 match it;\n- (2) the warehouse's documented default for unqualified numeric if the model is already built\n  (Snowflake NUMBER default is (38,0); Redshift/Postgres NUMERIC default is (38,0));\n- (3) if unknown, use a safe wide default `numeric(38,6)` and note the assumption in the results\n  report.\n- Preserve YAML quoting/style.\n- After editing, run `dbt parse`; if it fails, the likely cause is a mismatched type name for the\n  adapter (e.g. Snowflake prefers `number(38,3)`) \u2014 retry with the adapter-native spelling.\n- If the correct precision genuinely cannot be determined, leave the column and record it in the\n  results artifact (target/dbt_migration_results.json) as manual-required for the user to confirm."
+      },
+      "_path": "kb/core/1_6_003.yaml"
+    },
+    {
+      "issue_id": "1_6_004",
+      "sort_order": 4040,
+      "change": "merge_exclude_columns bug fix: excluded columns now correctly inserted in WHEN NOT MATCHED",
+      "action": "Review incremental models using merge_exclude_columns; excluded columns are now populated on new-row inserts",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "Incremental merge with merge_exclude_columns now inserts ALL columns for new rows (previously excluded columns were omitted on INSERT); resulting table data changes",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep model config for `merge_exclude_columns` in `models/**/*.sql` config() blocks (e.g.\n  `config(materialized='incremental', ... merge_exclude_columns=[...])`) and in schema YAML\n  `config:` blocks.\n- Only relevant when `materialized='incremental'` with the default `merge` strategy on the Redshift\n  adapter.\n- This is a behavior/warehouse change invisible to `dbt parse`; nothing makes parse fail.",
+        "fixing": "- No source edit is required to reach 1.8 or pass parse \u2014 the fix was in the adapter. The migration\n  action is to flag semantics.\n- For each model using merge_exclude_columns, new rows (WHEN NOT MATCHED) will now have the\n  previously-excluded columns inserted with their source values instead of being left null/default.\n- If the user intentionally relied on those columns being unset on insert, that assumption breaks.\n- Record each occurrence in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the issue_id, the model path, the merge_exclude_columns list, and a note to\n  verify the new insert behavior is acceptable.\n- Real validation happens in the warehouse build-green test layer, not here.\n- Do not modify the model unless the user confirms a semantic change is needed."
+      },
+      "_path": "kb/redshift/1_6_004.yaml"
+    },
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_004",
+      "sort_order": 5040,
+      "change": "Redshift catalog query macros restructured and split into multiple files",
+      "action": "Update custom overrides of redshift__get_base_catalog / catalog macros to match the new 1.8 structure",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "Custom overrides of redshift__get_catalog / redshift__get_base_catalog (and related catalog SQL) may break or silently diverge because the macro was split across a catalog/ directory in dbt-redshift 1.8",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant if the project (or an installed package) overrides Redshift catalog macros.\n- Grep macros/**/*.sql and packages' macros for definitions named `redshift__get_catalog`,\n  `redshift__get_base_catalog`, `redshift__get_catalog_relations`, or any\n  `{% macro redshift__...catalog...%}`.\n- If no such override exists, the change is not present (docs generate keeps working on the\n  built-in macros).\n- If an override exists, it likely mirrors the old single-file catalog.sql shape and will not\n  align with the 1.8 split.",
+        "fixing": "- If an override is found, compare it against the dbt-redshift 1.8 catalog macros (now under an\n  adapter catalog/ directory, split into base-catalog and relations pieces).\n- Re-implement the override on the new macro seams: typically split a monolithic\n  `redshift__get_catalog` override into `redshift__get_base_catalog` plus the relation-scoped\n  variant, matching the new signatures.\n- Invisible to `dbt parse` (catalog macros only compile when catalog generation runs), so parse\n  cannot validate correctness.\n- After adjusting, note that `dbt docs generate` against a warehouse is the real check (harness\n  build-green layer, not in-skill).\n- If the override's intent is unclear or reproducing the split is risky, record a manual-actions\n  entry pointing at the overriding macro and the dbt-redshift 1.8 catalog macro source."
+      },
+      "_path": "kb/redshift/1_7_004.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_4_snowflake.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_4_snowflake.json
@@ -1,0 +1,832 @@
+{
+  "from_version": "1.4",
+  "warehouse": "snowflake",
+  "target_version": "1.12",
+  "count": 38,
+  "issues": [
+    {
+      "issue_id": "1_4_001",
+      "sort_order": 2010,
+      "change": "--select/--exclude now accumulate when passed multiple times (argparse -> Click)",
+      "action": "Review scripts/jobs passing --select or --exclude more than once; collapse to a single flag with the intended union",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Scripts relying on last-wins override now see both selections combined, selecting more nodes than intended",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep in-repo invocation sites for repeated selection flags on a single command: shell scripts\n  (*.sh), Makefiles, CI YAML (.github/**, .gitlab-ci.yml, azure-pipelines.yml), tox.ini, and dbt\n  wrapper scripts.\n- Pattern: one dbt command containing two or more `--select`/`-s` or `--exclude` tokens (regex\n  `(--select|--exclude|-s)\\b.*\\b(--select|--exclude|-s)\\b`).\n- The real risk lives OUTSIDE the repo in dbt platform job definitions, so in-repo presence may be\n  zero even when the project is affected.",
+        "fixing": "- For each in-repo command with duplicated selection flags, decide intent: pre-1.5 was last-wins (only\n  the final flag applied); 1.5+ is union (all applied).\n- If the old intent was 'use only the last selection', delete the earlier occurrences. If a union was\n  intended, it already works \u2014 leave it.\n- Example: `dbt run --select tag:nightly --select my_model` (1.4 ran only my_model) -> `dbt run\n  --select my_model`.\n- Not visible to dbt parse.\n- ALWAYS add a results entry (manual-required): dbt platform job commands and orchestration outside\n  this repo may pass the flags multiple times; list the affected in-repo sites and tell the user to\n  audit job definitions."
+      },
+      "_path": "kb/core/1_4_001.yaml"
+    },
+    {
+      "issue_id": "1_4_002",
+      "sort_order": 2020,
+      "change": "Duplicate CLI flags before and after the subcommand now raise an error",
+      "action": "Ensure each CLI flag appears only once per dbt invocation",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands like `dbt --flag run --flag` now fail instead of silently taking one value",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan in-repo dbt invocation sites (shell scripts, Makefiles, CI YAML, tox.ini, wrapper scripts) for\n  a single dbt command repeating the same flag, especially placed both before and after the\n  subcommand.\n- Examples: `dbt --debug run --debug`, or a repeated `--profiles-dir` / `--target` / `--vars`.\n- Likeliest offenders: global flags (--debug, --profiles-dir, --project-dir, --target, --log-format)\n  appearing twice.\n- As with selection flags, the primary risk is in dbt platform job commands outside the repo.",
+        "fixing": "- Remove the duplicate occurrence, keeping the one with the intended value (pre-1.5 resolved to a\n  single value, so pick that).\n- Example: `dbt --target prod run --target prod` -> `dbt run --target prod`.\n- If two occurrences carry DIFFERENT values it was already ambiguous \u2014 keep the value the user\n  confirms and record the resolution in the migration log.\n- Not visible to dbt parse.\n- Add a results entry (manual-required) directing the user to audit external job/orchestration\n  commands for duplicated flags, since those now hard-error."
+      },
+      "_path": "kb/core/1_4_002.yaml"
+    },
+    {
+      "issue_id": "1_4_003",
+      "sort_order": 2030,
+      "change": "log-path in dbt_project.yml deprecated",
+      "action": "Move log-path out of dbt_project.yml to the --log-path CLI flag or DBT_LOG_PATH env var",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning at parse time; becomes fatal under --warn-error",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for a top-level `log-path:` key (regex `^\\s*log-path\\s*:`). Present if the key\n  exists with any value.\n- Only one location to check.",
+        "fixing": "- Remove the `log-path:` key from dbt_project.yml.\n- Re-provision out-of-repo: either the `--log-path <dir>` CLI flag on dbt invocations or the\n  `DBT_LOG_PATH` env var.\n- Because the effective destination now lives in job commands / env config outside this repo, add a\n  results entry recording the old value and telling the user to set --log-path/DBT_LOG_PATH wherever\n  dbt is invoked (CI, dbt platform jobs).\n- After removing the key, run dbt parse; the deprecation warning should be gone.\n- If parse still warns, confirm no other config file (a profiles-level or imported yml) re-declares\n  log-path."
+      },
+      "_path": "kb/core/1_4_003.yaml"
+    },
+    {
+      "issue_id": "1_4_004",
+      "sort_order": 2040,
+      "change": "target-path in dbt_project.yml deprecated",
+      "action": "Move target-path out of dbt_project.yml to the --target-path CLI flag or DBT_TARGET_PATH env var",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning at parse time; becomes fatal under --warn-error",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for a top-level `target-path:` key (regex `^\\s*target-path\\s*:`). Present if\n  the key exists.",
+        "fixing": "- Remove the `target-path:` key from dbt_project.yml.\n- Re-provision via the `--target-path <dir>` CLI flag or `DBT_TARGET_PATH` env var wherever dbt runs.\n- Add a results entry recording the old value and directing the user to set\n  --target-path/DBT_TARGET_PATH in job commands / CI / dbt platform, since anything reading generated\n  artifacts (manifest.json, run_results.json) from the custom path must be pointed at the new\n  location.\n- After removal, run dbt parse to confirm the warning is cleared."
+      },
+      "_path": "kb/core/1_4_004.yaml"
+    },
+    {
+      "issue_id": "1_4_005",
+      "sort_order": 2050,
+      "change": "DBT_NO_PRINT environment variable deprecated in favor of DBT_PRINT",
+      "action": "Replace DBT_NO_PRINT=true with DBT_PRINT=false",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for the literal `DBT_NO_PRINT` in CI YAML (.github/**, .gitlab-ci.yml, etc.),\n  Dockerfiles, .env / *.env files, shell scripts, Makefiles, and tox.ini. Present if the token appears\n  anywhere.\n- The variable is frequently set in orchestration outside the repo, so an in-repo miss does not mean\n  the project is clear.",
+        "fixing": "- Translate the value: DBT_NO_PRINT=true (suppress prints) becomes DBT_PRINT=false; DBT_NO_PRINT=false\n  becomes DBT_PRINT=true.\n- Update every in-repo occurrence found.\n- This is an env-var rename, not a Python-environment change, so it is a normal advisory edit (not\n  environment_change) and is not verified by dbt parse.\n- Add a results entry telling the user to replace DBT_NO_PRINT in external CI / dbt platform\n  environment settings with DBT_PRINT (inverted value)."
+      },
+      "_path": "kb/core/1_4_005.yaml"
+    },
+    {
+      "issue_id": "1_4_006",
+      "sort_order": 2060,
+      "change": "DBT_ARTIFACT_STATE_PATH environment variable deprecated in favor of DBT_STATE",
+      "action": "Replace DBT_ARTIFACT_STATE_PATH with DBT_STATE",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_ARTIFACT_STATE_PATH` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Commonly used in Slim CI / state-deferral setups that live in orchestration outside the repo.",
+        "fixing": "- Rename the variable to `DBT_STATE`, keeping the same value (path to the state/manifest directory).\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry telling the user to rename DBT_ARTIFACT_STATE_PATH to DBT_STATE in external CI\n  and dbt platform job environments used for state:modified / --defer selection."
+      },
+      "_path": "kb/core/1_4_006.yaml"
+    },
+    {
+      "issue_id": "1_4_007",
+      "sort_order": 2070,
+      "change": "DBT_FAVOR_STATE_MODE environment variable deprecated in favor of DBT_FAVOR_STATE",
+      "action": "Replace DBT_FAVOR_STATE_MODE with DBT_FAVOR_STATE",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_FAVOR_STATE_MODE` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Typically set in state-based CI selection outside the repo.",
+        "fixing": "- Rename to `DBT_FAVOR_STATE`, preserving the value.\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry directing the user to rename this variable in external CI / dbt platform\n  environments."
+      },
+      "_path": "kb/core/1_4_007.yaml"
+    },
+    {
+      "issue_id": "1_4_008",
+      "sort_order": 2080,
+      "change": "DBT_DEFER_TO_STATE environment variable deprecated in favor of DBT_DEFER",
+      "action": "Replace DBT_DEFER_TO_STATE with DBT_DEFER",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_DEFER_TO_STATE` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Used in --defer based CI workflows that usually live outside the repo.",
+        "fixing": "- Rename to `DBT_DEFER`, preserving the boolean value.\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry directing the user to rename DBT_DEFER_TO_STATE to DBT_DEFER in external CI /\n  dbt platform environments."
+      },
+      "_path": "kb/core/1_4_008.yaml"
+    },
+    {
+      "issue_id": "1_4_009",
+      "sort_order": 2090,
+      "change": "Isolated BEGIN/COMMIT statements now produce a warning",
+      "action": "Review custom macros/hooks that issue standalone BEGIN/COMMIT and remove or restructure them",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "snowflake",
+      "impact": "Standalone transactional keywords trigger a warning; transaction handling is managed by dbt",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/**/*.sql, models/**/*.sql (hooks embedded via config), and dbt_project.yml / model\n  configs for pre-hook / post-hook / on-run-start / on-run-end entries and macro bodies with a\n  standalone `BEGIN;`, `COMMIT;`, or `begin transaction` / `commit` not inside a stored-procedure\n  body.\n- Regex (case-insensitive): `(^|\\n)\\s*(begin|commit)\\s*;`.\n- Present when such isolated statements exist in Snowflake-targeted code.",
+        "fixing": "- Remove standalone BEGIN/COMMIT from hooks and custom macros; dbt manages transactions itself, so\n  these are redundant and now warn.\n- If the intent was to wrap several statements atomically, move that logic into a single statement or\n  a Snowflake stored procedure / scripting block rather than emitting bare transactional keywords.\n- Warehouse-behavior change invisible to dbt parse; parse passing does not confirm the warning is\n  gone.\n- Verify by grepping that no isolated BEGIN/COMMIT remain.\n- If a hook genuinely must control transactions, record it in the results report for user review."
+      },
+      "_path": "kb/snowflake/1_4_009.yaml"
+    },
+    {
+      "issue_id": "1_5_001",
+      "sort_order": 3010,
+      "change": "Metric YAML schema completely rewritten for MetricFlow",
+      "action": "Rewrite all metric definitions using the new type/type_params/filter format",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "All existing metric YAML definitions fail to parse in 1.6; the pre-1.6 UnparsedMetric fields (calculation_method, expression, sql, model, type: expression) and the rename_metric_attr compatibility shim were removed.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Search every YAML file under models/ and any schema-file globs declared in dbt_project.yml\n  (models/**/*.yml, models/**/*.yaml, plus any top-level metrics/ dir) for a `metrics:` block.\n- Flag a metric as legacy (pre-1.6) if its entry uses ANY of these keys: `calculation_method`,\n  `expression`, `sql`, `type: expression`, a top-level `type:` with the old enum\n  (`count`/`sum`/...), `model:`, `timestamp:`, `time_grains:`, `dimensions:` directly on the\n  metric, or `filters:` (the list-of-dict old form).\n- The new MetricFlow schema instead uses `type:` with values simple|ratio|cumulative|derived\n  plus a `type_params:` block. If a metric already has `type_params:`, it is migrated \u2014 skip it.\n- Also grep packages.yml for `dbt_metrics` usage and models for `metrics.calculate(` /\n  `metrics.develop(` macro calls \u2014 those depend on the old package and must be flagged too.",
+        "fixing": "- Rewrite each legacy metric into the new schema. Attribute mapping:\n  - `calculation_method` -> `type`: sum/average/min/max/count/count_distinct/median become\n    `type: simple` with `type_params.measure`; derived/expression become `type: derived` with\n    `type_params.expr` and `type_params.metrics`.\n  - `expression`/`sql` -> `type_params.measure` (the semantic measure name), or\n    `type_params.expr` for a derived metric.\n  - `model:` -> moves into a `semantic_models:` definition (see example below).\n  - `filters:` -> `filter:` (a single `{{ Dimension(...) }}` string, or keep the WHERE fragment).\n- Concrete before/after:\n  BEFORE (1.5):\n    metrics:\n      - name: total_revenue\n        calculation_method: sum\n        expression: amount\n        model: ref('orders')\n        timestamp: order_date\n        time_grains: [day, month]\n        dimensions: [status]\n  AFTER (1.6, MetricFlow):\n    semantic_models:\n      - name: orders\n        model: ref('orders')\n        defaults:\n          agg_time_dimension: order_date\n        entities:\n          - name: order\n            type: primary\n        dimensions:\n          - name: order_date\n            type: time\n            type_params: {time_granularity: day}\n          - name: status\n            type: categorical\n        measures:\n          - name: amount\n            agg: sum\n            agg_time_dimension: order_date\n    metrics:\n      - name: total_revenue\n        type: simple\n        type_params:\n          measure: amount\n- Derived example: `calculation_method: derived` + `expression: revenue - cost` becomes\n  `type: derived` with `type_params: {expr: 'revenue - cost', metrics: [{name: revenue},\n  {name: cost}]}`.\n- Judgment-heavy: 1.6 requires a `semantic_models:` layer that did not exist in 1.5, so the\n  measure/entity/dimension split cannot always be inferred mechanically.\n- If you cannot confidently reconstruct the semantic model (e.g. the source model's grain or\n  entities are ambiguous), do NOT guess \u2014 record the metric in the results report with\n  the original YAML and the suggested new shape, and move on.\n- After editing, run `dbt parse`. On a metric/semantic-model validation error, re-read it;\n  reverting to legacy form is NOT an option (it won't parse in 1.6) \u2014 instead leave the\n  semantic_model skeleton and flag it manual.\n- Remove `dbt_metrics` / `metrics.calculate` usages and flag them as requiring the\n  MetricFlow / Semantic Layer migration (out of scope for parse)."
+      },
+      "_path": "kb/core/1_5_001.yaml"
+    },
+    {
+      "issue_id": "1_5_002",
+      "sort_order": 3020,
+      "change": "Duplicate node names allowed across packages",
+      "action": "Disambiguate cross-package references with two-argument ref('package_name', 'model_name')",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.5 a flat manifest dict raised DuplicateResourceNameError; in 1.6 names are stored per-package, so a project and an installed package can legitimately share a model name. Single-argument ref() to a name that exists in more than one package becomes ambiguous (AmbiguousAliasError / wrong node).",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant if packages.yml / dependencies.yml declares packages.\n- Build the set of model/seed/snapshot names defined in the local project (models/**/*.sql,\n  seeds/**/*.csv, snapshots/**/*.sql).\n- Where available, add the names exposed by installed packages under dbt_packages/*/models.\n- Grep all .sql/.yml for single-argument `ref('name')` / `ref(\"name\")` whose `name` collides\n  with a name present in BOTH the local project and a package (or in two packages) \u2014 those are\n  the ambiguous refs.\n- If no packages are installed, mark skipped-not-present.",
+        "fixing": "- For each ambiguous single-arg ref, rewrite to the two-argument form\n  `ref('<package_name>', '<model_name>')`.\n- Choose the package the author intended; default to the local project's own model unless the\n  surrounding SQL clearly consumes the package's version.\n- Example: `ref('customers')` -> `ref('my_project', 'customers')` or\n  `ref('dbt_utils', 'customers')`. Leave unambiguous refs untouched.\n- After edits run `dbt parse`; a remaining AmbiguousAliasError names the offending ref and node.\n- If you cannot determine which package is intended, record it in the results report\n  rather than guessing \u2014 picking the wrong package silently changes lineage."
+      },
+      "_path": "kb/core/1_5_002.yaml"
+    },
+    {
+      "issue_id": "1_5_003",
+      "sort_order": 3030,
+      "change": "collect_freshness macro return type changed",
+      "action": "Update any custom collect_freshness macro override to return the full result object (table + response) instead of just the table",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.6 core's default collect_freshness returns a dict-like {table, response} object; a custom override that returns only the agate table triggers a deprecation warning and will break source freshness in later versions.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/**/*.sql for a macro named `collect_freshness` (i.e. `{% macro collect_freshness(`\n  or `{% macro <adapter>__collect_freshness(`).\n- If none exists, the project uses core's implementation \u2014 mark skipped-not-present.\n- If one exists, inspect its final `{{ return(...) }}` and flag it if it returns the query\n  result table directly (e.g. `return(load_result('collect_freshness').table)` or\n  `return(table)`) rather than the full result object.",
+        "fixing": "- Change the macro to capture the full result and return an object exposing both the table and\n  the adapter response.\n- Pattern: `{% set result = run_query(...) %}` then\n  `{{ return({'table': result.table, 'response': result.response}) }}`.\n- Mirror core's 1.6 signature: it returns `load_result('collect_freshness')`, which already has\n  `.table` and `.response`.\n- Simplest safe fix, if the override only existed to tweak the SQL: align the return statement\n  with core 1.6's macro body.\n- After editing run `dbt parse`.\n- If the override is complex or the intended response object is unclear, record it in the\n  results report with a pointer to core's 1.6 collect_freshness for reference."
+      },
+      "_path": "kb/core/1_5_003.yaml"
+    },
+    {
+      "issue_id": "1_6_011",
+      "sort_order": 4005,
+      "change": "dbt clean errors when clean-targets include source paths or paths outside the project",
+      "action": "Remove source paths (e.g. models/, macros/) and any path outside the project directory from clean-targets in dbt_project.yml",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "dbt clean now raises an error instead of silently deleting the wrong directories when clean-targets references source paths or paths outside the project root",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml's clean-targets list.\n- Flag any entry that resolves (relative to the project root) to a configured source path\n  (model-paths, seed-paths, macro-paths, etc.) or that resolves outside the project directory\n  (e.g. ../shared, /absolute/path).",
+        "fixing": "- Remove the offending entries from clean-targets, keeping only build/output directories\n  (e.g. target, dbt_packages, logs).\n- Re-run dbt clean to confirm it no longer errors."
+      },
+      "_path": "kb/core/1_6_011.yaml"
+    },
+    {
+      "issue_id": "1_6_001",
+      "sort_order": 4010,
+      "change": "New warning when --state and --target point to the same directory",
+      "action": "Fix --state/--target configuration so they reference distinct directories",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "WarnStateTargetEqual raised (informational) for previously silent misconfiguration; fatal under --warn-error",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- This is a runtime CLI/job configuration issue, not a repo-source issue, so `dbt parse` cannot\n  surface it. Detect by scanning invocation sites, not models.\n- Grep the repo for `--state` and `--target` / `--target-path` in shell scripts, Makefiles, and\n  `scripts/**/*.sh`.\n- Also grep CI configs: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `tox.ini`.\n- Check `dbt_project.yml` for a `target-path:` key (deprecated since 1.5 but may still be present).\n- Check for `DBT_STATE` / `DBT_TARGET_PATH` env vars in CI.\n- Flag any invocation where `--state` and `--target`/`--target-path` resolve to the same directory\n  (commonly both set to `target/`).\n- Note the value is frequently supplied outside the repo (dbt platform job definitions,\n  orchestration tools), which parse cannot see.",
+        "fixing": "- Point `--state` at a directory separate from the run's `--target` \u2014 e.g. keep run output in\n  `target/` and the comparison manifest in a distinct dir such as `state/` or `prod-artifacts/`.\n- Concretely, in the offending script/CI step change the duplicated paths so a command like\n  `dbt build --state ./state --target-path ./target` uses different dirs, and populate the state\n  artifacts there.\n- If the same-directory usage lives outside the repo (a dbt platform job command, an orchestration\n  tool), it cannot be edited from the repo.\n- For that out-of-repo case: record it in the results artifact (target/dbt_migration_results.json)\n  as manual-required with the issue_id, the invocation location if known, and the suggested command\n  change, then prompt the user.\n- This change never requires a repo edit to pass `dbt parse`; it is advisory / out-of-repo only."
+      },
+      "_path": "kb/core/1_6_001.yaml"
+    },
+    {
+      "issue_id": "1_6_002",
+      "sort_order": 4020,
+      "change": "Breaking contract changes on unversioned models now warn instead of error",
+      "action": "Add --warn-error (or version the models) to retain the previous hard-error behavior on breaking contract changes",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Unversioned models with a breaking schema/contract change warn via warn_or_error() instead of erroring; CI that relied on the error to block may now pass silently",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan schema YAML (`models/**/*.yml`, `models/**/*.yaml`) for models declaring `contract:` with\n  `enforced: true` that do NOT declare a `version:` / `versions:` block (i.e. unversioned).\n- Those unversioned enforced-contract models are the ones whose breaking contract changes now only\n  warn.\n- Also detect reliance on the old error behavior: grep CI/scripts for `dbt build` / `dbt run`\n  invocations that lack `--warn-error` or `--warn-error-options`.\n- Those flags are what previously turned the contract breakage into a hard failure.\n- This is a behavior/policy change; `dbt parse` stays clean either way, so detection is about intent,\n  not parse errors.",
+        "fixing": "- Preferred: preserve strict behavior by adding `--warn-error` (or a scoped `--warn-error-options`\n  targeting contract deprecations) to the relevant dbt invocation.\n- If that invocation is defined outside the repo (dbt platform job command, orchestration tool), it\n  cannot be edited here: record it in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the suggested flag, and prompt the user.\n- Alternative in-repo fix: add a `version:` to the affected models \u2014 versioning makes breaking\n  contract changes error again.\n- But versioning reshapes ref() resolution and downstream references, so only do it when the user\n  explicitly wants versioned models; note that trade-off in the results report rather than silently\n  versioning.\n- No edit is required for `dbt parse` to succeed."
+      },
+      "_path": "kb/core/1_6_002.yaml"
+    },
+    {
+      "issue_id": "1_6_003",
+      "sort_order": 4030,
+      "change": "New warning for contracted models with bare numeric columns (no precision/scale)",
+      "action": "Add explicit precision and scale to numeric column data_types in enforced contracts (e.g. numeric(38,3))",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with 'data_type: numeric' (or 'decimal') and no precision/scale in an enforced contract now emit a warning at parse time in 1.7",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- In schema YAML (`models/**/*.yml`, `models/**/*.yaml`), find models with `contract:`\n  `enforced: true` and columns whose `data_type` is a bare numeric type with no precision/scale.\n- Match the data_type value (case-insensitive) against `^(numeric|decimal|number)$` (no parentheses).\n- Types that already include `(p,s)` like `numeric(38,3)` are fine and must be left alone.\n- Only columns inside enforced-contract models trigger the warning; bare numeric on non-contracted\n  models is not affected.",
+        "fixing": "- For each flagged column, replace the bare type with an explicit precision/scale, e.g.\n  `data_type: numeric` -> `data_type: numeric(38,3)`.\n- Choose precision/scale from evidence in this order:\n- (1) an existing cast in the model SQL (e.g. `cast(x as numeric(18,2))`) \u2014 match it;\n- (2) the warehouse's documented default for unqualified numeric if the model is already built\n  (Snowflake NUMBER default is (38,0); Redshift/Postgres NUMERIC default is (38,0));\n- (3) if unknown, use a safe wide default `numeric(38,6)` and note the assumption in the results\n  report.\n- Preserve YAML quoting/style.\n- After editing, run `dbt parse`; if it fails, the likely cause is a mismatched type name for the\n  adapter (e.g. Snowflake prefers `number(38,3)`) \u2014 retry with the adapter-native spelling.\n- If the correct precision genuinely cannot be determined, leave the column and record it in the\n  results artifact (target/dbt_migration_results.json) as manual-required for the user to confirm."
+      },
+      "_path": "kb/core/1_6_003.yaml"
+    },
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_4_spark.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_4_spark.json
@@ -1,0 +1,832 @@
+{
+  "from_version": "1.4",
+  "warehouse": "spark",
+  "target_version": "1.12",
+  "count": 38,
+  "issues": [
+    {
+      "issue_id": "1_4_001",
+      "sort_order": 2010,
+      "change": "--select/--exclude now accumulate when passed multiple times (argparse -> Click)",
+      "action": "Review scripts/jobs passing --select or --exclude more than once; collapse to a single flag with the intended union",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Scripts relying on last-wins override now see both selections combined, selecting more nodes than intended",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep in-repo invocation sites for repeated selection flags on a single command: shell scripts\n  (*.sh), Makefiles, CI YAML (.github/**, .gitlab-ci.yml, azure-pipelines.yml), tox.ini, and dbt\n  wrapper scripts.\n- Pattern: one dbt command containing two or more `--select`/`-s` or `--exclude` tokens (regex\n  `(--select|--exclude|-s)\\b.*\\b(--select|--exclude|-s)\\b`).\n- The real risk lives OUTSIDE the repo in dbt platform job definitions, so in-repo presence may be\n  zero even when the project is affected.",
+        "fixing": "- For each in-repo command with duplicated selection flags, decide intent: pre-1.5 was last-wins (only\n  the final flag applied); 1.5+ is union (all applied).\n- If the old intent was 'use only the last selection', delete the earlier occurrences. If a union was\n  intended, it already works \u2014 leave it.\n- Example: `dbt run --select tag:nightly --select my_model` (1.4 ran only my_model) -> `dbt run\n  --select my_model`.\n- Not visible to dbt parse.\n- ALWAYS add a results entry (manual-required): dbt platform job commands and orchestration outside\n  this repo may pass the flags multiple times; list the affected in-repo sites and tell the user to\n  audit job definitions."
+      },
+      "_path": "kb/core/1_4_001.yaml"
+    },
+    {
+      "issue_id": "1_4_002",
+      "sort_order": 2020,
+      "change": "Duplicate CLI flags before and after the subcommand now raise an error",
+      "action": "Ensure each CLI flag appears only once per dbt invocation",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands like `dbt --flag run --flag` now fail instead of silently taking one value",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan in-repo dbt invocation sites (shell scripts, Makefiles, CI YAML, tox.ini, wrapper scripts) for\n  a single dbt command repeating the same flag, especially placed both before and after the\n  subcommand.\n- Examples: `dbt --debug run --debug`, or a repeated `--profiles-dir` / `--target` / `--vars`.\n- Likeliest offenders: global flags (--debug, --profiles-dir, --project-dir, --target, --log-format)\n  appearing twice.\n- As with selection flags, the primary risk is in dbt platform job commands outside the repo.",
+        "fixing": "- Remove the duplicate occurrence, keeping the one with the intended value (pre-1.5 resolved to a\n  single value, so pick that).\n- Example: `dbt --target prod run --target prod` -> `dbt run --target prod`.\n- If two occurrences carry DIFFERENT values it was already ambiguous \u2014 keep the value the user\n  confirms and record the resolution in the migration log.\n- Not visible to dbt parse.\n- Add a results entry (manual-required) directing the user to audit external job/orchestration\n  commands for duplicated flags, since those now hard-error."
+      },
+      "_path": "kb/core/1_4_002.yaml"
+    },
+    {
+      "issue_id": "1_4_003",
+      "sort_order": 2030,
+      "change": "log-path in dbt_project.yml deprecated",
+      "action": "Move log-path out of dbt_project.yml to the --log-path CLI flag or DBT_LOG_PATH env var",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning at parse time; becomes fatal under --warn-error",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for a top-level `log-path:` key (regex `^\\s*log-path\\s*:`). Present if the key\n  exists with any value.\n- Only one location to check.",
+        "fixing": "- Remove the `log-path:` key from dbt_project.yml.\n- Re-provision out-of-repo: either the `--log-path <dir>` CLI flag on dbt invocations or the\n  `DBT_LOG_PATH` env var.\n- Because the effective destination now lives in job commands / env config outside this repo, add a\n  results entry recording the old value and telling the user to set --log-path/DBT_LOG_PATH wherever\n  dbt is invoked (CI, dbt platform jobs).\n- After removing the key, run dbt parse; the deprecation warning should be gone.\n- If parse still warns, confirm no other config file (a profiles-level or imported yml) re-declares\n  log-path."
+      },
+      "_path": "kb/core/1_4_003.yaml"
+    },
+    {
+      "issue_id": "1_4_004",
+      "sort_order": 2040,
+      "change": "target-path in dbt_project.yml deprecated",
+      "action": "Move target-path out of dbt_project.yml to the --target-path CLI flag or DBT_TARGET_PATH env var",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning at parse time; becomes fatal under --warn-error",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml for a top-level `target-path:` key (regex `^\\s*target-path\\s*:`). Present if\n  the key exists.",
+        "fixing": "- Remove the `target-path:` key from dbt_project.yml.\n- Re-provision via the `--target-path <dir>` CLI flag or `DBT_TARGET_PATH` env var wherever dbt runs.\n- Add a results entry recording the old value and directing the user to set\n  --target-path/DBT_TARGET_PATH in job commands / CI / dbt platform, since anything reading generated\n  artifacts (manifest.json, run_results.json) from the custom path must be pointed at the new\n  location.\n- After removal, run dbt parse to confirm the warning is cleared."
+      },
+      "_path": "kb/core/1_4_004.yaml"
+    },
+    {
+      "issue_id": "1_4_005",
+      "sort_order": 2050,
+      "change": "DBT_NO_PRINT environment variable deprecated in favor of DBT_PRINT",
+      "action": "Replace DBT_NO_PRINT=true with DBT_PRINT=false",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for the literal `DBT_NO_PRINT` in CI YAML (.github/**, .gitlab-ci.yml, etc.),\n  Dockerfiles, .env / *.env files, shell scripts, Makefiles, and tox.ini. Present if the token appears\n  anywhere.\n- The variable is frequently set in orchestration outside the repo, so an in-repo miss does not mean\n  the project is clear.",
+        "fixing": "- Translate the value: DBT_NO_PRINT=true (suppress prints) becomes DBT_PRINT=false; DBT_NO_PRINT=false\n  becomes DBT_PRINT=true.\n- Update every in-repo occurrence found.\n- This is an env-var rename, not a Python-environment change, so it is a normal advisory edit (not\n  environment_change) and is not verified by dbt parse.\n- Add a results entry telling the user to replace DBT_NO_PRINT in external CI / dbt platform\n  environment settings with DBT_PRINT (inverted value)."
+      },
+      "_path": "kb/core/1_4_005.yaml"
+    },
+    {
+      "issue_id": "1_4_006",
+      "sort_order": 2060,
+      "change": "DBT_ARTIFACT_STATE_PATH environment variable deprecated in favor of DBT_STATE",
+      "action": "Replace DBT_ARTIFACT_STATE_PATH with DBT_STATE",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_ARTIFACT_STATE_PATH` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Commonly used in Slim CI / state-deferral setups that live in orchestration outside the repo.",
+        "fixing": "- Rename the variable to `DBT_STATE`, keeping the same value (path to the state/manifest directory).\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry telling the user to rename DBT_ARTIFACT_STATE_PATH to DBT_STATE in external CI\n  and dbt platform job environments used for state:modified / --defer selection."
+      },
+      "_path": "kb/core/1_4_006.yaml"
+    },
+    {
+      "issue_id": "1_4_007",
+      "sort_order": 2070,
+      "change": "DBT_FAVOR_STATE_MODE environment variable deprecated in favor of DBT_FAVOR_STATE",
+      "action": "Replace DBT_FAVOR_STATE_MODE with DBT_FAVOR_STATE",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_FAVOR_STATE_MODE` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Typically set in state-based CI selection outside the repo.",
+        "fixing": "- Rename to `DBT_FAVOR_STATE`, preserving the value.\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry directing the user to rename this variable in external CI / dbt platform\n  environments."
+      },
+      "_path": "kb/core/1_4_007.yaml"
+    },
+    {
+      "issue_id": "1_4_008",
+      "sort_order": 2080,
+      "change": "DBT_DEFER_TO_STATE environment variable deprecated in favor of DBT_DEFER",
+      "action": "Replace DBT_DEFER_TO_STATE with DBT_DEFER",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Deprecation warning; the old variable still works for now",
+      "from_version": "1.4",
+      "to_version": "1.5",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `DBT_DEFER_TO_STATE` in CI YAML, Dockerfiles, .env files, shell scripts,\n  Makefiles, tox.ini.\n- Used in --defer based CI workflows that usually live outside the repo.",
+        "fixing": "- Rename to `DBT_DEFER`, preserving the boolean value.\n- Update all in-repo occurrences. Advisory env-var rename, not verified by dbt parse.\n- Add a results entry directing the user to rename DBT_DEFER_TO_STATE to DBT_DEFER in external CI /\n  dbt platform environments."
+      },
+      "_path": "kb/core/1_4_008.yaml"
+    },
+    {
+      "issue_id": "1_5_001",
+      "sort_order": 3010,
+      "change": "Metric YAML schema completely rewritten for MetricFlow",
+      "action": "Rewrite all metric definitions using the new type/type_params/filter format",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "All existing metric YAML definitions fail to parse in 1.6; the pre-1.6 UnparsedMetric fields (calculation_method, expression, sql, model, type: expression) and the rename_metric_attr compatibility shim were removed.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Search every YAML file under models/ and any schema-file globs declared in dbt_project.yml\n  (models/**/*.yml, models/**/*.yaml, plus any top-level metrics/ dir) for a `metrics:` block.\n- Flag a metric as legacy (pre-1.6) if its entry uses ANY of these keys: `calculation_method`,\n  `expression`, `sql`, `type: expression`, a top-level `type:` with the old enum\n  (`count`/`sum`/...), `model:`, `timestamp:`, `time_grains:`, `dimensions:` directly on the\n  metric, or `filters:` (the list-of-dict old form).\n- The new MetricFlow schema instead uses `type:` with values simple|ratio|cumulative|derived\n  plus a `type_params:` block. If a metric already has `type_params:`, it is migrated \u2014 skip it.\n- Also grep packages.yml for `dbt_metrics` usage and models for `metrics.calculate(` /\n  `metrics.develop(` macro calls \u2014 those depend on the old package and must be flagged too.",
+        "fixing": "- Rewrite each legacy metric into the new schema. Attribute mapping:\n  - `calculation_method` -> `type`: sum/average/min/max/count/count_distinct/median become\n    `type: simple` with `type_params.measure`; derived/expression become `type: derived` with\n    `type_params.expr` and `type_params.metrics`.\n  - `expression`/`sql` -> `type_params.measure` (the semantic measure name), or\n    `type_params.expr` for a derived metric.\n  - `model:` -> moves into a `semantic_models:` definition (see example below).\n  - `filters:` -> `filter:` (a single `{{ Dimension(...) }}` string, or keep the WHERE fragment).\n- Concrete before/after:\n  BEFORE (1.5):\n    metrics:\n      - name: total_revenue\n        calculation_method: sum\n        expression: amount\n        model: ref('orders')\n        timestamp: order_date\n        time_grains: [day, month]\n        dimensions: [status]\n  AFTER (1.6, MetricFlow):\n    semantic_models:\n      - name: orders\n        model: ref('orders')\n        defaults:\n          agg_time_dimension: order_date\n        entities:\n          - name: order\n            type: primary\n        dimensions:\n          - name: order_date\n            type: time\n            type_params: {time_granularity: day}\n          - name: status\n            type: categorical\n        measures:\n          - name: amount\n            agg: sum\n            agg_time_dimension: order_date\n    metrics:\n      - name: total_revenue\n        type: simple\n        type_params:\n          measure: amount\n- Derived example: `calculation_method: derived` + `expression: revenue - cost` becomes\n  `type: derived` with `type_params: {expr: 'revenue - cost', metrics: [{name: revenue},\n  {name: cost}]}`.\n- Judgment-heavy: 1.6 requires a `semantic_models:` layer that did not exist in 1.5, so the\n  measure/entity/dimension split cannot always be inferred mechanically.\n- If you cannot confidently reconstruct the semantic model (e.g. the source model's grain or\n  entities are ambiguous), do NOT guess \u2014 record the metric in the results report with\n  the original YAML and the suggested new shape, and move on.\n- After editing, run `dbt parse`. On a metric/semantic-model validation error, re-read it;\n  reverting to legacy form is NOT an option (it won't parse in 1.6) \u2014 instead leave the\n  semantic_model skeleton and flag it manual.\n- Remove `dbt_metrics` / `metrics.calculate` usages and flag them as requiring the\n  MetricFlow / Semantic Layer migration (out of scope for parse)."
+      },
+      "_path": "kb/core/1_5_001.yaml"
+    },
+    {
+      "issue_id": "1_5_002",
+      "sort_order": 3020,
+      "change": "Duplicate node names allowed across packages",
+      "action": "Disambiguate cross-package references with two-argument ref('package_name', 'model_name')",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.5 a flat manifest dict raised DuplicateResourceNameError; in 1.6 names are stored per-package, so a project and an installed package can legitimately share a model name. Single-argument ref() to a name that exists in more than one package becomes ambiguous (AmbiguousAliasError / wrong node).",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant if packages.yml / dependencies.yml declares packages.\n- Build the set of model/seed/snapshot names defined in the local project (models/**/*.sql,\n  seeds/**/*.csv, snapshots/**/*.sql).\n- Where available, add the names exposed by installed packages under dbt_packages/*/models.\n- Grep all .sql/.yml for single-argument `ref('name')` / `ref(\"name\")` whose `name` collides\n  with a name present in BOTH the local project and a package (or in two packages) \u2014 those are\n  the ambiguous refs.\n- If no packages are installed, mark skipped-not-present.",
+        "fixing": "- For each ambiguous single-arg ref, rewrite to the two-argument form\n  `ref('<package_name>', '<model_name>')`.\n- Choose the package the author intended; default to the local project's own model unless the\n  surrounding SQL clearly consumes the package's version.\n- Example: `ref('customers')` -> `ref('my_project', 'customers')` or\n  `ref('dbt_utils', 'customers')`. Leave unambiguous refs untouched.\n- After edits run `dbt parse`; a remaining AmbiguousAliasError names the offending ref and node.\n- If you cannot determine which package is intended, record it in the results report\n  rather than guessing \u2014 picking the wrong package silently changes lineage."
+      },
+      "_path": "kb/core/1_5_002.yaml"
+    },
+    {
+      "issue_id": "1_5_003",
+      "sort_order": 3030,
+      "change": "collect_freshness macro return type changed",
+      "action": "Update any custom collect_freshness macro override to return the full result object (table + response) instead of just the table",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.6 core's default collect_freshness returns a dict-like {table, response} object; a custom override that returns only the agate table triggers a deprecation warning and will break source freshness in later versions.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/**/*.sql for a macro named `collect_freshness` (i.e. `{% macro collect_freshness(`\n  or `{% macro <adapter>__collect_freshness(`).\n- If none exists, the project uses core's implementation \u2014 mark skipped-not-present.\n- If one exists, inspect its final `{{ return(...) }}` and flag it if it returns the query\n  result table directly (e.g. `return(load_result('collect_freshness').table)` or\n  `return(table)`) rather than the full result object.",
+        "fixing": "- Change the macro to capture the full result and return an object exposing both the table and\n  the adapter response.\n- Pattern: `{% set result = run_query(...) %}` then\n  `{{ return({'table': result.table, 'response': result.response}) }}`.\n- Mirror core's 1.6 signature: it returns `load_result('collect_freshness')`, which already has\n  `.table` and `.response`.\n- Simplest safe fix, if the override only existed to tweak the SQL: align the return statement\n  with core 1.6's macro body.\n- After editing run `dbt parse`.\n- If the override is complex or the intended response object is unclear, record it in the\n  results report with a pointer to core's 1.6 collect_freshness for reference."
+      },
+      "_path": "kb/core/1_5_003.yaml"
+    },
+    {
+      "issue_id": "1_6_011",
+      "sort_order": 4005,
+      "change": "dbt clean errors when clean-targets include source paths or paths outside the project",
+      "action": "Remove source paths (e.g. models/, macros/) and any path outside the project directory from clean-targets in dbt_project.yml",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "dbt clean now raises an error instead of silently deleting the wrong directories when clean-targets references source paths or paths outside the project root",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml's clean-targets list.\n- Flag any entry that resolves (relative to the project root) to a configured source path\n  (model-paths, seed-paths, macro-paths, etc.) or that resolves outside the project directory\n  (e.g. ../shared, /absolute/path).",
+        "fixing": "- Remove the offending entries from clean-targets, keeping only build/output directories\n  (e.g. target, dbt_packages, logs).\n- Re-run dbt clean to confirm it no longer errors."
+      },
+      "_path": "kb/core/1_6_011.yaml"
+    },
+    {
+      "issue_id": "1_6_001",
+      "sort_order": 4010,
+      "change": "New warning when --state and --target point to the same directory",
+      "action": "Fix --state/--target configuration so they reference distinct directories",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "WarnStateTargetEqual raised (informational) for previously silent misconfiguration; fatal under --warn-error",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- This is a runtime CLI/job configuration issue, not a repo-source issue, so `dbt parse` cannot\n  surface it. Detect by scanning invocation sites, not models.\n- Grep the repo for `--state` and `--target` / `--target-path` in shell scripts, Makefiles, and\n  `scripts/**/*.sh`.\n- Also grep CI configs: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `tox.ini`.\n- Check `dbt_project.yml` for a `target-path:` key (deprecated since 1.5 but may still be present).\n- Check for `DBT_STATE` / `DBT_TARGET_PATH` env vars in CI.\n- Flag any invocation where `--state` and `--target`/`--target-path` resolve to the same directory\n  (commonly both set to `target/`).\n- Note the value is frequently supplied outside the repo (dbt platform job definitions,\n  orchestration tools), which parse cannot see.",
+        "fixing": "- Point `--state` at a directory separate from the run's `--target` \u2014 e.g. keep run output in\n  `target/` and the comparison manifest in a distinct dir such as `state/` or `prod-artifacts/`.\n- Concretely, in the offending script/CI step change the duplicated paths so a command like\n  `dbt build --state ./state --target-path ./target` uses different dirs, and populate the state\n  artifacts there.\n- If the same-directory usage lives outside the repo (a dbt platform job command, an orchestration\n  tool), it cannot be edited from the repo.\n- For that out-of-repo case: record it in the results artifact (target/dbt_migration_results.json)\n  as manual-required with the issue_id, the invocation location if known, and the suggested command\n  change, then prompt the user.\n- This change never requires a repo edit to pass `dbt parse`; it is advisory / out-of-repo only."
+      },
+      "_path": "kb/core/1_6_001.yaml"
+    },
+    {
+      "issue_id": "1_6_002",
+      "sort_order": 4020,
+      "change": "Breaking contract changes on unversioned models now warn instead of error",
+      "action": "Add --warn-error (or version the models) to retain the previous hard-error behavior on breaking contract changes",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Unversioned models with a breaking schema/contract change warn via warn_or_error() instead of erroring; CI that relied on the error to block may now pass silently",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan schema YAML (`models/**/*.yml`, `models/**/*.yaml`) for models declaring `contract:` with\n  `enforced: true` that do NOT declare a `version:` / `versions:` block (i.e. unversioned).\n- Those unversioned enforced-contract models are the ones whose breaking contract changes now only\n  warn.\n- Also detect reliance on the old error behavior: grep CI/scripts for `dbt build` / `dbt run`\n  invocations that lack `--warn-error` or `--warn-error-options`.\n- Those flags are what previously turned the contract breakage into a hard failure.\n- This is a behavior/policy change; `dbt parse` stays clean either way, so detection is about intent,\n  not parse errors.",
+        "fixing": "- Preferred: preserve strict behavior by adding `--warn-error` (or a scoped `--warn-error-options`\n  targeting contract deprecations) to the relevant dbt invocation.\n- If that invocation is defined outside the repo (dbt platform job command, orchestration tool), it\n  cannot be edited here: record it in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the suggested flag, and prompt the user.\n- Alternative in-repo fix: add a `version:` to the affected models \u2014 versioning makes breaking\n  contract changes error again.\n- But versioning reshapes ref() resolution and downstream references, so only do it when the user\n  explicitly wants versioned models; note that trade-off in the results report rather than silently\n  versioning.\n- No edit is required for `dbt parse` to succeed."
+      },
+      "_path": "kb/core/1_6_002.yaml"
+    },
+    {
+      "issue_id": "1_6_003",
+      "sort_order": 4030,
+      "change": "New warning for contracted models with bare numeric columns (no precision/scale)",
+      "action": "Add explicit precision and scale to numeric column data_types in enforced contracts (e.g. numeric(38,3))",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with 'data_type: numeric' (or 'decimal') and no precision/scale in an enforced contract now emit a warning at parse time in 1.7",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- In schema YAML (`models/**/*.yml`, `models/**/*.yaml`), find models with `contract:`\n  `enforced: true` and columns whose `data_type` is a bare numeric type with no precision/scale.\n- Match the data_type value (case-insensitive) against `^(numeric|decimal|number)$` (no parentheses).\n- Types that already include `(p,s)` like `numeric(38,3)` are fine and must be left alone.\n- Only columns inside enforced-contract models trigger the warning; bare numeric on non-contracted\n  models is not affected.",
+        "fixing": "- For each flagged column, replace the bare type with an explicit precision/scale, e.g.\n  `data_type: numeric` -> `data_type: numeric(38,3)`.\n- Choose precision/scale from evidence in this order:\n- (1) an existing cast in the model SQL (e.g. `cast(x as numeric(18,2))`) \u2014 match it;\n- (2) the warehouse's documented default for unqualified numeric if the model is already built\n  (Snowflake NUMBER default is (38,0); Redshift/Postgres NUMERIC default is (38,0));\n- (3) if unknown, use a safe wide default `numeric(38,6)` and note the assumption in the results\n  report.\n- Preserve YAML quoting/style.\n- After editing, run `dbt parse`; if it fails, the likely cause is a mismatched type name for the\n  adapter (e.g. Snowflake prefers `number(38,3)`) \u2014 retry with the adapter-native spelling.\n- If the correct precision genuinely cannot be determined, leave the column and record it in the\n  results artifact (target/dbt_migration_results.json) as manual-required for the user to confirm."
+      },
+      "_path": "kb/core/1_6_003.yaml"
+    },
+    {
+      "issue_id": "1_6_010",
+      "sort_order": 4100,
+      "change": "server_side_parameters values coerced to strings",
+      "action": "Review server_side_parameters that use non-string values; they are now str()-coerced (e.g. True -> \"True\")",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "spark",
+      "impact": "server_side_parameters is now typed Dict[str, str] with str() coercion; non-string values are converted, so booleans/ints render as their Python str form (True -> \"True\" with a capital T, 1 -> \"1\")",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep for `server_side_parameters` in `profiles.yml` (`outputs.<target>`), `dbt_project.yml`,\n  model config() blocks, and schema YAML `config:` blocks.\n- Inspect the mapped values: flag any value that is not already a quoted string \u2014 YAML bare\n  `true`/`false` (parsed as booleans), bare integers/floats, or Jinja expressions producing\n  non-strings.\n- String values are unaffected.",
+        "fixing": "- This is a behavior change with no parse impact.\n- For each non-string value, decide the intended wire value and make it an explicit string so the\n  coercion is predictable.\n- Example: if Spark expects lowercase `true`, write `'true'` as a quoted string rather than YAML\n  boolean `true` (which str()-coerces to `\"True\"` with a capital T and may be rejected by Spark).\n- Edit the value in place (quote it / normalize case) and record in the results report.\n- Where the config lives in `profiles.yml` outside the repo, record the recommendation in the\n  results artifact (target/dbt_migration_results.json) as manual-required instead.\n- If unsure of the exact string Spark expects for a given parameter, leave it and flag it for the\n  user rather than guessing.\n- Real effect is validated in the warehouse build-green layer."
+      },
+      "_path": "kb/spark/1_6_010.yaml"
+    },
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_5_bigquery.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_5_bigquery.json
@@ -1,0 +1,672 @@
+{
+  "from_version": "1.5",
+  "warehouse": "bigquery",
+  "target_version": "1.12",
+  "count": 30,
+  "issues": [
+    {
+      "issue_id": "1_5_001",
+      "sort_order": 3010,
+      "change": "Metric YAML schema completely rewritten for MetricFlow",
+      "action": "Rewrite all metric definitions using the new type/type_params/filter format",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "All existing metric YAML definitions fail to parse in 1.6; the pre-1.6 UnparsedMetric fields (calculation_method, expression, sql, model, type: expression) and the rename_metric_attr compatibility shim were removed.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Search every YAML file under models/ and any schema-file globs declared in dbt_project.yml\n  (models/**/*.yml, models/**/*.yaml, plus any top-level metrics/ dir) for a `metrics:` block.\n- Flag a metric as legacy (pre-1.6) if its entry uses ANY of these keys: `calculation_method`,\n  `expression`, `sql`, `type: expression`, a top-level `type:` with the old enum\n  (`count`/`sum`/...), `model:`, `timestamp:`, `time_grains:`, `dimensions:` directly on the\n  metric, or `filters:` (the list-of-dict old form).\n- The new MetricFlow schema instead uses `type:` with values simple|ratio|cumulative|derived\n  plus a `type_params:` block. If a metric already has `type_params:`, it is migrated \u2014 skip it.\n- Also grep packages.yml for `dbt_metrics` usage and models for `metrics.calculate(` /\n  `metrics.develop(` macro calls \u2014 those depend on the old package and must be flagged too.",
+        "fixing": "- Rewrite each legacy metric into the new schema. Attribute mapping:\n  - `calculation_method` -> `type`: sum/average/min/max/count/count_distinct/median become\n    `type: simple` with `type_params.measure`; derived/expression become `type: derived` with\n    `type_params.expr` and `type_params.metrics`.\n  - `expression`/`sql` -> `type_params.measure` (the semantic measure name), or\n    `type_params.expr` for a derived metric.\n  - `model:` -> moves into a `semantic_models:` definition (see example below).\n  - `filters:` -> `filter:` (a single `{{ Dimension(...) }}` string, or keep the WHERE fragment).\n- Concrete before/after:\n  BEFORE (1.5):\n    metrics:\n      - name: total_revenue\n        calculation_method: sum\n        expression: amount\n        model: ref('orders')\n        timestamp: order_date\n        time_grains: [day, month]\n        dimensions: [status]\n  AFTER (1.6, MetricFlow):\n    semantic_models:\n      - name: orders\n        model: ref('orders')\n        defaults:\n          agg_time_dimension: order_date\n        entities:\n          - name: order\n            type: primary\n        dimensions:\n          - name: order_date\n            type: time\n            type_params: {time_granularity: day}\n          - name: status\n            type: categorical\n        measures:\n          - name: amount\n            agg: sum\n            agg_time_dimension: order_date\n    metrics:\n      - name: total_revenue\n        type: simple\n        type_params:\n          measure: amount\n- Derived example: `calculation_method: derived` + `expression: revenue - cost` becomes\n  `type: derived` with `type_params: {expr: 'revenue - cost', metrics: [{name: revenue},\n  {name: cost}]}`.\n- Judgment-heavy: 1.6 requires a `semantic_models:` layer that did not exist in 1.5, so the\n  measure/entity/dimension split cannot always be inferred mechanically.\n- If you cannot confidently reconstruct the semantic model (e.g. the source model's grain or\n  entities are ambiguous), do NOT guess \u2014 record the metric in the results report with\n  the original YAML and the suggested new shape, and move on.\n- After editing, run `dbt parse`. On a metric/semantic-model validation error, re-read it;\n  reverting to legacy form is NOT an option (it won't parse in 1.6) \u2014 instead leave the\n  semantic_model skeleton and flag it manual.\n- Remove `dbt_metrics` / `metrics.calculate` usages and flag them as requiring the\n  MetricFlow / Semantic Layer migration (out of scope for parse)."
+      },
+      "_path": "kb/core/1_5_001.yaml"
+    },
+    {
+      "issue_id": "1_5_002",
+      "sort_order": 3020,
+      "change": "Duplicate node names allowed across packages",
+      "action": "Disambiguate cross-package references with two-argument ref('package_name', 'model_name')",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.5 a flat manifest dict raised DuplicateResourceNameError; in 1.6 names are stored per-package, so a project and an installed package can legitimately share a model name. Single-argument ref() to a name that exists in more than one package becomes ambiguous (AmbiguousAliasError / wrong node).",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant if packages.yml / dependencies.yml declares packages.\n- Build the set of model/seed/snapshot names defined in the local project (models/**/*.sql,\n  seeds/**/*.csv, snapshots/**/*.sql).\n- Where available, add the names exposed by installed packages under dbt_packages/*/models.\n- Grep all .sql/.yml for single-argument `ref('name')` / `ref(\"name\")` whose `name` collides\n  with a name present in BOTH the local project and a package (or in two packages) \u2014 those are\n  the ambiguous refs.\n- If no packages are installed, mark skipped-not-present.",
+        "fixing": "- For each ambiguous single-arg ref, rewrite to the two-argument form\n  `ref('<package_name>', '<model_name>')`.\n- Choose the package the author intended; default to the local project's own model unless the\n  surrounding SQL clearly consumes the package's version.\n- Example: `ref('customers')` -> `ref('my_project', 'customers')` or\n  `ref('dbt_utils', 'customers')`. Leave unambiguous refs untouched.\n- After edits run `dbt parse`; a remaining AmbiguousAliasError names the offending ref and node.\n- If you cannot determine which package is intended, record it in the results report\n  rather than guessing \u2014 picking the wrong package silently changes lineage."
+      },
+      "_path": "kb/core/1_5_002.yaml"
+    },
+    {
+      "issue_id": "1_5_003",
+      "sort_order": 3030,
+      "change": "collect_freshness macro return type changed",
+      "action": "Update any custom collect_freshness macro override to return the full result object (table + response) instead of just the table",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.6 core's default collect_freshness returns a dict-like {table, response} object; a custom override that returns only the agate table triggers a deprecation warning and will break source freshness in later versions.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/**/*.sql for a macro named `collect_freshness` (i.e. `{% macro collect_freshness(`\n  or `{% macro <adapter>__collect_freshness(`).\n- If none exists, the project uses core's implementation \u2014 mark skipped-not-present.\n- If one exists, inspect its final `{{ return(...) }}` and flag it if it returns the query\n  result table directly (e.g. `return(load_result('collect_freshness').table)` or\n  `return(table)`) rather than the full result object.",
+        "fixing": "- Change the macro to capture the full result and return an object exposing both the table and\n  the adapter response.\n- Pattern: `{% set result = run_query(...) %}` then\n  `{{ return({'table': result.table, 'response': result.response}) }}`.\n- Mirror core's 1.6 signature: it returns `load_result('collect_freshness')`, which already has\n  `.table` and `.response`.\n- Simplest safe fix, if the override only existed to tweak the SQL: align the return statement\n  with core 1.6's macro body.\n- After editing run `dbt parse`.\n- If the override is complex or the intended response object is unclear, record it in the\n  results report with a pointer to core's 1.6 collect_freshness for reference."
+      },
+      "_path": "kb/core/1_5_003.yaml"
+    },
+    {
+      "issue_id": "1_6_011",
+      "sort_order": 4005,
+      "change": "dbt clean errors when clean-targets include source paths or paths outside the project",
+      "action": "Remove source paths (e.g. models/, macros/) and any path outside the project directory from clean-targets in dbt_project.yml",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "dbt clean now raises an error instead of silently deleting the wrong directories when clean-targets references source paths or paths outside the project root",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml's clean-targets list.\n- Flag any entry that resolves (relative to the project root) to a configured source path\n  (model-paths, seed-paths, macro-paths, etc.) or that resolves outside the project directory\n  (e.g. ../shared, /absolute/path).",
+        "fixing": "- Remove the offending entries from clean-targets, keeping only build/output directories\n  (e.g. target, dbt_packages, logs).\n- Re-run dbt clean to confirm it no longer errors."
+      },
+      "_path": "kb/core/1_6_011.yaml"
+    },
+    {
+      "issue_id": "1_6_001",
+      "sort_order": 4010,
+      "change": "New warning when --state and --target point to the same directory",
+      "action": "Fix --state/--target configuration so they reference distinct directories",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "WarnStateTargetEqual raised (informational) for previously silent misconfiguration; fatal under --warn-error",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- This is a runtime CLI/job configuration issue, not a repo-source issue, so `dbt parse` cannot\n  surface it. Detect by scanning invocation sites, not models.\n- Grep the repo for `--state` and `--target` / `--target-path` in shell scripts, Makefiles, and\n  `scripts/**/*.sh`.\n- Also grep CI configs: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `tox.ini`.\n- Check `dbt_project.yml` for a `target-path:` key (deprecated since 1.5 but may still be present).\n- Check for `DBT_STATE` / `DBT_TARGET_PATH` env vars in CI.\n- Flag any invocation where `--state` and `--target`/`--target-path` resolve to the same directory\n  (commonly both set to `target/`).\n- Note the value is frequently supplied outside the repo (dbt platform job definitions,\n  orchestration tools), which parse cannot see.",
+        "fixing": "- Point `--state` at a directory separate from the run's `--target` \u2014 e.g. keep run output in\n  `target/` and the comparison manifest in a distinct dir such as `state/` or `prod-artifacts/`.\n- Concretely, in the offending script/CI step change the duplicated paths so a command like\n  `dbt build --state ./state --target-path ./target` uses different dirs, and populate the state\n  artifacts there.\n- If the same-directory usage lives outside the repo (a dbt platform job command, an orchestration\n  tool), it cannot be edited from the repo.\n- For that out-of-repo case: record it in the results artifact (target/dbt_migration_results.json)\n  as manual-required with the issue_id, the invocation location if known, and the suggested command\n  change, then prompt the user.\n- This change never requires a repo edit to pass `dbt parse`; it is advisory / out-of-repo only."
+      },
+      "_path": "kb/core/1_6_001.yaml"
+    },
+    {
+      "issue_id": "1_6_002",
+      "sort_order": 4020,
+      "change": "Breaking contract changes on unversioned models now warn instead of error",
+      "action": "Add --warn-error (or version the models) to retain the previous hard-error behavior on breaking contract changes",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Unversioned models with a breaking schema/contract change warn via warn_or_error() instead of erroring; CI that relied on the error to block may now pass silently",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan schema YAML (`models/**/*.yml`, `models/**/*.yaml`) for models declaring `contract:` with\n  `enforced: true` that do NOT declare a `version:` / `versions:` block (i.e. unversioned).\n- Those unversioned enforced-contract models are the ones whose breaking contract changes now only\n  warn.\n- Also detect reliance on the old error behavior: grep CI/scripts for `dbt build` / `dbt run`\n  invocations that lack `--warn-error` or `--warn-error-options`.\n- Those flags are what previously turned the contract breakage into a hard failure.\n- This is a behavior/policy change; `dbt parse` stays clean either way, so detection is about intent,\n  not parse errors.",
+        "fixing": "- Preferred: preserve strict behavior by adding `--warn-error` (or a scoped `--warn-error-options`\n  targeting contract deprecations) to the relevant dbt invocation.\n- If that invocation is defined outside the repo (dbt platform job command, orchestration tool), it\n  cannot be edited here: record it in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the suggested flag, and prompt the user.\n- Alternative in-repo fix: add a `version:` to the affected models \u2014 versioning makes breaking\n  contract changes error again.\n- But versioning reshapes ref() resolution and downstream references, so only do it when the user\n  explicitly wants versioned models; note that trade-off in the results report rather than silently\n  versioning.\n- No edit is required for `dbt parse` to succeed."
+      },
+      "_path": "kb/core/1_6_002.yaml"
+    },
+    {
+      "issue_id": "1_6_003",
+      "sort_order": 4030,
+      "change": "New warning for contracted models with bare numeric columns (no precision/scale)",
+      "action": "Add explicit precision and scale to numeric column data_types in enforced contracts (e.g. numeric(38,3))",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with 'data_type: numeric' (or 'decimal') and no precision/scale in an enforced contract now emit a warning at parse time in 1.7",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- In schema YAML (`models/**/*.yml`, `models/**/*.yaml`), find models with `contract:`\n  `enforced: true` and columns whose `data_type` is a bare numeric type with no precision/scale.\n- Match the data_type value (case-insensitive) against `^(numeric|decimal|number)$` (no parentheses).\n- Types that already include `(p,s)` like `numeric(38,3)` are fine and must be left alone.\n- Only columns inside enforced-contract models trigger the warning; bare numeric on non-contracted\n  models is not affected.",
+        "fixing": "- For each flagged column, replace the bare type with an explicit precision/scale, e.g.\n  `data_type: numeric` -> `data_type: numeric(38,3)`.\n- Choose precision/scale from evidence in this order:\n- (1) an existing cast in the model SQL (e.g. `cast(x as numeric(18,2))`) \u2014 match it;\n- (2) the warehouse's documented default for unqualified numeric if the model is already built\n  (Snowflake NUMBER default is (38,0); Redshift/Postgres NUMERIC default is (38,0));\n- (3) if unknown, use a safe wide default `numeric(38,6)` and note the assumption in the results\n  report.\n- Preserve YAML quoting/style.\n- After editing, run `dbt parse`; if it fails, the likely cause is a mismatched type name for the\n  adapter (e.g. Snowflake prefers `number(38,3)`) \u2014 retry with the adapter-native spelling.\n- If the correct precision genuinely cannot be determined, leave the column and record it in the\n  results artifact (target/dbt_migration_results.json) as manual-required for the user to confirm."
+      },
+      "_path": "kb/core/1_6_003.yaml"
+    },
+    {
+      "issue_id": "1_6_006",
+      "sort_order": 4060,
+      "change": "job_execution_timeout now actually cancels queries via asyncio",
+      "action": "Review all job_execution_timeout_seconds values and increase them where legitimate long-running queries could now be cancelled",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "bigquery",
+      "impact": "Queries exceeding job_execution_timeout_seconds are now actually cancelled and error; previously the timeout was passed but not enforced, so long queries silently ran to completion",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep for `job_execution_timeout_seconds` across the project: `profiles.yml`\n  (`outputs.<target>`), `dbt_project.yml` (`models:` config), model config() blocks, and schema\n  YAML `config:` blocks.\n- Any value set low relative to real query runtimes is now a live cancellation risk.\n- This is a runtime/behavior change invisible to `dbt parse`.",
+        "fixing": "- No edit is needed to pass parse or reach 1.8. The action is protective.\n- For each configured job_execution_timeout_seconds, assess whether real models run longer than the\n  value; if so, raise it (e.g. comfortably above observed p99 runtime) in the same location it is\n  configured.\n- Where the value lives in `profiles.yml` outside the repo, record the recommendation in the\n  results artifact (target/dbt_migration_results.json) as manual-required instead of editing.\n- If no timeout is set anywhere, BigQuery's own default applies and there is nothing to change \u2014\n  note it and move on.\n- Do not lower any timeouts. True impact is only observable in the warehouse build-green layer."
+      },
+      "_path": "kb/bigquery/1_6_006.yaml"
+    },
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_5_core.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_5_core.json
@@ -1,0 +1,652 @@
+{
+  "from_version": "1.5",
+  "warehouse": "core",
+  "target_version": "1.12",
+  "count": 29,
+  "issues": [
+    {
+      "issue_id": "1_5_001",
+      "sort_order": 3010,
+      "change": "Metric YAML schema completely rewritten for MetricFlow",
+      "action": "Rewrite all metric definitions using the new type/type_params/filter format",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "All existing metric YAML definitions fail to parse in 1.6; the pre-1.6 UnparsedMetric fields (calculation_method, expression, sql, model, type: expression) and the rename_metric_attr compatibility shim were removed.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Search every YAML file under models/ and any schema-file globs declared in dbt_project.yml\n  (models/**/*.yml, models/**/*.yaml, plus any top-level metrics/ dir) for a `metrics:` block.\n- Flag a metric as legacy (pre-1.6) if its entry uses ANY of these keys: `calculation_method`,\n  `expression`, `sql`, `type: expression`, a top-level `type:` with the old enum\n  (`count`/`sum`/...), `model:`, `timestamp:`, `time_grains:`, `dimensions:` directly on the\n  metric, or `filters:` (the list-of-dict old form).\n- The new MetricFlow schema instead uses `type:` with values simple|ratio|cumulative|derived\n  plus a `type_params:` block. If a metric already has `type_params:`, it is migrated \u2014 skip it.\n- Also grep packages.yml for `dbt_metrics` usage and models for `metrics.calculate(` /\n  `metrics.develop(` macro calls \u2014 those depend on the old package and must be flagged too.",
+        "fixing": "- Rewrite each legacy metric into the new schema. Attribute mapping:\n  - `calculation_method` -> `type`: sum/average/min/max/count/count_distinct/median become\n    `type: simple` with `type_params.measure`; derived/expression become `type: derived` with\n    `type_params.expr` and `type_params.metrics`.\n  - `expression`/`sql` -> `type_params.measure` (the semantic measure name), or\n    `type_params.expr` for a derived metric.\n  - `model:` -> moves into a `semantic_models:` definition (see example below).\n  - `filters:` -> `filter:` (a single `{{ Dimension(...) }}` string, or keep the WHERE fragment).\n- Concrete before/after:\n  BEFORE (1.5):\n    metrics:\n      - name: total_revenue\n        calculation_method: sum\n        expression: amount\n        model: ref('orders')\n        timestamp: order_date\n        time_grains: [day, month]\n        dimensions: [status]\n  AFTER (1.6, MetricFlow):\n    semantic_models:\n      - name: orders\n        model: ref('orders')\n        defaults:\n          agg_time_dimension: order_date\n        entities:\n          - name: order\n            type: primary\n        dimensions:\n          - name: order_date\n            type: time\n            type_params: {time_granularity: day}\n          - name: status\n            type: categorical\n        measures:\n          - name: amount\n            agg: sum\n            agg_time_dimension: order_date\n    metrics:\n      - name: total_revenue\n        type: simple\n        type_params:\n          measure: amount\n- Derived example: `calculation_method: derived` + `expression: revenue - cost` becomes\n  `type: derived` with `type_params: {expr: 'revenue - cost', metrics: [{name: revenue},\n  {name: cost}]}`.\n- Judgment-heavy: 1.6 requires a `semantic_models:` layer that did not exist in 1.5, so the\n  measure/entity/dimension split cannot always be inferred mechanically.\n- If you cannot confidently reconstruct the semantic model (e.g. the source model's grain or\n  entities are ambiguous), do NOT guess \u2014 record the metric in the results report with\n  the original YAML and the suggested new shape, and move on.\n- After editing, run `dbt parse`. On a metric/semantic-model validation error, re-read it;\n  reverting to legacy form is NOT an option (it won't parse in 1.6) \u2014 instead leave the\n  semantic_model skeleton and flag it manual.\n- Remove `dbt_metrics` / `metrics.calculate` usages and flag them as requiring the\n  MetricFlow / Semantic Layer migration (out of scope for parse)."
+      },
+      "_path": "kb/core/1_5_001.yaml"
+    },
+    {
+      "issue_id": "1_5_002",
+      "sort_order": 3020,
+      "change": "Duplicate node names allowed across packages",
+      "action": "Disambiguate cross-package references with two-argument ref('package_name', 'model_name')",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.5 a flat manifest dict raised DuplicateResourceNameError; in 1.6 names are stored per-package, so a project and an installed package can legitimately share a model name. Single-argument ref() to a name that exists in more than one package becomes ambiguous (AmbiguousAliasError / wrong node).",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant if packages.yml / dependencies.yml declares packages.\n- Build the set of model/seed/snapshot names defined in the local project (models/**/*.sql,\n  seeds/**/*.csv, snapshots/**/*.sql).\n- Where available, add the names exposed by installed packages under dbt_packages/*/models.\n- Grep all .sql/.yml for single-argument `ref('name')` / `ref(\"name\")` whose `name` collides\n  with a name present in BOTH the local project and a package (or in two packages) \u2014 those are\n  the ambiguous refs.\n- If no packages are installed, mark skipped-not-present.",
+        "fixing": "- For each ambiguous single-arg ref, rewrite to the two-argument form\n  `ref('<package_name>', '<model_name>')`.\n- Choose the package the author intended; default to the local project's own model unless the\n  surrounding SQL clearly consumes the package's version.\n- Example: `ref('customers')` -> `ref('my_project', 'customers')` or\n  `ref('dbt_utils', 'customers')`. Leave unambiguous refs untouched.\n- After edits run `dbt parse`; a remaining AmbiguousAliasError names the offending ref and node.\n- If you cannot determine which package is intended, record it in the results report\n  rather than guessing \u2014 picking the wrong package silently changes lineage."
+      },
+      "_path": "kb/core/1_5_002.yaml"
+    },
+    {
+      "issue_id": "1_5_003",
+      "sort_order": 3030,
+      "change": "collect_freshness macro return type changed",
+      "action": "Update any custom collect_freshness macro override to return the full result object (table + response) instead of just the table",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.6 core's default collect_freshness returns a dict-like {table, response} object; a custom override that returns only the agate table triggers a deprecation warning and will break source freshness in later versions.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/**/*.sql for a macro named `collect_freshness` (i.e. `{% macro collect_freshness(`\n  or `{% macro <adapter>__collect_freshness(`).\n- If none exists, the project uses core's implementation \u2014 mark skipped-not-present.\n- If one exists, inspect its final `{{ return(...) }}` and flag it if it returns the query\n  result table directly (e.g. `return(load_result('collect_freshness').table)` or\n  `return(table)`) rather than the full result object.",
+        "fixing": "- Change the macro to capture the full result and return an object exposing both the table and\n  the adapter response.\n- Pattern: `{% set result = run_query(...) %}` then\n  `{{ return({'table': result.table, 'response': result.response}) }}`.\n- Mirror core's 1.6 signature: it returns `load_result('collect_freshness')`, which already has\n  `.table` and `.response`.\n- Simplest safe fix, if the override only existed to tweak the SQL: align the return statement\n  with core 1.6's macro body.\n- After editing run `dbt parse`.\n- If the override is complex or the intended response object is unclear, record it in the\n  results report with a pointer to core's 1.6 collect_freshness for reference."
+      },
+      "_path": "kb/core/1_5_003.yaml"
+    },
+    {
+      "issue_id": "1_6_011",
+      "sort_order": 4005,
+      "change": "dbt clean errors when clean-targets include source paths or paths outside the project",
+      "action": "Remove source paths (e.g. models/, macros/) and any path outside the project directory from clean-targets in dbt_project.yml",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "dbt clean now raises an error instead of silently deleting the wrong directories when clean-targets references source paths or paths outside the project root",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml's clean-targets list.\n- Flag any entry that resolves (relative to the project root) to a configured source path\n  (model-paths, seed-paths, macro-paths, etc.) or that resolves outside the project directory\n  (e.g. ../shared, /absolute/path).",
+        "fixing": "- Remove the offending entries from clean-targets, keeping only build/output directories\n  (e.g. target, dbt_packages, logs).\n- Re-run dbt clean to confirm it no longer errors."
+      },
+      "_path": "kb/core/1_6_011.yaml"
+    },
+    {
+      "issue_id": "1_6_001",
+      "sort_order": 4010,
+      "change": "New warning when --state and --target point to the same directory",
+      "action": "Fix --state/--target configuration so they reference distinct directories",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "WarnStateTargetEqual raised (informational) for previously silent misconfiguration; fatal under --warn-error",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- This is a runtime CLI/job configuration issue, not a repo-source issue, so `dbt parse` cannot\n  surface it. Detect by scanning invocation sites, not models.\n- Grep the repo for `--state` and `--target` / `--target-path` in shell scripts, Makefiles, and\n  `scripts/**/*.sh`.\n- Also grep CI configs: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `tox.ini`.\n- Check `dbt_project.yml` for a `target-path:` key (deprecated since 1.5 but may still be present).\n- Check for `DBT_STATE` / `DBT_TARGET_PATH` env vars in CI.\n- Flag any invocation where `--state` and `--target`/`--target-path` resolve to the same directory\n  (commonly both set to `target/`).\n- Note the value is frequently supplied outside the repo (dbt platform job definitions,\n  orchestration tools), which parse cannot see.",
+        "fixing": "- Point `--state` at a directory separate from the run's `--target` \u2014 e.g. keep run output in\n  `target/` and the comparison manifest in a distinct dir such as `state/` or `prod-artifacts/`.\n- Concretely, in the offending script/CI step change the duplicated paths so a command like\n  `dbt build --state ./state --target-path ./target` uses different dirs, and populate the state\n  artifacts there.\n- If the same-directory usage lives outside the repo (a dbt platform job command, an orchestration\n  tool), it cannot be edited from the repo.\n- For that out-of-repo case: record it in the results artifact (target/dbt_migration_results.json)\n  as manual-required with the issue_id, the invocation location if known, and the suggested command\n  change, then prompt the user.\n- This change never requires a repo edit to pass `dbt parse`; it is advisory / out-of-repo only."
+      },
+      "_path": "kb/core/1_6_001.yaml"
+    },
+    {
+      "issue_id": "1_6_002",
+      "sort_order": 4020,
+      "change": "Breaking contract changes on unversioned models now warn instead of error",
+      "action": "Add --warn-error (or version the models) to retain the previous hard-error behavior on breaking contract changes",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Unversioned models with a breaking schema/contract change warn via warn_or_error() instead of erroring; CI that relied on the error to block may now pass silently",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan schema YAML (`models/**/*.yml`, `models/**/*.yaml`) for models declaring `contract:` with\n  `enforced: true` that do NOT declare a `version:` / `versions:` block (i.e. unversioned).\n- Those unversioned enforced-contract models are the ones whose breaking contract changes now only\n  warn.\n- Also detect reliance on the old error behavior: grep CI/scripts for `dbt build` / `dbt run`\n  invocations that lack `--warn-error` or `--warn-error-options`.\n- Those flags are what previously turned the contract breakage into a hard failure.\n- This is a behavior/policy change; `dbt parse` stays clean either way, so detection is about intent,\n  not parse errors.",
+        "fixing": "- Preferred: preserve strict behavior by adding `--warn-error` (or a scoped `--warn-error-options`\n  targeting contract deprecations) to the relevant dbt invocation.\n- If that invocation is defined outside the repo (dbt platform job command, orchestration tool), it\n  cannot be edited here: record it in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the suggested flag, and prompt the user.\n- Alternative in-repo fix: add a `version:` to the affected models \u2014 versioning makes breaking\n  contract changes error again.\n- But versioning reshapes ref() resolution and downstream references, so only do it when the user\n  explicitly wants versioned models; note that trade-off in the results report rather than silently\n  versioning.\n- No edit is required for `dbt parse` to succeed."
+      },
+      "_path": "kb/core/1_6_002.yaml"
+    },
+    {
+      "issue_id": "1_6_003",
+      "sort_order": 4030,
+      "change": "New warning for contracted models with bare numeric columns (no precision/scale)",
+      "action": "Add explicit precision and scale to numeric column data_types in enforced contracts (e.g. numeric(38,3))",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with 'data_type: numeric' (or 'decimal') and no precision/scale in an enforced contract now emit a warning at parse time in 1.7",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- In schema YAML (`models/**/*.yml`, `models/**/*.yaml`), find models with `contract:`\n  `enforced: true` and columns whose `data_type` is a bare numeric type with no precision/scale.\n- Match the data_type value (case-insensitive) against `^(numeric|decimal|number)$` (no parentheses).\n- Types that already include `(p,s)` like `numeric(38,3)` are fine and must be left alone.\n- Only columns inside enforced-contract models trigger the warning; bare numeric on non-contracted\n  models is not affected.",
+        "fixing": "- For each flagged column, replace the bare type with an explicit precision/scale, e.g.\n  `data_type: numeric` -> `data_type: numeric(38,3)`.\n- Choose precision/scale from evidence in this order:\n- (1) an existing cast in the model SQL (e.g. `cast(x as numeric(18,2))`) \u2014 match it;\n- (2) the warehouse's documented default for unqualified numeric if the model is already built\n  (Snowflake NUMBER default is (38,0); Redshift/Postgres NUMERIC default is (38,0));\n- (3) if unknown, use a safe wide default `numeric(38,6)` and note the assumption in the results\n  report.\n- Preserve YAML quoting/style.\n- After editing, run `dbt parse`; if it fails, the likely cause is a mismatched type name for the\n  adapter (e.g. Snowflake prefers `number(38,3)`) \u2014 retry with the adapter-native spelling.\n- If the correct precision genuinely cannot be determined, leave the column and record it in the\n  results artifact (target/dbt_migration_results.json) as manual-required for the user to confirm."
+      },
+      "_path": "kb/core/1_6_003.yaml"
+    },
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_5_databricks.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_5_databricks.json
@@ -1,0 +1,692 @@
+{
+  "from_version": "1.5",
+  "warehouse": "databricks",
+  "target_version": "1.12",
+  "count": 31,
+  "issues": [
+    {
+      "issue_id": "1_5_001",
+      "sort_order": 3010,
+      "change": "Metric YAML schema completely rewritten for MetricFlow",
+      "action": "Rewrite all metric definitions using the new type/type_params/filter format",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "All existing metric YAML definitions fail to parse in 1.6; the pre-1.6 UnparsedMetric fields (calculation_method, expression, sql, model, type: expression) and the rename_metric_attr compatibility shim were removed.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Search every YAML file under models/ and any schema-file globs declared in dbt_project.yml\n  (models/**/*.yml, models/**/*.yaml, plus any top-level metrics/ dir) for a `metrics:` block.\n- Flag a metric as legacy (pre-1.6) if its entry uses ANY of these keys: `calculation_method`,\n  `expression`, `sql`, `type: expression`, a top-level `type:` with the old enum\n  (`count`/`sum`/...), `model:`, `timestamp:`, `time_grains:`, `dimensions:` directly on the\n  metric, or `filters:` (the list-of-dict old form).\n- The new MetricFlow schema instead uses `type:` with values simple|ratio|cumulative|derived\n  plus a `type_params:` block. If a metric already has `type_params:`, it is migrated \u2014 skip it.\n- Also grep packages.yml for `dbt_metrics` usage and models for `metrics.calculate(` /\n  `metrics.develop(` macro calls \u2014 those depend on the old package and must be flagged too.",
+        "fixing": "- Rewrite each legacy metric into the new schema. Attribute mapping:\n  - `calculation_method` -> `type`: sum/average/min/max/count/count_distinct/median become\n    `type: simple` with `type_params.measure`; derived/expression become `type: derived` with\n    `type_params.expr` and `type_params.metrics`.\n  - `expression`/`sql` -> `type_params.measure` (the semantic measure name), or\n    `type_params.expr` for a derived metric.\n  - `model:` -> moves into a `semantic_models:` definition (see example below).\n  - `filters:` -> `filter:` (a single `{{ Dimension(...) }}` string, or keep the WHERE fragment).\n- Concrete before/after:\n  BEFORE (1.5):\n    metrics:\n      - name: total_revenue\n        calculation_method: sum\n        expression: amount\n        model: ref('orders')\n        timestamp: order_date\n        time_grains: [day, month]\n        dimensions: [status]\n  AFTER (1.6, MetricFlow):\n    semantic_models:\n      - name: orders\n        model: ref('orders')\n        defaults:\n          agg_time_dimension: order_date\n        entities:\n          - name: order\n            type: primary\n        dimensions:\n          - name: order_date\n            type: time\n            type_params: {time_granularity: day}\n          - name: status\n            type: categorical\n        measures:\n          - name: amount\n            agg: sum\n            agg_time_dimension: order_date\n    metrics:\n      - name: total_revenue\n        type: simple\n        type_params:\n          measure: amount\n- Derived example: `calculation_method: derived` + `expression: revenue - cost` becomes\n  `type: derived` with `type_params: {expr: 'revenue - cost', metrics: [{name: revenue},\n  {name: cost}]}`.\n- Judgment-heavy: 1.6 requires a `semantic_models:` layer that did not exist in 1.5, so the\n  measure/entity/dimension split cannot always be inferred mechanically.\n- If you cannot confidently reconstruct the semantic model (e.g. the source model's grain or\n  entities are ambiguous), do NOT guess \u2014 record the metric in the results report with\n  the original YAML and the suggested new shape, and move on.\n- After editing, run `dbt parse`. On a metric/semantic-model validation error, re-read it;\n  reverting to legacy form is NOT an option (it won't parse in 1.6) \u2014 instead leave the\n  semantic_model skeleton and flag it manual.\n- Remove `dbt_metrics` / `metrics.calculate` usages and flag them as requiring the\n  MetricFlow / Semantic Layer migration (out of scope for parse)."
+      },
+      "_path": "kb/core/1_5_001.yaml"
+    },
+    {
+      "issue_id": "1_5_002",
+      "sort_order": 3020,
+      "change": "Duplicate node names allowed across packages",
+      "action": "Disambiguate cross-package references with two-argument ref('package_name', 'model_name')",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.5 a flat manifest dict raised DuplicateResourceNameError; in 1.6 names are stored per-package, so a project and an installed package can legitimately share a model name. Single-argument ref() to a name that exists in more than one package becomes ambiguous (AmbiguousAliasError / wrong node).",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant if packages.yml / dependencies.yml declares packages.\n- Build the set of model/seed/snapshot names defined in the local project (models/**/*.sql,\n  seeds/**/*.csv, snapshots/**/*.sql).\n- Where available, add the names exposed by installed packages under dbt_packages/*/models.\n- Grep all .sql/.yml for single-argument `ref('name')` / `ref(\"name\")` whose `name` collides\n  with a name present in BOTH the local project and a package (or in two packages) \u2014 those are\n  the ambiguous refs.\n- If no packages are installed, mark skipped-not-present.",
+        "fixing": "- For each ambiguous single-arg ref, rewrite to the two-argument form\n  `ref('<package_name>', '<model_name>')`.\n- Choose the package the author intended; default to the local project's own model unless the\n  surrounding SQL clearly consumes the package's version.\n- Example: `ref('customers')` -> `ref('my_project', 'customers')` or\n  `ref('dbt_utils', 'customers')`. Leave unambiguous refs untouched.\n- After edits run `dbt parse`; a remaining AmbiguousAliasError names the offending ref and node.\n- If you cannot determine which package is intended, record it in the results report\n  rather than guessing \u2014 picking the wrong package silently changes lineage."
+      },
+      "_path": "kb/core/1_5_002.yaml"
+    },
+    {
+      "issue_id": "1_5_003",
+      "sort_order": 3030,
+      "change": "collect_freshness macro return type changed",
+      "action": "Update any custom collect_freshness macro override to return the full result object (table + response) instead of just the table",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.6 core's default collect_freshness returns a dict-like {table, response} object; a custom override that returns only the agate table triggers a deprecation warning and will break source freshness in later versions.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/**/*.sql for a macro named `collect_freshness` (i.e. `{% macro collect_freshness(`\n  or `{% macro <adapter>__collect_freshness(`).\n- If none exists, the project uses core's implementation \u2014 mark skipped-not-present.\n- If one exists, inspect its final `{{ return(...) }}` and flag it if it returns the query\n  result table directly (e.g. `return(load_result('collect_freshness').table)` or\n  `return(table)`) rather than the full result object.",
+        "fixing": "- Change the macro to capture the full result and return an object exposing both the table and\n  the adapter response.\n- Pattern: `{% set result = run_query(...) %}` then\n  `{{ return({'table': result.table, 'response': result.response}) }}`.\n- Mirror core's 1.6 signature: it returns `load_result('collect_freshness')`, which already has\n  `.table` and `.response`.\n- Simplest safe fix, if the override only existed to tweak the SQL: align the return statement\n  with core 1.6's macro body.\n- After editing run `dbt parse`.\n- If the override is complex or the intended response object is unclear, record it in the\n  results report with a pointer to core's 1.6 collect_freshness for reference."
+      },
+      "_path": "kb/core/1_5_003.yaml"
+    },
+    {
+      "issue_id": "1_5_010",
+      "sort_order": 3100,
+      "change": "Default socket timeout set to 180 seconds",
+      "action": "Adjust _socket_timeout in connection_parameters if long-idle connections time out",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "databricks",
+      "impact": "1.6 introduces a default socket timeout of 180s. Long-idle connections (e.g. warehouses that were paused/cold) may now time out where they previously waited indefinitely.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": true,
+      "context": {
+        "detection": "- Behavioral connection change invisible to `dbt parse`.\n- Check the databricks output in profiles.yml (usually out of repo) for a\n  `connect_timeout` / `_socket_timeout` / `connection_parameters` setting.\n- Risk signals: projects querying serverless / auto-stopping SQL warehouses with long cold-start\n  times, or long-running single statements exceeding 180s of socket idleness.",
+        "fixing": "- ADVISORY ONLY.\n- If timeouts are a risk, recommend setting `_socket_timeout` under `connection_parameters` in\n  the databricks profile to a higher value; otherwise no change.\n- profiles.yml is usually out of repo and this is warehouse behavior \u2014 add a manual-actions entry\n  noting the new 180s default and the tuning knob.\n- Excluded from the parse verify loop."
+      },
+      "_path": "kb/databricks/1_5_010.yaml"
+    },
+    {
+      "issue_id": "1_6_011",
+      "sort_order": 4005,
+      "change": "dbt clean errors when clean-targets include source paths or paths outside the project",
+      "action": "Remove source paths (e.g. models/, macros/) and any path outside the project directory from clean-targets in dbt_project.yml",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "dbt clean now raises an error instead of silently deleting the wrong directories when clean-targets references source paths or paths outside the project root",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml's clean-targets list.\n- Flag any entry that resolves (relative to the project root) to a configured source path\n  (model-paths, seed-paths, macro-paths, etc.) or that resolves outside the project directory\n  (e.g. ../shared, /absolute/path).",
+        "fixing": "- Remove the offending entries from clean-targets, keeping only build/output directories\n  (e.g. target, dbt_packages, logs).\n- Re-run dbt clean to confirm it no longer errors."
+      },
+      "_path": "kb/core/1_6_011.yaml"
+    },
+    {
+      "issue_id": "1_6_001",
+      "sort_order": 4010,
+      "change": "New warning when --state and --target point to the same directory",
+      "action": "Fix --state/--target configuration so they reference distinct directories",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "WarnStateTargetEqual raised (informational) for previously silent misconfiguration; fatal under --warn-error",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- This is a runtime CLI/job configuration issue, not a repo-source issue, so `dbt parse` cannot\n  surface it. Detect by scanning invocation sites, not models.\n- Grep the repo for `--state` and `--target` / `--target-path` in shell scripts, Makefiles, and\n  `scripts/**/*.sh`.\n- Also grep CI configs: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `tox.ini`.\n- Check `dbt_project.yml` for a `target-path:` key (deprecated since 1.5 but may still be present).\n- Check for `DBT_STATE` / `DBT_TARGET_PATH` env vars in CI.\n- Flag any invocation where `--state` and `--target`/`--target-path` resolve to the same directory\n  (commonly both set to `target/`).\n- Note the value is frequently supplied outside the repo (dbt platform job definitions,\n  orchestration tools), which parse cannot see.",
+        "fixing": "- Point `--state` at a directory separate from the run's `--target` \u2014 e.g. keep run output in\n  `target/` and the comparison manifest in a distinct dir such as `state/` or `prod-artifacts/`.\n- Concretely, in the offending script/CI step change the duplicated paths so a command like\n  `dbt build --state ./state --target-path ./target` uses different dirs, and populate the state\n  artifacts there.\n- If the same-directory usage lives outside the repo (a dbt platform job command, an orchestration\n  tool), it cannot be edited from the repo.\n- For that out-of-repo case: record it in the results artifact (target/dbt_migration_results.json)\n  as manual-required with the issue_id, the invocation location if known, and the suggested command\n  change, then prompt the user.\n- This change never requires a repo edit to pass `dbt parse`; it is advisory / out-of-repo only."
+      },
+      "_path": "kb/core/1_6_001.yaml"
+    },
+    {
+      "issue_id": "1_6_002",
+      "sort_order": 4020,
+      "change": "Breaking contract changes on unversioned models now warn instead of error",
+      "action": "Add --warn-error (or version the models) to retain the previous hard-error behavior on breaking contract changes",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Unversioned models with a breaking schema/contract change warn via warn_or_error() instead of erroring; CI that relied on the error to block may now pass silently",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan schema YAML (`models/**/*.yml`, `models/**/*.yaml`) for models declaring `contract:` with\n  `enforced: true` that do NOT declare a `version:` / `versions:` block (i.e. unversioned).\n- Those unversioned enforced-contract models are the ones whose breaking contract changes now only\n  warn.\n- Also detect reliance on the old error behavior: grep CI/scripts for `dbt build` / `dbt run`\n  invocations that lack `--warn-error` or `--warn-error-options`.\n- Those flags are what previously turned the contract breakage into a hard failure.\n- This is a behavior/policy change; `dbt parse` stays clean either way, so detection is about intent,\n  not parse errors.",
+        "fixing": "- Preferred: preserve strict behavior by adding `--warn-error` (or a scoped `--warn-error-options`\n  targeting contract deprecations) to the relevant dbt invocation.\n- If that invocation is defined outside the repo (dbt platform job command, orchestration tool), it\n  cannot be edited here: record it in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the suggested flag, and prompt the user.\n- Alternative in-repo fix: add a `version:` to the affected models \u2014 versioning makes breaking\n  contract changes error again.\n- But versioning reshapes ref() resolution and downstream references, so only do it when the user\n  explicitly wants versioned models; note that trade-off in the results report rather than silently\n  versioning.\n- No edit is required for `dbt parse` to succeed."
+      },
+      "_path": "kb/core/1_6_002.yaml"
+    },
+    {
+      "issue_id": "1_6_003",
+      "sort_order": 4030,
+      "change": "New warning for contracted models with bare numeric columns (no precision/scale)",
+      "action": "Add explicit precision and scale to numeric column data_types in enforced contracts (e.g. numeric(38,3))",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with 'data_type: numeric' (or 'decimal') and no precision/scale in an enforced contract now emit a warning at parse time in 1.7",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- In schema YAML (`models/**/*.yml`, `models/**/*.yaml`), find models with `contract:`\n  `enforced: true` and columns whose `data_type` is a bare numeric type with no precision/scale.\n- Match the data_type value (case-insensitive) against `^(numeric|decimal|number)$` (no parentheses).\n- Types that already include `(p,s)` like `numeric(38,3)` are fine and must be left alone.\n- Only columns inside enforced-contract models trigger the warning; bare numeric on non-contracted\n  models is not affected.",
+        "fixing": "- For each flagged column, replace the bare type with an explicit precision/scale, e.g.\n  `data_type: numeric` -> `data_type: numeric(38,3)`.\n- Choose precision/scale from evidence in this order:\n- (1) an existing cast in the model SQL (e.g. `cast(x as numeric(18,2))`) \u2014 match it;\n- (2) the warehouse's documented default for unqualified numeric if the model is already built\n  (Snowflake NUMBER default is (38,0); Redshift/Postgres NUMERIC default is (38,0));\n- (3) if unknown, use a safe wide default `numeric(38,6)` and note the assumption in the results\n  report.\n- Preserve YAML quoting/style.\n- After editing, run `dbt parse`; if it fails, the likely cause is a mismatched type name for the\n  adapter (e.g. Snowflake prefers `number(38,3)`) \u2014 retry with the adapter-native spelling.\n- If the correct precision genuinely cannot be determined, leave the column and record it in the\n  results artifact (target/dbt_migration_results.json) as manual-required for the user to confirm."
+      },
+      "_path": "kb/core/1_6_003.yaml"
+    },
+    {
+      "issue_id": "1_6_005",
+      "sort_order": 4050,
+      "change": "Default catalog set to hive_metastore when not specified",
+      "action": "Verify the default matches expectations; set catalog explicitly in profiles.yml if a different catalog is intended",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "databricks",
+      "impact": "Projects that did not set a catalog now explicitly resolve to hive_metastore; relations may be created/read in hive_metastore instead of a previously-implicit Unity Catalog default",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": true,
+      "context": {
+        "detection": "- This is a connection/environment default, not a repo-source change, so `dbt parse` cannot see it.\n- Inspect the Databricks connection config: `profiles.yml` (`outputs.<target>.catalog`) and any\n  `catalog:` / `database:` set in `dbt_project.yml` or model configs.\n- Flag the project if NO catalog/database is set anywhere for the Databricks target \u2014 those projects\n  now implicitly get `hive_metastore`.\n- If a catalog is already set explicitly, no action.\n- Note `profiles.yml` often lives outside the repo (`~/.dbt/` or dbt platform connection settings).",
+        "fixing": "- Advisory / environment change only \u2014 never mutate credentials or run anything.\n- If the workspace uses Unity Catalog and the user expects a UC catalog rather than the legacy\n  hive_metastore, add an explicit `catalog: <name>` to the Databricks output in `profiles.yml` (or\n  the platform connection).\n- If `profiles.yml` is inside the repo, apply the advisory edit and record it in the results report.\n- If it is outside the repo, record the recommended `catalog:` setting in the results artifact\n  (target/dbt_migration_results.json) as advisory and prompt the user to confirm the intended\n  catalog.\n- Exclude from the parse-verify loop (parse does not reflect connection settings)."
+      },
+      "_path": "kb/databricks/1_6_005.yaml"
+    },
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_5_redshift.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_5_redshift.json
@@ -1,0 +1,752 @@
+{
+  "from_version": "1.5",
+  "warehouse": "redshift",
+  "target_version": "1.12",
+  "count": 34,
+  "issues": [
+    {
+      "issue_id": "1_5_001",
+      "sort_order": 3010,
+      "change": "Metric YAML schema completely rewritten for MetricFlow",
+      "action": "Rewrite all metric definitions using the new type/type_params/filter format",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "All existing metric YAML definitions fail to parse in 1.6; the pre-1.6 UnparsedMetric fields (calculation_method, expression, sql, model, type: expression) and the rename_metric_attr compatibility shim were removed.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Search every YAML file under models/ and any schema-file globs declared in dbt_project.yml\n  (models/**/*.yml, models/**/*.yaml, plus any top-level metrics/ dir) for a `metrics:` block.\n- Flag a metric as legacy (pre-1.6) if its entry uses ANY of these keys: `calculation_method`,\n  `expression`, `sql`, `type: expression`, a top-level `type:` with the old enum\n  (`count`/`sum`/...), `model:`, `timestamp:`, `time_grains:`, `dimensions:` directly on the\n  metric, or `filters:` (the list-of-dict old form).\n- The new MetricFlow schema instead uses `type:` with values simple|ratio|cumulative|derived\n  plus a `type_params:` block. If a metric already has `type_params:`, it is migrated \u2014 skip it.\n- Also grep packages.yml for `dbt_metrics` usage and models for `metrics.calculate(` /\n  `metrics.develop(` macro calls \u2014 those depend on the old package and must be flagged too.",
+        "fixing": "- Rewrite each legacy metric into the new schema. Attribute mapping:\n  - `calculation_method` -> `type`: sum/average/min/max/count/count_distinct/median become\n    `type: simple` with `type_params.measure`; derived/expression become `type: derived` with\n    `type_params.expr` and `type_params.metrics`.\n  - `expression`/`sql` -> `type_params.measure` (the semantic measure name), or\n    `type_params.expr` for a derived metric.\n  - `model:` -> moves into a `semantic_models:` definition (see example below).\n  - `filters:` -> `filter:` (a single `{{ Dimension(...) }}` string, or keep the WHERE fragment).\n- Concrete before/after:\n  BEFORE (1.5):\n    metrics:\n      - name: total_revenue\n        calculation_method: sum\n        expression: amount\n        model: ref('orders')\n        timestamp: order_date\n        time_grains: [day, month]\n        dimensions: [status]\n  AFTER (1.6, MetricFlow):\n    semantic_models:\n      - name: orders\n        model: ref('orders')\n        defaults:\n          agg_time_dimension: order_date\n        entities:\n          - name: order\n            type: primary\n        dimensions:\n          - name: order_date\n            type: time\n            type_params: {time_granularity: day}\n          - name: status\n            type: categorical\n        measures:\n          - name: amount\n            agg: sum\n            agg_time_dimension: order_date\n    metrics:\n      - name: total_revenue\n        type: simple\n        type_params:\n          measure: amount\n- Derived example: `calculation_method: derived` + `expression: revenue - cost` becomes\n  `type: derived` with `type_params: {expr: 'revenue - cost', metrics: [{name: revenue},\n  {name: cost}]}`.\n- Judgment-heavy: 1.6 requires a `semantic_models:` layer that did not exist in 1.5, so the\n  measure/entity/dimension split cannot always be inferred mechanically.\n- If you cannot confidently reconstruct the semantic model (e.g. the source model's grain or\n  entities are ambiguous), do NOT guess \u2014 record the metric in the results report with\n  the original YAML and the suggested new shape, and move on.\n- After editing, run `dbt parse`. On a metric/semantic-model validation error, re-read it;\n  reverting to legacy form is NOT an option (it won't parse in 1.6) \u2014 instead leave the\n  semantic_model skeleton and flag it manual.\n- Remove `dbt_metrics` / `metrics.calculate` usages and flag them as requiring the\n  MetricFlow / Semantic Layer migration (out of scope for parse)."
+      },
+      "_path": "kb/core/1_5_001.yaml"
+    },
+    {
+      "issue_id": "1_5_002",
+      "sort_order": 3020,
+      "change": "Duplicate node names allowed across packages",
+      "action": "Disambiguate cross-package references with two-argument ref('package_name', 'model_name')",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.5 a flat manifest dict raised DuplicateResourceNameError; in 1.6 names are stored per-package, so a project and an installed package can legitimately share a model name. Single-argument ref() to a name that exists in more than one package becomes ambiguous (AmbiguousAliasError / wrong node).",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant if packages.yml / dependencies.yml declares packages.\n- Build the set of model/seed/snapshot names defined in the local project (models/**/*.sql,\n  seeds/**/*.csv, snapshots/**/*.sql).\n- Where available, add the names exposed by installed packages under dbt_packages/*/models.\n- Grep all .sql/.yml for single-argument `ref('name')` / `ref(\"name\")` whose `name` collides\n  with a name present in BOTH the local project and a package (or in two packages) \u2014 those are\n  the ambiguous refs.\n- If no packages are installed, mark skipped-not-present.",
+        "fixing": "- For each ambiguous single-arg ref, rewrite to the two-argument form\n  `ref('<package_name>', '<model_name>')`.\n- Choose the package the author intended; default to the local project's own model unless the\n  surrounding SQL clearly consumes the package's version.\n- Example: `ref('customers')` -> `ref('my_project', 'customers')` or\n  `ref('dbt_utils', 'customers')`. Leave unambiguous refs untouched.\n- After edits run `dbt parse`; a remaining AmbiguousAliasError names the offending ref and node.\n- If you cannot determine which package is intended, record it in the results report\n  rather than guessing \u2014 picking the wrong package silently changes lineage."
+      },
+      "_path": "kb/core/1_5_002.yaml"
+    },
+    {
+      "issue_id": "1_5_003",
+      "sort_order": 3030,
+      "change": "collect_freshness macro return type changed",
+      "action": "Update any custom collect_freshness macro override to return the full result object (table + response) instead of just the table",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.6 core's default collect_freshness returns a dict-like {table, response} object; a custom override that returns only the agate table triggers a deprecation warning and will break source freshness in later versions.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/**/*.sql for a macro named `collect_freshness` (i.e. `{% macro collect_freshness(`\n  or `{% macro <adapter>__collect_freshness(`).\n- If none exists, the project uses core's implementation \u2014 mark skipped-not-present.\n- If one exists, inspect its final `{{ return(...) }}` and flag it if it returns the query\n  result table directly (e.g. `return(load_result('collect_freshness').table)` or\n  `return(table)`) rather than the full result object.",
+        "fixing": "- Change the macro to capture the full result and return an object exposing both the table and\n  the adapter response.\n- Pattern: `{% set result = run_query(...) %}` then\n  `{{ return({'table': result.table, 'response': result.response}) }}`.\n- Mirror core's 1.6 signature: it returns `load_result('collect_freshness')`, which already has\n  `.table` and `.response`.\n- Simplest safe fix, if the override only existed to tweak the SQL: align the return statement\n  with core 1.6's macro body.\n- After editing run `dbt parse`.\n- If the override is complex or the intended response object is unclear, record it in the\n  results report with a pointer to core's 1.6 collect_freshness for reference."
+      },
+      "_path": "kb/core/1_5_003.yaml"
+    },
+    {
+      "issue_id": "1_5_006",
+      "sort_order": 3060,
+      "change": "sslmode behavior changed; require/allow/prefer now map to verify-ca",
+      "action": "Review and update sslmode in profiles.yml (advisory)",
+      "category": "Breaking",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "In 1.6 the redshift_connector sslmode mapping changed: require/allow/prefer are treated as verify-ca, so connections that relied on the looser semantics may fail without a CA certificate.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": true,
+      "context": {
+        "detection": "- Connection-profile concern, not visible to dbt parse.\n- Look for `sslmode:` under a redshift target in profiles.yml (usually ~/.dbt/profiles.yml, but\n  also any in-repo profiles.yml or profiles template).\n- Flag values `require`, `allow`, or `prefer`.\n- If profiles.yml is not in the repo, this can only be advised, not edited.",
+        "fixing": "- ADVISORY \u2014 do not open a warehouse connection.\n- If an in-repo profiles.yml exists, note (do not silently rewrite auth) that require/allow/prefer\n  now behave as verify-ca.\n- Advise the user to either provide a CA cert (`sslrootcert`) or set the intended sslmode\n  explicitly (e.g. `disable` / `verify-ca` / `verify-full`) to match their security posture.\n- Record in the results report with the target name and current sslmode value.\n- Excluded from the dbt parse verify loop (connection behavior is not exercised by parse)."
+      },
+      "_path": "kb/redshift/1_5_006.yaml"
+    },
+    {
+      "issue_id": "1_5_007",
+      "sort_order": 3070,
+      "change": "Autocommit enabled by default (autocommit: True)",
+      "action": "Set autocommit: false in profiles.yml if you relied on 1.5's transactional behavior (advisory)",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "1.6 restores pre-1.5 semantics: autocommit defaults to True, so DDL and standalone statements auto-commit. Projects that depended on 1.5's implicit transaction wrapping (e.g. multi-statement hooks meant to roll back together) change behavior.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": true,
+      "context": {
+        "detection": "- Connection-profile concern, not visible to dbt parse.\n- Check the redshift target(s) in profiles.yml for an explicit `autocommit:` key.\n- Grep macros/**/*.sql and models for pre-hook/post-hook/on-run-* blocks containing explicit\n  BEGIN/COMMIT/ROLLBACK \u2014 these suggest the project relied on transactional grouping.\n- If neither profiles.yml is available nor transactional hooks exist, mark skipped-not-present.",
+        "fixing": "- ADVISORY \u2014 do not connect to the warehouse.\n- If the project shows reliance on transactional behavior, advise setting `autocommit: false` on\n  the redshift target in profiles.yml and record it in the results report (with target\n  name).\n- Do not blanket-add autocommit:false \u2014 the 1.6 default is intentional for most projects.\n- Excluded from the dbt parse verify loop."
+      },
+      "_path": "kb/redshift/1_5_007.yaml"
+    },
+    {
+      "issue_id": "1_5_008",
+      "sort_order": 3080,
+      "change": "list_relations_without_caching rewritten with Redshift-native SQL",
+      "action": "Review the macro if you override it; edge-case results may differ",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "1.6 replaces the Postgres-based relation listing with Redshift-native SQL. Projects that override redshift__list_relations_without_caching may diverge from the new base behavior on edge cases (late-binding views, external schemas).",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/**/*.sql for an override named `list_relations_without_caching`,\n  `redshift__list_relations_without_caching`, or `postgres__list_relations_without_caching`\n  used by the redshift adapter.\n- If no override exists, mark skipped-not-present \u2014 core's new implementation applies\n  automatically and needs no code change.",
+        "fixing": "- If an override exists, compare it against dbt-redshift 1.6's\n  redshift__list_relations_without_caching.\n- If the override only reproduced the old Postgres query, recommend removing it to inherit the\n  fixed native version.\n- If it adds project-specific logic, port that logic onto the 1.6 base query.\n- This is behavioral (warehouse-executed), so `dbt parse` passes regardless \u2014 record a\n  manual-actions note asking the user to validate relation listing against a live Redshift.\n- If unsure whether the override is still needed, flag it rather than deleting it."
+      },
+      "_path": "kb/redshift/1_5_008.yaml"
+    },
+    {
+      "issue_id": "1_6_011",
+      "sort_order": 4005,
+      "change": "dbt clean errors when clean-targets include source paths or paths outside the project",
+      "action": "Remove source paths (e.g. models/, macros/) and any path outside the project directory from clean-targets in dbt_project.yml",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "dbt clean now raises an error instead of silently deleting the wrong directories when clean-targets references source paths or paths outside the project root",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml's clean-targets list.\n- Flag any entry that resolves (relative to the project root) to a configured source path\n  (model-paths, seed-paths, macro-paths, etc.) or that resolves outside the project directory\n  (e.g. ../shared, /absolute/path).",
+        "fixing": "- Remove the offending entries from clean-targets, keeping only build/output directories\n  (e.g. target, dbt_packages, logs).\n- Re-run dbt clean to confirm it no longer errors."
+      },
+      "_path": "kb/core/1_6_011.yaml"
+    },
+    {
+      "issue_id": "1_6_001",
+      "sort_order": 4010,
+      "change": "New warning when --state and --target point to the same directory",
+      "action": "Fix --state/--target configuration so they reference distinct directories",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "WarnStateTargetEqual raised (informational) for previously silent misconfiguration; fatal under --warn-error",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- This is a runtime CLI/job configuration issue, not a repo-source issue, so `dbt parse` cannot\n  surface it. Detect by scanning invocation sites, not models.\n- Grep the repo for `--state` and `--target` / `--target-path` in shell scripts, Makefiles, and\n  `scripts/**/*.sh`.\n- Also grep CI configs: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `tox.ini`.\n- Check `dbt_project.yml` for a `target-path:` key (deprecated since 1.5 but may still be present).\n- Check for `DBT_STATE` / `DBT_TARGET_PATH` env vars in CI.\n- Flag any invocation where `--state` and `--target`/`--target-path` resolve to the same directory\n  (commonly both set to `target/`).\n- Note the value is frequently supplied outside the repo (dbt platform job definitions,\n  orchestration tools), which parse cannot see.",
+        "fixing": "- Point `--state` at a directory separate from the run's `--target` \u2014 e.g. keep run output in\n  `target/` and the comparison manifest in a distinct dir such as `state/` or `prod-artifacts/`.\n- Concretely, in the offending script/CI step change the duplicated paths so a command like\n  `dbt build --state ./state --target-path ./target` uses different dirs, and populate the state\n  artifacts there.\n- If the same-directory usage lives outside the repo (a dbt platform job command, an orchestration\n  tool), it cannot be edited from the repo.\n- For that out-of-repo case: record it in the results artifact (target/dbt_migration_results.json)\n  as manual-required with the issue_id, the invocation location if known, and the suggested command\n  change, then prompt the user.\n- This change never requires a repo edit to pass `dbt parse`; it is advisory / out-of-repo only."
+      },
+      "_path": "kb/core/1_6_001.yaml"
+    },
+    {
+      "issue_id": "1_6_002",
+      "sort_order": 4020,
+      "change": "Breaking contract changes on unversioned models now warn instead of error",
+      "action": "Add --warn-error (or version the models) to retain the previous hard-error behavior on breaking contract changes",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Unversioned models with a breaking schema/contract change warn via warn_or_error() instead of erroring; CI that relied on the error to block may now pass silently",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan schema YAML (`models/**/*.yml`, `models/**/*.yaml`) for models declaring `contract:` with\n  `enforced: true` that do NOT declare a `version:` / `versions:` block (i.e. unversioned).\n- Those unversioned enforced-contract models are the ones whose breaking contract changes now only\n  warn.\n- Also detect reliance on the old error behavior: grep CI/scripts for `dbt build` / `dbt run`\n  invocations that lack `--warn-error` or `--warn-error-options`.\n- Those flags are what previously turned the contract breakage into a hard failure.\n- This is a behavior/policy change; `dbt parse` stays clean either way, so detection is about intent,\n  not parse errors.",
+        "fixing": "- Preferred: preserve strict behavior by adding `--warn-error` (or a scoped `--warn-error-options`\n  targeting contract deprecations) to the relevant dbt invocation.\n- If that invocation is defined outside the repo (dbt platform job command, orchestration tool), it\n  cannot be edited here: record it in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the suggested flag, and prompt the user.\n- Alternative in-repo fix: add a `version:` to the affected models \u2014 versioning makes breaking\n  contract changes error again.\n- But versioning reshapes ref() resolution and downstream references, so only do it when the user\n  explicitly wants versioned models; note that trade-off in the results report rather than silently\n  versioning.\n- No edit is required for `dbt parse` to succeed."
+      },
+      "_path": "kb/core/1_6_002.yaml"
+    },
+    {
+      "issue_id": "1_6_003",
+      "sort_order": 4030,
+      "change": "New warning for contracted models with bare numeric columns (no precision/scale)",
+      "action": "Add explicit precision and scale to numeric column data_types in enforced contracts (e.g. numeric(38,3))",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with 'data_type: numeric' (or 'decimal') and no precision/scale in an enforced contract now emit a warning at parse time in 1.7",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- In schema YAML (`models/**/*.yml`, `models/**/*.yaml`), find models with `contract:`\n  `enforced: true` and columns whose `data_type` is a bare numeric type with no precision/scale.\n- Match the data_type value (case-insensitive) against `^(numeric|decimal|number)$` (no parentheses).\n- Types that already include `(p,s)` like `numeric(38,3)` are fine and must be left alone.\n- Only columns inside enforced-contract models trigger the warning; bare numeric on non-contracted\n  models is not affected.",
+        "fixing": "- For each flagged column, replace the bare type with an explicit precision/scale, e.g.\n  `data_type: numeric` -> `data_type: numeric(38,3)`.\n- Choose precision/scale from evidence in this order:\n- (1) an existing cast in the model SQL (e.g. `cast(x as numeric(18,2))`) \u2014 match it;\n- (2) the warehouse's documented default for unqualified numeric if the model is already built\n  (Snowflake NUMBER default is (38,0); Redshift/Postgres NUMERIC default is (38,0));\n- (3) if unknown, use a safe wide default `numeric(38,6)` and note the assumption in the results\n  report.\n- Preserve YAML quoting/style.\n- After editing, run `dbt parse`; if it fails, the likely cause is a mismatched type name for the\n  adapter (e.g. Snowflake prefers `number(38,3)`) \u2014 retry with the adapter-native spelling.\n- If the correct precision genuinely cannot be determined, leave the column and record it in the\n  results artifact (target/dbt_migration_results.json) as manual-required for the user to confirm."
+      },
+      "_path": "kb/core/1_6_003.yaml"
+    },
+    {
+      "issue_id": "1_6_004",
+      "sort_order": 4040,
+      "change": "merge_exclude_columns bug fix: excluded columns now correctly inserted in WHEN NOT MATCHED",
+      "action": "Review incremental models using merge_exclude_columns; excluded columns are now populated on new-row inserts",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "Incremental merge with merge_exclude_columns now inserts ALL columns for new rows (previously excluded columns were omitted on INSERT); resulting table data changes",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep model config for `merge_exclude_columns` in `models/**/*.sql` config() blocks (e.g.\n  `config(materialized='incremental', ... merge_exclude_columns=[...])`) and in schema YAML\n  `config:` blocks.\n- Only relevant when `materialized='incremental'` with the default `merge` strategy on the Redshift\n  adapter.\n- This is a behavior/warehouse change invisible to `dbt parse`; nothing makes parse fail.",
+        "fixing": "- No source edit is required to reach 1.8 or pass parse \u2014 the fix was in the adapter. The migration\n  action is to flag semantics.\n- For each model using merge_exclude_columns, new rows (WHEN NOT MATCHED) will now have the\n  previously-excluded columns inserted with their source values instead of being left null/default.\n- If the user intentionally relied on those columns being unset on insert, that assumption breaks.\n- Record each occurrence in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the issue_id, the model path, the merge_exclude_columns list, and a note to\n  verify the new insert behavior is acceptable.\n- Real validation happens in the warehouse build-green test layer, not here.\n- Do not modify the model unless the user confirms a semantic change is needed."
+      },
+      "_path": "kb/redshift/1_6_004.yaml"
+    },
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_004",
+      "sort_order": 5040,
+      "change": "Redshift catalog query macros restructured and split into multiple files",
+      "action": "Update custom overrides of redshift__get_base_catalog / catalog macros to match the new 1.8 structure",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "Custom overrides of redshift__get_catalog / redshift__get_base_catalog (and related catalog SQL) may break or silently diverge because the macro was split across a catalog/ directory in dbt-redshift 1.8",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant if the project (or an installed package) overrides Redshift catalog macros.\n- Grep macros/**/*.sql and packages' macros for definitions named `redshift__get_catalog`,\n  `redshift__get_base_catalog`, `redshift__get_catalog_relations`, or any\n  `{% macro redshift__...catalog...%}`.\n- If no such override exists, the change is not present (docs generate keeps working on the\n  built-in macros).\n- If an override exists, it likely mirrors the old single-file catalog.sql shape and will not\n  align with the 1.8 split.",
+        "fixing": "- If an override is found, compare it against the dbt-redshift 1.8 catalog macros (now under an\n  adapter catalog/ directory, split into base-catalog and relations pieces).\n- Re-implement the override on the new macro seams: typically split a monolithic\n  `redshift__get_catalog` override into `redshift__get_base_catalog` plus the relation-scoped\n  variant, matching the new signatures.\n- Invisible to `dbt parse` (catalog macros only compile when catalog generation runs), so parse\n  cannot validate correctness.\n- After adjusting, note that `dbt docs generate` against a warehouse is the real check (harness\n  build-green layer, not in-skill).\n- If the override's intent is unclear or reproducing the split is risky, record a manual-actions\n  entry pointing at the overriding macro and the dbt-redshift 1.8 catalog macro source."
+      },
+      "_path": "kb/redshift/1_7_004.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_5_snowflake.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_5_snowflake.json
@@ -1,0 +1,652 @@
+{
+  "from_version": "1.5",
+  "warehouse": "snowflake",
+  "target_version": "1.12",
+  "count": 29,
+  "issues": [
+    {
+      "issue_id": "1_5_001",
+      "sort_order": 3010,
+      "change": "Metric YAML schema completely rewritten for MetricFlow",
+      "action": "Rewrite all metric definitions using the new type/type_params/filter format",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "All existing metric YAML definitions fail to parse in 1.6; the pre-1.6 UnparsedMetric fields (calculation_method, expression, sql, model, type: expression) and the rename_metric_attr compatibility shim were removed.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Search every YAML file under models/ and any schema-file globs declared in dbt_project.yml\n  (models/**/*.yml, models/**/*.yaml, plus any top-level metrics/ dir) for a `metrics:` block.\n- Flag a metric as legacy (pre-1.6) if its entry uses ANY of these keys: `calculation_method`,\n  `expression`, `sql`, `type: expression`, a top-level `type:` with the old enum\n  (`count`/`sum`/...), `model:`, `timestamp:`, `time_grains:`, `dimensions:` directly on the\n  metric, or `filters:` (the list-of-dict old form).\n- The new MetricFlow schema instead uses `type:` with values simple|ratio|cumulative|derived\n  plus a `type_params:` block. If a metric already has `type_params:`, it is migrated \u2014 skip it.\n- Also grep packages.yml for `dbt_metrics` usage and models for `metrics.calculate(` /\n  `metrics.develop(` macro calls \u2014 those depend on the old package and must be flagged too.",
+        "fixing": "- Rewrite each legacy metric into the new schema. Attribute mapping:\n  - `calculation_method` -> `type`: sum/average/min/max/count/count_distinct/median become\n    `type: simple` with `type_params.measure`; derived/expression become `type: derived` with\n    `type_params.expr` and `type_params.metrics`.\n  - `expression`/`sql` -> `type_params.measure` (the semantic measure name), or\n    `type_params.expr` for a derived metric.\n  - `model:` -> moves into a `semantic_models:` definition (see example below).\n  - `filters:` -> `filter:` (a single `{{ Dimension(...) }}` string, or keep the WHERE fragment).\n- Concrete before/after:\n  BEFORE (1.5):\n    metrics:\n      - name: total_revenue\n        calculation_method: sum\n        expression: amount\n        model: ref('orders')\n        timestamp: order_date\n        time_grains: [day, month]\n        dimensions: [status]\n  AFTER (1.6, MetricFlow):\n    semantic_models:\n      - name: orders\n        model: ref('orders')\n        defaults:\n          agg_time_dimension: order_date\n        entities:\n          - name: order\n            type: primary\n        dimensions:\n          - name: order_date\n            type: time\n            type_params: {time_granularity: day}\n          - name: status\n            type: categorical\n        measures:\n          - name: amount\n            agg: sum\n            agg_time_dimension: order_date\n    metrics:\n      - name: total_revenue\n        type: simple\n        type_params:\n          measure: amount\n- Derived example: `calculation_method: derived` + `expression: revenue - cost` becomes\n  `type: derived` with `type_params: {expr: 'revenue - cost', metrics: [{name: revenue},\n  {name: cost}]}`.\n- Judgment-heavy: 1.6 requires a `semantic_models:` layer that did not exist in 1.5, so the\n  measure/entity/dimension split cannot always be inferred mechanically.\n- If you cannot confidently reconstruct the semantic model (e.g. the source model's grain or\n  entities are ambiguous), do NOT guess \u2014 record the metric in the results report with\n  the original YAML and the suggested new shape, and move on.\n- After editing, run `dbt parse`. On a metric/semantic-model validation error, re-read it;\n  reverting to legacy form is NOT an option (it won't parse in 1.6) \u2014 instead leave the\n  semantic_model skeleton and flag it manual.\n- Remove `dbt_metrics` / `metrics.calculate` usages and flag them as requiring the\n  MetricFlow / Semantic Layer migration (out of scope for parse)."
+      },
+      "_path": "kb/core/1_5_001.yaml"
+    },
+    {
+      "issue_id": "1_5_002",
+      "sort_order": 3020,
+      "change": "Duplicate node names allowed across packages",
+      "action": "Disambiguate cross-package references with two-argument ref('package_name', 'model_name')",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.5 a flat manifest dict raised DuplicateResourceNameError; in 1.6 names are stored per-package, so a project and an installed package can legitimately share a model name. Single-argument ref() to a name that exists in more than one package becomes ambiguous (AmbiguousAliasError / wrong node).",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant if packages.yml / dependencies.yml declares packages.\n- Build the set of model/seed/snapshot names defined in the local project (models/**/*.sql,\n  seeds/**/*.csv, snapshots/**/*.sql).\n- Where available, add the names exposed by installed packages under dbt_packages/*/models.\n- Grep all .sql/.yml for single-argument `ref('name')` / `ref(\"name\")` whose `name` collides\n  with a name present in BOTH the local project and a package (or in two packages) \u2014 those are\n  the ambiguous refs.\n- If no packages are installed, mark skipped-not-present.",
+        "fixing": "- For each ambiguous single-arg ref, rewrite to the two-argument form\n  `ref('<package_name>', '<model_name>')`.\n- Choose the package the author intended; default to the local project's own model unless the\n  surrounding SQL clearly consumes the package's version.\n- Example: `ref('customers')` -> `ref('my_project', 'customers')` or\n  `ref('dbt_utils', 'customers')`. Leave unambiguous refs untouched.\n- After edits run `dbt parse`; a remaining AmbiguousAliasError names the offending ref and node.\n- If you cannot determine which package is intended, record it in the results report\n  rather than guessing \u2014 picking the wrong package silently changes lineage."
+      },
+      "_path": "kb/core/1_5_002.yaml"
+    },
+    {
+      "issue_id": "1_5_003",
+      "sort_order": 3030,
+      "change": "collect_freshness macro return type changed",
+      "action": "Update any custom collect_freshness macro override to return the full result object (table + response) instead of just the table",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.6 core's default collect_freshness returns a dict-like {table, response} object; a custom override that returns only the agate table triggers a deprecation warning and will break source freshness in later versions.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/**/*.sql for a macro named `collect_freshness` (i.e. `{% macro collect_freshness(`\n  or `{% macro <adapter>__collect_freshness(`).\n- If none exists, the project uses core's implementation \u2014 mark skipped-not-present.\n- If one exists, inspect its final `{{ return(...) }}` and flag it if it returns the query\n  result table directly (e.g. `return(load_result('collect_freshness').table)` or\n  `return(table)`) rather than the full result object.",
+        "fixing": "- Change the macro to capture the full result and return an object exposing both the table and\n  the adapter response.\n- Pattern: `{% set result = run_query(...) %}` then\n  `{{ return({'table': result.table, 'response': result.response}) }}`.\n- Mirror core's 1.6 signature: it returns `load_result('collect_freshness')`, which already has\n  `.table` and `.response`.\n- Simplest safe fix, if the override only existed to tweak the SQL: align the return statement\n  with core 1.6's macro body.\n- After editing run `dbt parse`.\n- If the override is complex or the intended response object is unclear, record it in the\n  results report with a pointer to core's 1.6 collect_freshness for reference."
+      },
+      "_path": "kb/core/1_5_003.yaml"
+    },
+    {
+      "issue_id": "1_6_011",
+      "sort_order": 4005,
+      "change": "dbt clean errors when clean-targets include source paths or paths outside the project",
+      "action": "Remove source paths (e.g. models/, macros/) and any path outside the project directory from clean-targets in dbt_project.yml",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "dbt clean now raises an error instead of silently deleting the wrong directories when clean-targets references source paths or paths outside the project root",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml's clean-targets list.\n- Flag any entry that resolves (relative to the project root) to a configured source path\n  (model-paths, seed-paths, macro-paths, etc.) or that resolves outside the project directory\n  (e.g. ../shared, /absolute/path).",
+        "fixing": "- Remove the offending entries from clean-targets, keeping only build/output directories\n  (e.g. target, dbt_packages, logs).\n- Re-run dbt clean to confirm it no longer errors."
+      },
+      "_path": "kb/core/1_6_011.yaml"
+    },
+    {
+      "issue_id": "1_6_001",
+      "sort_order": 4010,
+      "change": "New warning when --state and --target point to the same directory",
+      "action": "Fix --state/--target configuration so they reference distinct directories",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "WarnStateTargetEqual raised (informational) for previously silent misconfiguration; fatal under --warn-error",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- This is a runtime CLI/job configuration issue, not a repo-source issue, so `dbt parse` cannot\n  surface it. Detect by scanning invocation sites, not models.\n- Grep the repo for `--state` and `--target` / `--target-path` in shell scripts, Makefiles, and\n  `scripts/**/*.sh`.\n- Also grep CI configs: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `tox.ini`.\n- Check `dbt_project.yml` for a `target-path:` key (deprecated since 1.5 but may still be present).\n- Check for `DBT_STATE` / `DBT_TARGET_PATH` env vars in CI.\n- Flag any invocation where `--state` and `--target`/`--target-path` resolve to the same directory\n  (commonly both set to `target/`).\n- Note the value is frequently supplied outside the repo (dbt platform job definitions,\n  orchestration tools), which parse cannot see.",
+        "fixing": "- Point `--state` at a directory separate from the run's `--target` \u2014 e.g. keep run output in\n  `target/` and the comparison manifest in a distinct dir such as `state/` or `prod-artifacts/`.\n- Concretely, in the offending script/CI step change the duplicated paths so a command like\n  `dbt build --state ./state --target-path ./target` uses different dirs, and populate the state\n  artifacts there.\n- If the same-directory usage lives outside the repo (a dbt platform job command, an orchestration\n  tool), it cannot be edited from the repo.\n- For that out-of-repo case: record it in the results artifact (target/dbt_migration_results.json)\n  as manual-required with the issue_id, the invocation location if known, and the suggested command\n  change, then prompt the user.\n- This change never requires a repo edit to pass `dbt parse`; it is advisory / out-of-repo only."
+      },
+      "_path": "kb/core/1_6_001.yaml"
+    },
+    {
+      "issue_id": "1_6_002",
+      "sort_order": 4020,
+      "change": "Breaking contract changes on unversioned models now warn instead of error",
+      "action": "Add --warn-error (or version the models) to retain the previous hard-error behavior on breaking contract changes",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Unversioned models with a breaking schema/contract change warn via warn_or_error() instead of erroring; CI that relied on the error to block may now pass silently",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan schema YAML (`models/**/*.yml`, `models/**/*.yaml`) for models declaring `contract:` with\n  `enforced: true` that do NOT declare a `version:` / `versions:` block (i.e. unversioned).\n- Those unversioned enforced-contract models are the ones whose breaking contract changes now only\n  warn.\n- Also detect reliance on the old error behavior: grep CI/scripts for `dbt build` / `dbt run`\n  invocations that lack `--warn-error` or `--warn-error-options`.\n- Those flags are what previously turned the contract breakage into a hard failure.\n- This is a behavior/policy change; `dbt parse` stays clean either way, so detection is about intent,\n  not parse errors.",
+        "fixing": "- Preferred: preserve strict behavior by adding `--warn-error` (or a scoped `--warn-error-options`\n  targeting contract deprecations) to the relevant dbt invocation.\n- If that invocation is defined outside the repo (dbt platform job command, orchestration tool), it\n  cannot be edited here: record it in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the suggested flag, and prompt the user.\n- Alternative in-repo fix: add a `version:` to the affected models \u2014 versioning makes breaking\n  contract changes error again.\n- But versioning reshapes ref() resolution and downstream references, so only do it when the user\n  explicitly wants versioned models; note that trade-off in the results report rather than silently\n  versioning.\n- No edit is required for `dbt parse` to succeed."
+      },
+      "_path": "kb/core/1_6_002.yaml"
+    },
+    {
+      "issue_id": "1_6_003",
+      "sort_order": 4030,
+      "change": "New warning for contracted models with bare numeric columns (no precision/scale)",
+      "action": "Add explicit precision and scale to numeric column data_types in enforced contracts (e.g. numeric(38,3))",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with 'data_type: numeric' (or 'decimal') and no precision/scale in an enforced contract now emit a warning at parse time in 1.7",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- In schema YAML (`models/**/*.yml`, `models/**/*.yaml`), find models with `contract:`\n  `enforced: true` and columns whose `data_type` is a bare numeric type with no precision/scale.\n- Match the data_type value (case-insensitive) against `^(numeric|decimal|number)$` (no parentheses).\n- Types that already include `(p,s)` like `numeric(38,3)` are fine and must be left alone.\n- Only columns inside enforced-contract models trigger the warning; bare numeric on non-contracted\n  models is not affected.",
+        "fixing": "- For each flagged column, replace the bare type with an explicit precision/scale, e.g.\n  `data_type: numeric` -> `data_type: numeric(38,3)`.\n- Choose precision/scale from evidence in this order:\n- (1) an existing cast in the model SQL (e.g. `cast(x as numeric(18,2))`) \u2014 match it;\n- (2) the warehouse's documented default for unqualified numeric if the model is already built\n  (Snowflake NUMBER default is (38,0); Redshift/Postgres NUMERIC default is (38,0));\n- (3) if unknown, use a safe wide default `numeric(38,6)` and note the assumption in the results\n  report.\n- Preserve YAML quoting/style.\n- After editing, run `dbt parse`; if it fails, the likely cause is a mismatched type name for the\n  adapter (e.g. Snowflake prefers `number(38,3)`) \u2014 retry with the adapter-native spelling.\n- If the correct precision genuinely cannot be determined, leave the column and record it in the\n  results artifact (target/dbt_migration_results.json) as manual-required for the user to confirm."
+      },
+      "_path": "kb/core/1_6_003.yaml"
+    },
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_5_spark.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_5_spark.json
@@ -1,0 +1,672 @@
+{
+  "from_version": "1.5",
+  "warehouse": "spark",
+  "target_version": "1.12",
+  "count": 30,
+  "issues": [
+    {
+      "issue_id": "1_5_001",
+      "sort_order": 3010,
+      "change": "Metric YAML schema completely rewritten for MetricFlow",
+      "action": "Rewrite all metric definitions using the new type/type_params/filter format",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "All existing metric YAML definitions fail to parse in 1.6; the pre-1.6 UnparsedMetric fields (calculation_method, expression, sql, model, type: expression) and the rename_metric_attr compatibility shim were removed.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Search every YAML file under models/ and any schema-file globs declared in dbt_project.yml\n  (models/**/*.yml, models/**/*.yaml, plus any top-level metrics/ dir) for a `metrics:` block.\n- Flag a metric as legacy (pre-1.6) if its entry uses ANY of these keys: `calculation_method`,\n  `expression`, `sql`, `type: expression`, a top-level `type:` with the old enum\n  (`count`/`sum`/...), `model:`, `timestamp:`, `time_grains:`, `dimensions:` directly on the\n  metric, or `filters:` (the list-of-dict old form).\n- The new MetricFlow schema instead uses `type:` with values simple|ratio|cumulative|derived\n  plus a `type_params:` block. If a metric already has `type_params:`, it is migrated \u2014 skip it.\n- Also grep packages.yml for `dbt_metrics` usage and models for `metrics.calculate(` /\n  `metrics.develop(` macro calls \u2014 those depend on the old package and must be flagged too.",
+        "fixing": "- Rewrite each legacy metric into the new schema. Attribute mapping:\n  - `calculation_method` -> `type`: sum/average/min/max/count/count_distinct/median become\n    `type: simple` with `type_params.measure`; derived/expression become `type: derived` with\n    `type_params.expr` and `type_params.metrics`.\n  - `expression`/`sql` -> `type_params.measure` (the semantic measure name), or\n    `type_params.expr` for a derived metric.\n  - `model:` -> moves into a `semantic_models:` definition (see example below).\n  - `filters:` -> `filter:` (a single `{{ Dimension(...) }}` string, or keep the WHERE fragment).\n- Concrete before/after:\n  BEFORE (1.5):\n    metrics:\n      - name: total_revenue\n        calculation_method: sum\n        expression: amount\n        model: ref('orders')\n        timestamp: order_date\n        time_grains: [day, month]\n        dimensions: [status]\n  AFTER (1.6, MetricFlow):\n    semantic_models:\n      - name: orders\n        model: ref('orders')\n        defaults:\n          agg_time_dimension: order_date\n        entities:\n          - name: order\n            type: primary\n        dimensions:\n          - name: order_date\n            type: time\n            type_params: {time_granularity: day}\n          - name: status\n            type: categorical\n        measures:\n          - name: amount\n            agg: sum\n            agg_time_dimension: order_date\n    metrics:\n      - name: total_revenue\n        type: simple\n        type_params:\n          measure: amount\n- Derived example: `calculation_method: derived` + `expression: revenue - cost` becomes\n  `type: derived` with `type_params: {expr: 'revenue - cost', metrics: [{name: revenue},\n  {name: cost}]}`.\n- Judgment-heavy: 1.6 requires a `semantic_models:` layer that did not exist in 1.5, so the\n  measure/entity/dimension split cannot always be inferred mechanically.\n- If you cannot confidently reconstruct the semantic model (e.g. the source model's grain or\n  entities are ambiguous), do NOT guess \u2014 record the metric in the results report with\n  the original YAML and the suggested new shape, and move on.\n- After editing, run `dbt parse`. On a metric/semantic-model validation error, re-read it;\n  reverting to legacy form is NOT an option (it won't parse in 1.6) \u2014 instead leave the\n  semantic_model skeleton and flag it manual.\n- Remove `dbt_metrics` / `metrics.calculate` usages and flag them as requiring the\n  MetricFlow / Semantic Layer migration (out of scope for parse)."
+      },
+      "_path": "kb/core/1_5_001.yaml"
+    },
+    {
+      "issue_id": "1_5_002",
+      "sort_order": 3020,
+      "change": "Duplicate node names allowed across packages",
+      "action": "Disambiguate cross-package references with two-argument ref('package_name', 'model_name')",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.5 a flat manifest dict raised DuplicateResourceNameError; in 1.6 names are stored per-package, so a project and an installed package can legitimately share a model name. Single-argument ref() to a name that exists in more than one package becomes ambiguous (AmbiguousAliasError / wrong node).",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant if packages.yml / dependencies.yml declares packages.\n- Build the set of model/seed/snapshot names defined in the local project (models/**/*.sql,\n  seeds/**/*.csv, snapshots/**/*.sql).\n- Where available, add the names exposed by installed packages under dbt_packages/*/models.\n- Grep all .sql/.yml for single-argument `ref('name')` / `ref(\"name\")` whose `name` collides\n  with a name present in BOTH the local project and a package (or in two packages) \u2014 those are\n  the ambiguous refs.\n- If no packages are installed, mark skipped-not-present.",
+        "fixing": "- For each ambiguous single-arg ref, rewrite to the two-argument form\n  `ref('<package_name>', '<model_name>')`.\n- Choose the package the author intended; default to the local project's own model unless the\n  surrounding SQL clearly consumes the package's version.\n- Example: `ref('customers')` -> `ref('my_project', 'customers')` or\n  `ref('dbt_utils', 'customers')`. Leave unambiguous refs untouched.\n- After edits run `dbt parse`; a remaining AmbiguousAliasError names the offending ref and node.\n- If you cannot determine which package is intended, record it in the results report\n  rather than guessing \u2014 picking the wrong package silently changes lineage."
+      },
+      "_path": "kb/core/1_5_002.yaml"
+    },
+    {
+      "issue_id": "1_5_003",
+      "sort_order": 3030,
+      "change": "collect_freshness macro return type changed",
+      "action": "Update any custom collect_freshness macro override to return the full result object (table + response) instead of just the table",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In 1.6 core's default collect_freshness returns a dict-like {table, response} object; a custom override that returns only the agate table triggers a deprecation warning and will break source freshness in later versions.",
+      "from_version": "1.5",
+      "to_version": "1.6",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep macros/**/*.sql for a macro named `collect_freshness` (i.e. `{% macro collect_freshness(`\n  or `{% macro <adapter>__collect_freshness(`).\n- If none exists, the project uses core's implementation \u2014 mark skipped-not-present.\n- If one exists, inspect its final `{{ return(...) }}` and flag it if it returns the query\n  result table directly (e.g. `return(load_result('collect_freshness').table)` or\n  `return(table)`) rather than the full result object.",
+        "fixing": "- Change the macro to capture the full result and return an object exposing both the table and\n  the adapter response.\n- Pattern: `{% set result = run_query(...) %}` then\n  `{{ return({'table': result.table, 'response': result.response}) }}`.\n- Mirror core's 1.6 signature: it returns `load_result('collect_freshness')`, which already has\n  `.table` and `.response`.\n- Simplest safe fix, if the override only existed to tweak the SQL: align the return statement\n  with core 1.6's macro body.\n- After editing run `dbt parse`.\n- If the override is complex or the intended response object is unclear, record it in the\n  results report with a pointer to core's 1.6 collect_freshness for reference."
+      },
+      "_path": "kb/core/1_5_003.yaml"
+    },
+    {
+      "issue_id": "1_6_011",
+      "sort_order": 4005,
+      "change": "dbt clean errors when clean-targets include source paths or paths outside the project",
+      "action": "Remove source paths (e.g. models/, macros/) and any path outside the project directory from clean-targets in dbt_project.yml",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "dbt clean now raises an error instead of silently deleting the wrong directories when clean-targets references source paths or paths outside the project root",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml's clean-targets list.\n- Flag any entry that resolves (relative to the project root) to a configured source path\n  (model-paths, seed-paths, macro-paths, etc.) or that resolves outside the project directory\n  (e.g. ../shared, /absolute/path).",
+        "fixing": "- Remove the offending entries from clean-targets, keeping only build/output directories\n  (e.g. target, dbt_packages, logs).\n- Re-run dbt clean to confirm it no longer errors."
+      },
+      "_path": "kb/core/1_6_011.yaml"
+    },
+    {
+      "issue_id": "1_6_001",
+      "sort_order": 4010,
+      "change": "New warning when --state and --target point to the same directory",
+      "action": "Fix --state/--target configuration so they reference distinct directories",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "WarnStateTargetEqual raised (informational) for previously silent misconfiguration; fatal under --warn-error",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- This is a runtime CLI/job configuration issue, not a repo-source issue, so `dbt parse` cannot\n  surface it. Detect by scanning invocation sites, not models.\n- Grep the repo for `--state` and `--target` / `--target-path` in shell scripts, Makefiles, and\n  `scripts/**/*.sh`.\n- Also grep CI configs: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `tox.ini`.\n- Check `dbt_project.yml` for a `target-path:` key (deprecated since 1.5 but may still be present).\n- Check for `DBT_STATE` / `DBT_TARGET_PATH` env vars in CI.\n- Flag any invocation where `--state` and `--target`/`--target-path` resolve to the same directory\n  (commonly both set to `target/`).\n- Note the value is frequently supplied outside the repo (dbt platform job definitions,\n  orchestration tools), which parse cannot see.",
+        "fixing": "- Point `--state` at a directory separate from the run's `--target` \u2014 e.g. keep run output in\n  `target/` and the comparison manifest in a distinct dir such as `state/` or `prod-artifacts/`.\n- Concretely, in the offending script/CI step change the duplicated paths so a command like\n  `dbt build --state ./state --target-path ./target` uses different dirs, and populate the state\n  artifacts there.\n- If the same-directory usage lives outside the repo (a dbt platform job command, an orchestration\n  tool), it cannot be edited from the repo.\n- For that out-of-repo case: record it in the results artifact (target/dbt_migration_results.json)\n  as manual-required with the issue_id, the invocation location if known, and the suggested command\n  change, then prompt the user.\n- This change never requires a repo edit to pass `dbt parse`; it is advisory / out-of-repo only."
+      },
+      "_path": "kb/core/1_6_001.yaml"
+    },
+    {
+      "issue_id": "1_6_002",
+      "sort_order": 4020,
+      "change": "Breaking contract changes on unversioned models now warn instead of error",
+      "action": "Add --warn-error (or version the models) to retain the previous hard-error behavior on breaking contract changes",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Unversioned models with a breaking schema/contract change warn via warn_or_error() instead of erroring; CI that relied on the error to block may now pass silently",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan schema YAML (`models/**/*.yml`, `models/**/*.yaml`) for models declaring `contract:` with\n  `enforced: true` that do NOT declare a `version:` / `versions:` block (i.e. unversioned).\n- Those unversioned enforced-contract models are the ones whose breaking contract changes now only\n  warn.\n- Also detect reliance on the old error behavior: grep CI/scripts for `dbt build` / `dbt run`\n  invocations that lack `--warn-error` or `--warn-error-options`.\n- Those flags are what previously turned the contract breakage into a hard failure.\n- This is a behavior/policy change; `dbt parse` stays clean either way, so detection is about intent,\n  not parse errors.",
+        "fixing": "- Preferred: preserve strict behavior by adding `--warn-error` (or a scoped `--warn-error-options`\n  targeting contract deprecations) to the relevant dbt invocation.\n- If that invocation is defined outside the repo (dbt platform job command, orchestration tool), it\n  cannot be edited here: record it in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the suggested flag, and prompt the user.\n- Alternative in-repo fix: add a `version:` to the affected models \u2014 versioning makes breaking\n  contract changes error again.\n- But versioning reshapes ref() resolution and downstream references, so only do it when the user\n  explicitly wants versioned models; note that trade-off in the results report rather than silently\n  versioning.\n- No edit is required for `dbt parse` to succeed."
+      },
+      "_path": "kb/core/1_6_002.yaml"
+    },
+    {
+      "issue_id": "1_6_003",
+      "sort_order": 4030,
+      "change": "New warning for contracted models with bare numeric columns (no precision/scale)",
+      "action": "Add explicit precision and scale to numeric column data_types in enforced contracts (e.g. numeric(38,3))",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with 'data_type: numeric' (or 'decimal') and no precision/scale in an enforced contract now emit a warning at parse time in 1.7",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- In schema YAML (`models/**/*.yml`, `models/**/*.yaml`), find models with `contract:`\n  `enforced: true` and columns whose `data_type` is a bare numeric type with no precision/scale.\n- Match the data_type value (case-insensitive) against `^(numeric|decimal|number)$` (no parentheses).\n- Types that already include `(p,s)` like `numeric(38,3)` are fine and must be left alone.\n- Only columns inside enforced-contract models trigger the warning; bare numeric on non-contracted\n  models is not affected.",
+        "fixing": "- For each flagged column, replace the bare type with an explicit precision/scale, e.g.\n  `data_type: numeric` -> `data_type: numeric(38,3)`.\n- Choose precision/scale from evidence in this order:\n- (1) an existing cast in the model SQL (e.g. `cast(x as numeric(18,2))`) \u2014 match it;\n- (2) the warehouse's documented default for unqualified numeric if the model is already built\n  (Snowflake NUMBER default is (38,0); Redshift/Postgres NUMERIC default is (38,0));\n- (3) if unknown, use a safe wide default `numeric(38,6)` and note the assumption in the results\n  report.\n- Preserve YAML quoting/style.\n- After editing, run `dbt parse`; if it fails, the likely cause is a mismatched type name for the\n  adapter (e.g. Snowflake prefers `number(38,3)`) \u2014 retry with the adapter-native spelling.\n- If the correct precision genuinely cannot be determined, leave the column and record it in the\n  results artifact (target/dbt_migration_results.json) as manual-required for the user to confirm."
+      },
+      "_path": "kb/core/1_6_003.yaml"
+    },
+    {
+      "issue_id": "1_6_010",
+      "sort_order": 4100,
+      "change": "server_side_parameters values coerced to strings",
+      "action": "Review server_side_parameters that use non-string values; they are now str()-coerced (e.g. True -> \"True\")",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "spark",
+      "impact": "server_side_parameters is now typed Dict[str, str] with str() coercion; non-string values are converted, so booleans/ints render as their Python str form (True -> \"True\" with a capital T, 1 -> \"1\")",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep for `server_side_parameters` in `profiles.yml` (`outputs.<target>`), `dbt_project.yml`,\n  model config() blocks, and schema YAML `config:` blocks.\n- Inspect the mapped values: flag any value that is not already a quoted string \u2014 YAML bare\n  `true`/`false` (parsed as booleans), bare integers/floats, or Jinja expressions producing\n  non-strings.\n- String values are unaffected.",
+        "fixing": "- This is a behavior change with no parse impact.\n- For each non-string value, decide the intended wire value and make it an explicit string so the\n  coercion is predictable.\n- Example: if Spark expects lowercase `true`, write `'true'` as a quoted string rather than YAML\n  boolean `true` (which str()-coerces to `\"True\"` with a capital T and may be rejected by Spark).\n- Edit the value in place (quote it / normalize case) and record in the results report.\n- Where the config lives in `profiles.yml` outside the repo, record the recommendation in the\n  results artifact (target/dbt_migration_results.json) as manual-required instead.\n- If unsure of the exact string Spark expects for a given parameter, leave it and flag it for the\n  user rather than guessing.\n- Real effect is validated in the warehouse build-green layer."
+      },
+      "_path": "kb/spark/1_6_010.yaml"
+    },
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_6_bigquery.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_6_bigquery.json
@@ -1,0 +1,612 @@
+{
+  "from_version": "1.6",
+  "warehouse": "bigquery",
+  "target_version": "1.12",
+  "count": 27,
+  "issues": [
+    {
+      "issue_id": "1_6_011",
+      "sort_order": 4005,
+      "change": "dbt clean errors when clean-targets include source paths or paths outside the project",
+      "action": "Remove source paths (e.g. models/, macros/) and any path outside the project directory from clean-targets in dbt_project.yml",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "dbt clean now raises an error instead of silently deleting the wrong directories when clean-targets references source paths or paths outside the project root",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml's clean-targets list.\n- Flag any entry that resolves (relative to the project root) to a configured source path\n  (model-paths, seed-paths, macro-paths, etc.) or that resolves outside the project directory\n  (e.g. ../shared, /absolute/path).",
+        "fixing": "- Remove the offending entries from clean-targets, keeping only build/output directories\n  (e.g. target, dbt_packages, logs).\n- Re-run dbt clean to confirm it no longer errors."
+      },
+      "_path": "kb/core/1_6_011.yaml"
+    },
+    {
+      "issue_id": "1_6_001",
+      "sort_order": 4010,
+      "change": "New warning when --state and --target point to the same directory",
+      "action": "Fix --state/--target configuration so they reference distinct directories",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "WarnStateTargetEqual raised (informational) for previously silent misconfiguration; fatal under --warn-error",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- This is a runtime CLI/job configuration issue, not a repo-source issue, so `dbt parse` cannot\n  surface it. Detect by scanning invocation sites, not models.\n- Grep the repo for `--state` and `--target` / `--target-path` in shell scripts, Makefiles, and\n  `scripts/**/*.sh`.\n- Also grep CI configs: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `tox.ini`.\n- Check `dbt_project.yml` for a `target-path:` key (deprecated since 1.5 but may still be present).\n- Check for `DBT_STATE` / `DBT_TARGET_PATH` env vars in CI.\n- Flag any invocation where `--state` and `--target`/`--target-path` resolve to the same directory\n  (commonly both set to `target/`).\n- Note the value is frequently supplied outside the repo (dbt platform job definitions,\n  orchestration tools), which parse cannot see.",
+        "fixing": "- Point `--state` at a directory separate from the run's `--target` \u2014 e.g. keep run output in\n  `target/` and the comparison manifest in a distinct dir such as `state/` or `prod-artifacts/`.\n- Concretely, in the offending script/CI step change the duplicated paths so a command like\n  `dbt build --state ./state --target-path ./target` uses different dirs, and populate the state\n  artifacts there.\n- If the same-directory usage lives outside the repo (a dbt platform job command, an orchestration\n  tool), it cannot be edited from the repo.\n- For that out-of-repo case: record it in the results artifact (target/dbt_migration_results.json)\n  as manual-required with the issue_id, the invocation location if known, and the suggested command\n  change, then prompt the user.\n- This change never requires a repo edit to pass `dbt parse`; it is advisory / out-of-repo only."
+      },
+      "_path": "kb/core/1_6_001.yaml"
+    },
+    {
+      "issue_id": "1_6_002",
+      "sort_order": 4020,
+      "change": "Breaking contract changes on unversioned models now warn instead of error",
+      "action": "Add --warn-error (or version the models) to retain the previous hard-error behavior on breaking contract changes",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Unversioned models with a breaking schema/contract change warn via warn_or_error() instead of erroring; CI that relied on the error to block may now pass silently",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan schema YAML (`models/**/*.yml`, `models/**/*.yaml`) for models declaring `contract:` with\n  `enforced: true` that do NOT declare a `version:` / `versions:` block (i.e. unversioned).\n- Those unversioned enforced-contract models are the ones whose breaking contract changes now only\n  warn.\n- Also detect reliance on the old error behavior: grep CI/scripts for `dbt build` / `dbt run`\n  invocations that lack `--warn-error` or `--warn-error-options`.\n- Those flags are what previously turned the contract breakage into a hard failure.\n- This is a behavior/policy change; `dbt parse` stays clean either way, so detection is about intent,\n  not parse errors.",
+        "fixing": "- Preferred: preserve strict behavior by adding `--warn-error` (or a scoped `--warn-error-options`\n  targeting contract deprecations) to the relevant dbt invocation.\n- If that invocation is defined outside the repo (dbt platform job command, orchestration tool), it\n  cannot be edited here: record it in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the suggested flag, and prompt the user.\n- Alternative in-repo fix: add a `version:` to the affected models \u2014 versioning makes breaking\n  contract changes error again.\n- But versioning reshapes ref() resolution and downstream references, so only do it when the user\n  explicitly wants versioned models; note that trade-off in the results report rather than silently\n  versioning.\n- No edit is required for `dbt parse` to succeed."
+      },
+      "_path": "kb/core/1_6_002.yaml"
+    },
+    {
+      "issue_id": "1_6_003",
+      "sort_order": 4030,
+      "change": "New warning for contracted models with bare numeric columns (no precision/scale)",
+      "action": "Add explicit precision and scale to numeric column data_types in enforced contracts (e.g. numeric(38,3))",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with 'data_type: numeric' (or 'decimal') and no precision/scale in an enforced contract now emit a warning at parse time in 1.7",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- In schema YAML (`models/**/*.yml`, `models/**/*.yaml`), find models with `contract:`\n  `enforced: true` and columns whose `data_type` is a bare numeric type with no precision/scale.\n- Match the data_type value (case-insensitive) against `^(numeric|decimal|number)$` (no parentheses).\n- Types that already include `(p,s)` like `numeric(38,3)` are fine and must be left alone.\n- Only columns inside enforced-contract models trigger the warning; bare numeric on non-contracted\n  models is not affected.",
+        "fixing": "- For each flagged column, replace the bare type with an explicit precision/scale, e.g.\n  `data_type: numeric` -> `data_type: numeric(38,3)`.\n- Choose precision/scale from evidence in this order:\n- (1) an existing cast in the model SQL (e.g. `cast(x as numeric(18,2))`) \u2014 match it;\n- (2) the warehouse's documented default for unqualified numeric if the model is already built\n  (Snowflake NUMBER default is (38,0); Redshift/Postgres NUMERIC default is (38,0));\n- (3) if unknown, use a safe wide default `numeric(38,6)` and note the assumption in the results\n  report.\n- Preserve YAML quoting/style.\n- After editing, run `dbt parse`; if it fails, the likely cause is a mismatched type name for the\n  adapter (e.g. Snowflake prefers `number(38,3)`) \u2014 retry with the adapter-native spelling.\n- If the correct precision genuinely cannot be determined, leave the column and record it in the\n  results artifact (target/dbt_migration_results.json) as manual-required for the user to confirm."
+      },
+      "_path": "kb/core/1_6_003.yaml"
+    },
+    {
+      "issue_id": "1_6_006",
+      "sort_order": 4060,
+      "change": "job_execution_timeout now actually cancels queries via asyncio",
+      "action": "Review all job_execution_timeout_seconds values and increase them where legitimate long-running queries could now be cancelled",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "bigquery",
+      "impact": "Queries exceeding job_execution_timeout_seconds are now actually cancelled and error; previously the timeout was passed but not enforced, so long queries silently ran to completion",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep for `job_execution_timeout_seconds` across the project: `profiles.yml`\n  (`outputs.<target>`), `dbt_project.yml` (`models:` config), model config() blocks, and schema\n  YAML `config:` blocks.\n- Any value set low relative to real query runtimes is now a live cancellation risk.\n- This is a runtime/behavior change invisible to `dbt parse`.",
+        "fixing": "- No edit is needed to pass parse or reach 1.8. The action is protective.\n- For each configured job_execution_timeout_seconds, assess whether real models run longer than the\n  value; if so, raise it (e.g. comfortably above observed p99 runtime) in the same location it is\n  configured.\n- Where the value lives in `profiles.yml` outside the repo, record the recommendation in the\n  results artifact (target/dbt_migration_results.json) as manual-required instead of editing.\n- If no timeout is set anywhere, BigQuery's own default applies and there is nothing to change \u2014\n  note it and move on.\n- Do not lower any timeouts. True impact is only observable in the warehouse build-green layer."
+      },
+      "_path": "kb/bigquery/1_6_006.yaml"
+    },
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_6_core.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_6_core.json
@@ -1,0 +1,592 @@
+{
+  "from_version": "1.6",
+  "warehouse": "core",
+  "target_version": "1.12",
+  "count": 26,
+  "issues": [
+    {
+      "issue_id": "1_6_011",
+      "sort_order": 4005,
+      "change": "dbt clean errors when clean-targets include source paths or paths outside the project",
+      "action": "Remove source paths (e.g. models/, macros/) and any path outside the project directory from clean-targets in dbt_project.yml",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "dbt clean now raises an error instead of silently deleting the wrong directories when clean-targets references source paths or paths outside the project root",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml's clean-targets list.\n- Flag any entry that resolves (relative to the project root) to a configured source path\n  (model-paths, seed-paths, macro-paths, etc.) or that resolves outside the project directory\n  (e.g. ../shared, /absolute/path).",
+        "fixing": "- Remove the offending entries from clean-targets, keeping only build/output directories\n  (e.g. target, dbt_packages, logs).\n- Re-run dbt clean to confirm it no longer errors."
+      },
+      "_path": "kb/core/1_6_011.yaml"
+    },
+    {
+      "issue_id": "1_6_001",
+      "sort_order": 4010,
+      "change": "New warning when --state and --target point to the same directory",
+      "action": "Fix --state/--target configuration so they reference distinct directories",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "WarnStateTargetEqual raised (informational) for previously silent misconfiguration; fatal under --warn-error",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- This is a runtime CLI/job configuration issue, not a repo-source issue, so `dbt parse` cannot\n  surface it. Detect by scanning invocation sites, not models.\n- Grep the repo for `--state` and `--target` / `--target-path` in shell scripts, Makefiles, and\n  `scripts/**/*.sh`.\n- Also grep CI configs: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `tox.ini`.\n- Check `dbt_project.yml` for a `target-path:` key (deprecated since 1.5 but may still be present).\n- Check for `DBT_STATE` / `DBT_TARGET_PATH` env vars in CI.\n- Flag any invocation where `--state` and `--target`/`--target-path` resolve to the same directory\n  (commonly both set to `target/`).\n- Note the value is frequently supplied outside the repo (dbt platform job definitions,\n  orchestration tools), which parse cannot see.",
+        "fixing": "- Point `--state` at a directory separate from the run's `--target` \u2014 e.g. keep run output in\n  `target/` and the comparison manifest in a distinct dir such as `state/` or `prod-artifacts/`.\n- Concretely, in the offending script/CI step change the duplicated paths so a command like\n  `dbt build --state ./state --target-path ./target` uses different dirs, and populate the state\n  artifacts there.\n- If the same-directory usage lives outside the repo (a dbt platform job command, an orchestration\n  tool), it cannot be edited from the repo.\n- For that out-of-repo case: record it in the results artifact (target/dbt_migration_results.json)\n  as manual-required with the issue_id, the invocation location if known, and the suggested command\n  change, then prompt the user.\n- This change never requires a repo edit to pass `dbt parse`; it is advisory / out-of-repo only."
+      },
+      "_path": "kb/core/1_6_001.yaml"
+    },
+    {
+      "issue_id": "1_6_002",
+      "sort_order": 4020,
+      "change": "Breaking contract changes on unversioned models now warn instead of error",
+      "action": "Add --warn-error (or version the models) to retain the previous hard-error behavior on breaking contract changes",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Unversioned models with a breaking schema/contract change warn via warn_or_error() instead of erroring; CI that relied on the error to block may now pass silently",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan schema YAML (`models/**/*.yml`, `models/**/*.yaml`) for models declaring `contract:` with\n  `enforced: true` that do NOT declare a `version:` / `versions:` block (i.e. unversioned).\n- Those unversioned enforced-contract models are the ones whose breaking contract changes now only\n  warn.\n- Also detect reliance on the old error behavior: grep CI/scripts for `dbt build` / `dbt run`\n  invocations that lack `--warn-error` or `--warn-error-options`.\n- Those flags are what previously turned the contract breakage into a hard failure.\n- This is a behavior/policy change; `dbt parse` stays clean either way, so detection is about intent,\n  not parse errors.",
+        "fixing": "- Preferred: preserve strict behavior by adding `--warn-error` (or a scoped `--warn-error-options`\n  targeting contract deprecations) to the relevant dbt invocation.\n- If that invocation is defined outside the repo (dbt platform job command, orchestration tool), it\n  cannot be edited here: record it in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the suggested flag, and prompt the user.\n- Alternative in-repo fix: add a `version:` to the affected models \u2014 versioning makes breaking\n  contract changes error again.\n- But versioning reshapes ref() resolution and downstream references, so only do it when the user\n  explicitly wants versioned models; note that trade-off in the results report rather than silently\n  versioning.\n- No edit is required for `dbt parse` to succeed."
+      },
+      "_path": "kb/core/1_6_002.yaml"
+    },
+    {
+      "issue_id": "1_6_003",
+      "sort_order": 4030,
+      "change": "New warning for contracted models with bare numeric columns (no precision/scale)",
+      "action": "Add explicit precision and scale to numeric column data_types in enforced contracts (e.g. numeric(38,3))",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with 'data_type: numeric' (or 'decimal') and no precision/scale in an enforced contract now emit a warning at parse time in 1.7",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- In schema YAML (`models/**/*.yml`, `models/**/*.yaml`), find models with `contract:`\n  `enforced: true` and columns whose `data_type` is a bare numeric type with no precision/scale.\n- Match the data_type value (case-insensitive) against `^(numeric|decimal|number)$` (no parentheses).\n- Types that already include `(p,s)` like `numeric(38,3)` are fine and must be left alone.\n- Only columns inside enforced-contract models trigger the warning; bare numeric on non-contracted\n  models is not affected.",
+        "fixing": "- For each flagged column, replace the bare type with an explicit precision/scale, e.g.\n  `data_type: numeric` -> `data_type: numeric(38,3)`.\n- Choose precision/scale from evidence in this order:\n- (1) an existing cast in the model SQL (e.g. `cast(x as numeric(18,2))`) \u2014 match it;\n- (2) the warehouse's documented default for unqualified numeric if the model is already built\n  (Snowflake NUMBER default is (38,0); Redshift/Postgres NUMERIC default is (38,0));\n- (3) if unknown, use a safe wide default `numeric(38,6)` and note the assumption in the results\n  report.\n- Preserve YAML quoting/style.\n- After editing, run `dbt parse`; if it fails, the likely cause is a mismatched type name for the\n  adapter (e.g. Snowflake prefers `number(38,3)`) \u2014 retry with the adapter-native spelling.\n- If the correct precision genuinely cannot be determined, leave the column and record it in the\n  results artifact (target/dbt_migration_results.json) as manual-required for the user to confirm."
+      },
+      "_path": "kb/core/1_6_003.yaml"
+    },
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_6_databricks.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_6_databricks.json
@@ -1,0 +1,612 @@
+{
+  "from_version": "1.6",
+  "warehouse": "databricks",
+  "target_version": "1.12",
+  "count": 27,
+  "issues": [
+    {
+      "issue_id": "1_6_011",
+      "sort_order": 4005,
+      "change": "dbt clean errors when clean-targets include source paths or paths outside the project",
+      "action": "Remove source paths (e.g. models/, macros/) and any path outside the project directory from clean-targets in dbt_project.yml",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "dbt clean now raises an error instead of silently deleting the wrong directories when clean-targets references source paths or paths outside the project root",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml's clean-targets list.\n- Flag any entry that resolves (relative to the project root) to a configured source path\n  (model-paths, seed-paths, macro-paths, etc.) or that resolves outside the project directory\n  (e.g. ../shared, /absolute/path).",
+        "fixing": "- Remove the offending entries from clean-targets, keeping only build/output directories\n  (e.g. target, dbt_packages, logs).\n- Re-run dbt clean to confirm it no longer errors."
+      },
+      "_path": "kb/core/1_6_011.yaml"
+    },
+    {
+      "issue_id": "1_6_001",
+      "sort_order": 4010,
+      "change": "New warning when --state and --target point to the same directory",
+      "action": "Fix --state/--target configuration so they reference distinct directories",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "WarnStateTargetEqual raised (informational) for previously silent misconfiguration; fatal under --warn-error",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- This is a runtime CLI/job configuration issue, not a repo-source issue, so `dbt parse` cannot\n  surface it. Detect by scanning invocation sites, not models.\n- Grep the repo for `--state` and `--target` / `--target-path` in shell scripts, Makefiles, and\n  `scripts/**/*.sh`.\n- Also grep CI configs: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `tox.ini`.\n- Check `dbt_project.yml` for a `target-path:` key (deprecated since 1.5 but may still be present).\n- Check for `DBT_STATE` / `DBT_TARGET_PATH` env vars in CI.\n- Flag any invocation where `--state` and `--target`/`--target-path` resolve to the same directory\n  (commonly both set to `target/`).\n- Note the value is frequently supplied outside the repo (dbt platform job definitions,\n  orchestration tools), which parse cannot see.",
+        "fixing": "- Point `--state` at a directory separate from the run's `--target` \u2014 e.g. keep run output in\n  `target/` and the comparison manifest in a distinct dir such as `state/` or `prod-artifacts/`.\n- Concretely, in the offending script/CI step change the duplicated paths so a command like\n  `dbt build --state ./state --target-path ./target` uses different dirs, and populate the state\n  artifacts there.\n- If the same-directory usage lives outside the repo (a dbt platform job command, an orchestration\n  tool), it cannot be edited from the repo.\n- For that out-of-repo case: record it in the results artifact (target/dbt_migration_results.json)\n  as manual-required with the issue_id, the invocation location if known, and the suggested command\n  change, then prompt the user.\n- This change never requires a repo edit to pass `dbt parse`; it is advisory / out-of-repo only."
+      },
+      "_path": "kb/core/1_6_001.yaml"
+    },
+    {
+      "issue_id": "1_6_002",
+      "sort_order": 4020,
+      "change": "Breaking contract changes on unversioned models now warn instead of error",
+      "action": "Add --warn-error (or version the models) to retain the previous hard-error behavior on breaking contract changes",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Unversioned models with a breaking schema/contract change warn via warn_or_error() instead of erroring; CI that relied on the error to block may now pass silently",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan schema YAML (`models/**/*.yml`, `models/**/*.yaml`) for models declaring `contract:` with\n  `enforced: true` that do NOT declare a `version:` / `versions:` block (i.e. unversioned).\n- Those unversioned enforced-contract models are the ones whose breaking contract changes now only\n  warn.\n- Also detect reliance on the old error behavior: grep CI/scripts for `dbt build` / `dbt run`\n  invocations that lack `--warn-error` or `--warn-error-options`.\n- Those flags are what previously turned the contract breakage into a hard failure.\n- This is a behavior/policy change; `dbt parse` stays clean either way, so detection is about intent,\n  not parse errors.",
+        "fixing": "- Preferred: preserve strict behavior by adding `--warn-error` (or a scoped `--warn-error-options`\n  targeting contract deprecations) to the relevant dbt invocation.\n- If that invocation is defined outside the repo (dbt platform job command, orchestration tool), it\n  cannot be edited here: record it in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the suggested flag, and prompt the user.\n- Alternative in-repo fix: add a `version:` to the affected models \u2014 versioning makes breaking\n  contract changes error again.\n- But versioning reshapes ref() resolution and downstream references, so only do it when the user\n  explicitly wants versioned models; note that trade-off in the results report rather than silently\n  versioning.\n- No edit is required for `dbt parse` to succeed."
+      },
+      "_path": "kb/core/1_6_002.yaml"
+    },
+    {
+      "issue_id": "1_6_003",
+      "sort_order": 4030,
+      "change": "New warning for contracted models with bare numeric columns (no precision/scale)",
+      "action": "Add explicit precision and scale to numeric column data_types in enforced contracts (e.g. numeric(38,3))",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with 'data_type: numeric' (or 'decimal') and no precision/scale in an enforced contract now emit a warning at parse time in 1.7",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- In schema YAML (`models/**/*.yml`, `models/**/*.yaml`), find models with `contract:`\n  `enforced: true` and columns whose `data_type` is a bare numeric type with no precision/scale.\n- Match the data_type value (case-insensitive) against `^(numeric|decimal|number)$` (no parentheses).\n- Types that already include `(p,s)` like `numeric(38,3)` are fine and must be left alone.\n- Only columns inside enforced-contract models trigger the warning; bare numeric on non-contracted\n  models is not affected.",
+        "fixing": "- For each flagged column, replace the bare type with an explicit precision/scale, e.g.\n  `data_type: numeric` -> `data_type: numeric(38,3)`.\n- Choose precision/scale from evidence in this order:\n- (1) an existing cast in the model SQL (e.g. `cast(x as numeric(18,2))`) \u2014 match it;\n- (2) the warehouse's documented default for unqualified numeric if the model is already built\n  (Snowflake NUMBER default is (38,0); Redshift/Postgres NUMERIC default is (38,0));\n- (3) if unknown, use a safe wide default `numeric(38,6)` and note the assumption in the results\n  report.\n- Preserve YAML quoting/style.\n- After editing, run `dbt parse`; if it fails, the likely cause is a mismatched type name for the\n  adapter (e.g. Snowflake prefers `number(38,3)`) \u2014 retry with the adapter-native spelling.\n- If the correct precision genuinely cannot be determined, leave the column and record it in the\n  results artifact (target/dbt_migration_results.json) as manual-required for the user to confirm."
+      },
+      "_path": "kb/core/1_6_003.yaml"
+    },
+    {
+      "issue_id": "1_6_005",
+      "sort_order": 4050,
+      "change": "Default catalog set to hive_metastore when not specified",
+      "action": "Verify the default matches expectations; set catalog explicitly in profiles.yml if a different catalog is intended",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "databricks",
+      "impact": "Projects that did not set a catalog now explicitly resolve to hive_metastore; relations may be created/read in hive_metastore instead of a previously-implicit Unity Catalog default",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": true,
+      "context": {
+        "detection": "- This is a connection/environment default, not a repo-source change, so `dbt parse` cannot see it.\n- Inspect the Databricks connection config: `profiles.yml` (`outputs.<target>.catalog`) and any\n  `catalog:` / `database:` set in `dbt_project.yml` or model configs.\n- Flag the project if NO catalog/database is set anywhere for the Databricks target \u2014 those projects\n  now implicitly get `hive_metastore`.\n- If a catalog is already set explicitly, no action.\n- Note `profiles.yml` often lives outside the repo (`~/.dbt/` or dbt platform connection settings).",
+        "fixing": "- Advisory / environment change only \u2014 never mutate credentials or run anything.\n- If the workspace uses Unity Catalog and the user expects a UC catalog rather than the legacy\n  hive_metastore, add an explicit `catalog: <name>` to the Databricks output in `profiles.yml` (or\n  the platform connection).\n- If `profiles.yml` is inside the repo, apply the advisory edit and record it in the results report.\n- If it is outside the repo, record the recommended `catalog:` setting in the results artifact\n  (target/dbt_migration_results.json) as advisory and prompt the user to confirm the intended\n  catalog.\n- Exclude from the parse-verify loop (parse does not reflect connection settings)."
+      },
+      "_path": "kb/databricks/1_6_005.yaml"
+    },
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_6_redshift.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_6_redshift.json
@@ -1,0 +1,632 @@
+{
+  "from_version": "1.6",
+  "warehouse": "redshift",
+  "target_version": "1.12",
+  "count": 28,
+  "issues": [
+    {
+      "issue_id": "1_6_011",
+      "sort_order": 4005,
+      "change": "dbt clean errors when clean-targets include source paths or paths outside the project",
+      "action": "Remove source paths (e.g. models/, macros/) and any path outside the project directory from clean-targets in dbt_project.yml",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "dbt clean now raises an error instead of silently deleting the wrong directories when clean-targets references source paths or paths outside the project root",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml's clean-targets list.\n- Flag any entry that resolves (relative to the project root) to a configured source path\n  (model-paths, seed-paths, macro-paths, etc.) or that resolves outside the project directory\n  (e.g. ../shared, /absolute/path).",
+        "fixing": "- Remove the offending entries from clean-targets, keeping only build/output directories\n  (e.g. target, dbt_packages, logs).\n- Re-run dbt clean to confirm it no longer errors."
+      },
+      "_path": "kb/core/1_6_011.yaml"
+    },
+    {
+      "issue_id": "1_6_001",
+      "sort_order": 4010,
+      "change": "New warning when --state and --target point to the same directory",
+      "action": "Fix --state/--target configuration so they reference distinct directories",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "WarnStateTargetEqual raised (informational) for previously silent misconfiguration; fatal under --warn-error",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- This is a runtime CLI/job configuration issue, not a repo-source issue, so `dbt parse` cannot\n  surface it. Detect by scanning invocation sites, not models.\n- Grep the repo for `--state` and `--target` / `--target-path` in shell scripts, Makefiles, and\n  `scripts/**/*.sh`.\n- Also grep CI configs: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `tox.ini`.\n- Check `dbt_project.yml` for a `target-path:` key (deprecated since 1.5 but may still be present).\n- Check for `DBT_STATE` / `DBT_TARGET_PATH` env vars in CI.\n- Flag any invocation where `--state` and `--target`/`--target-path` resolve to the same directory\n  (commonly both set to `target/`).\n- Note the value is frequently supplied outside the repo (dbt platform job definitions,\n  orchestration tools), which parse cannot see.",
+        "fixing": "- Point `--state` at a directory separate from the run's `--target` \u2014 e.g. keep run output in\n  `target/` and the comparison manifest in a distinct dir such as `state/` or `prod-artifacts/`.\n- Concretely, in the offending script/CI step change the duplicated paths so a command like\n  `dbt build --state ./state --target-path ./target` uses different dirs, and populate the state\n  artifacts there.\n- If the same-directory usage lives outside the repo (a dbt platform job command, an orchestration\n  tool), it cannot be edited from the repo.\n- For that out-of-repo case: record it in the results artifact (target/dbt_migration_results.json)\n  as manual-required with the issue_id, the invocation location if known, and the suggested command\n  change, then prompt the user.\n- This change never requires a repo edit to pass `dbt parse`; it is advisory / out-of-repo only."
+      },
+      "_path": "kb/core/1_6_001.yaml"
+    },
+    {
+      "issue_id": "1_6_002",
+      "sort_order": 4020,
+      "change": "Breaking contract changes on unversioned models now warn instead of error",
+      "action": "Add --warn-error (or version the models) to retain the previous hard-error behavior on breaking contract changes",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Unversioned models with a breaking schema/contract change warn via warn_or_error() instead of erroring; CI that relied on the error to block may now pass silently",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan schema YAML (`models/**/*.yml`, `models/**/*.yaml`) for models declaring `contract:` with\n  `enforced: true` that do NOT declare a `version:` / `versions:` block (i.e. unversioned).\n- Those unversioned enforced-contract models are the ones whose breaking contract changes now only\n  warn.\n- Also detect reliance on the old error behavior: grep CI/scripts for `dbt build` / `dbt run`\n  invocations that lack `--warn-error` or `--warn-error-options`.\n- Those flags are what previously turned the contract breakage into a hard failure.\n- This is a behavior/policy change; `dbt parse` stays clean either way, so detection is about intent,\n  not parse errors.",
+        "fixing": "- Preferred: preserve strict behavior by adding `--warn-error` (or a scoped `--warn-error-options`\n  targeting contract deprecations) to the relevant dbt invocation.\n- If that invocation is defined outside the repo (dbt platform job command, orchestration tool), it\n  cannot be edited here: record it in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the suggested flag, and prompt the user.\n- Alternative in-repo fix: add a `version:` to the affected models \u2014 versioning makes breaking\n  contract changes error again.\n- But versioning reshapes ref() resolution and downstream references, so only do it when the user\n  explicitly wants versioned models; note that trade-off in the results report rather than silently\n  versioning.\n- No edit is required for `dbt parse` to succeed."
+      },
+      "_path": "kb/core/1_6_002.yaml"
+    },
+    {
+      "issue_id": "1_6_003",
+      "sort_order": 4030,
+      "change": "New warning for contracted models with bare numeric columns (no precision/scale)",
+      "action": "Add explicit precision and scale to numeric column data_types in enforced contracts (e.g. numeric(38,3))",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with 'data_type: numeric' (or 'decimal') and no precision/scale in an enforced contract now emit a warning at parse time in 1.7",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- In schema YAML (`models/**/*.yml`, `models/**/*.yaml`), find models with `contract:`\n  `enforced: true` and columns whose `data_type` is a bare numeric type with no precision/scale.\n- Match the data_type value (case-insensitive) against `^(numeric|decimal|number)$` (no parentheses).\n- Types that already include `(p,s)` like `numeric(38,3)` are fine and must be left alone.\n- Only columns inside enforced-contract models trigger the warning; bare numeric on non-contracted\n  models is not affected.",
+        "fixing": "- For each flagged column, replace the bare type with an explicit precision/scale, e.g.\n  `data_type: numeric` -> `data_type: numeric(38,3)`.\n- Choose precision/scale from evidence in this order:\n- (1) an existing cast in the model SQL (e.g. `cast(x as numeric(18,2))`) \u2014 match it;\n- (2) the warehouse's documented default for unqualified numeric if the model is already built\n  (Snowflake NUMBER default is (38,0); Redshift/Postgres NUMERIC default is (38,0));\n- (3) if unknown, use a safe wide default `numeric(38,6)` and note the assumption in the results\n  report.\n- Preserve YAML quoting/style.\n- After editing, run `dbt parse`; if it fails, the likely cause is a mismatched type name for the\n  adapter (e.g. Snowflake prefers `number(38,3)`) \u2014 retry with the adapter-native spelling.\n- If the correct precision genuinely cannot be determined, leave the column and record it in the\n  results artifact (target/dbt_migration_results.json) as manual-required for the user to confirm."
+      },
+      "_path": "kb/core/1_6_003.yaml"
+    },
+    {
+      "issue_id": "1_6_004",
+      "sort_order": 4040,
+      "change": "merge_exclude_columns bug fix: excluded columns now correctly inserted in WHEN NOT MATCHED",
+      "action": "Review incremental models using merge_exclude_columns; excluded columns are now populated on new-row inserts",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "Incremental merge with merge_exclude_columns now inserts ALL columns for new rows (previously excluded columns were omitted on INSERT); resulting table data changes",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep model config for `merge_exclude_columns` in `models/**/*.sql` config() blocks (e.g.\n  `config(materialized='incremental', ... merge_exclude_columns=[...])`) and in schema YAML\n  `config:` blocks.\n- Only relevant when `materialized='incremental'` with the default `merge` strategy on the Redshift\n  adapter.\n- This is a behavior/warehouse change invisible to `dbt parse`; nothing makes parse fail.",
+        "fixing": "- No source edit is required to reach 1.8 or pass parse \u2014 the fix was in the adapter. The migration\n  action is to flag semantics.\n- For each model using merge_exclude_columns, new rows (WHEN NOT MATCHED) will now have the\n  previously-excluded columns inserted with their source values instead of being left null/default.\n- If the user intentionally relied on those columns being unset on insert, that assumption breaks.\n- Record each occurrence in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the issue_id, the model path, the merge_exclude_columns list, and a note to\n  verify the new insert behavior is acceptable.\n- Real validation happens in the warehouse build-green test layer, not here.\n- Do not modify the model unless the user confirms a semantic change is needed."
+      },
+      "_path": "kb/redshift/1_6_004.yaml"
+    },
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_004",
+      "sort_order": 5040,
+      "change": "Redshift catalog query macros restructured and split into multiple files",
+      "action": "Update custom overrides of redshift__get_base_catalog / catalog macros to match the new 1.8 structure",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "Custom overrides of redshift__get_catalog / redshift__get_base_catalog (and related catalog SQL) may break or silently diverge because the macro was split across a catalog/ directory in dbt-redshift 1.8",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant if the project (or an installed package) overrides Redshift catalog macros.\n- Grep macros/**/*.sql and packages' macros for definitions named `redshift__get_catalog`,\n  `redshift__get_base_catalog`, `redshift__get_catalog_relations`, or any\n  `{% macro redshift__...catalog...%}`.\n- If no such override exists, the change is not present (docs generate keeps working on the\n  built-in macros).\n- If an override exists, it likely mirrors the old single-file catalog.sql shape and will not\n  align with the 1.8 split.",
+        "fixing": "- If an override is found, compare it against the dbt-redshift 1.8 catalog macros (now under an\n  adapter catalog/ directory, split into base-catalog and relations pieces).\n- Re-implement the override on the new macro seams: typically split a monolithic\n  `redshift__get_catalog` override into `redshift__get_base_catalog` plus the relation-scoped\n  variant, matching the new signatures.\n- Invisible to `dbt parse` (catalog macros only compile when catalog generation runs), so parse\n  cannot validate correctness.\n- After adjusting, note that `dbt docs generate` against a warehouse is the real check (harness\n  build-green layer, not in-skill).\n- If the override's intent is unclear or reproducing the split is risky, record a manual-actions\n  entry pointing at the overriding macro and the dbt-redshift 1.8 catalog macro source."
+      },
+      "_path": "kb/redshift/1_7_004.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_6_snowflake.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_6_snowflake.json
@@ -1,0 +1,592 @@
+{
+  "from_version": "1.6",
+  "warehouse": "snowflake",
+  "target_version": "1.12",
+  "count": 26,
+  "issues": [
+    {
+      "issue_id": "1_6_011",
+      "sort_order": 4005,
+      "change": "dbt clean errors when clean-targets include source paths or paths outside the project",
+      "action": "Remove source paths (e.g. models/, macros/) and any path outside the project directory from clean-targets in dbt_project.yml",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "dbt clean now raises an error instead of silently deleting the wrong directories when clean-targets references source paths or paths outside the project root",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml's clean-targets list.\n- Flag any entry that resolves (relative to the project root) to a configured source path\n  (model-paths, seed-paths, macro-paths, etc.) or that resolves outside the project directory\n  (e.g. ../shared, /absolute/path).",
+        "fixing": "- Remove the offending entries from clean-targets, keeping only build/output directories\n  (e.g. target, dbt_packages, logs).\n- Re-run dbt clean to confirm it no longer errors."
+      },
+      "_path": "kb/core/1_6_011.yaml"
+    },
+    {
+      "issue_id": "1_6_001",
+      "sort_order": 4010,
+      "change": "New warning when --state and --target point to the same directory",
+      "action": "Fix --state/--target configuration so they reference distinct directories",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "WarnStateTargetEqual raised (informational) for previously silent misconfiguration; fatal under --warn-error",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- This is a runtime CLI/job configuration issue, not a repo-source issue, so `dbt parse` cannot\n  surface it. Detect by scanning invocation sites, not models.\n- Grep the repo for `--state` and `--target` / `--target-path` in shell scripts, Makefiles, and\n  `scripts/**/*.sh`.\n- Also grep CI configs: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `tox.ini`.\n- Check `dbt_project.yml` for a `target-path:` key (deprecated since 1.5 but may still be present).\n- Check for `DBT_STATE` / `DBT_TARGET_PATH` env vars in CI.\n- Flag any invocation where `--state` and `--target`/`--target-path` resolve to the same directory\n  (commonly both set to `target/`).\n- Note the value is frequently supplied outside the repo (dbt platform job definitions,\n  orchestration tools), which parse cannot see.",
+        "fixing": "- Point `--state` at a directory separate from the run's `--target` \u2014 e.g. keep run output in\n  `target/` and the comparison manifest in a distinct dir such as `state/` or `prod-artifacts/`.\n- Concretely, in the offending script/CI step change the duplicated paths so a command like\n  `dbt build --state ./state --target-path ./target` uses different dirs, and populate the state\n  artifacts there.\n- If the same-directory usage lives outside the repo (a dbt platform job command, an orchestration\n  tool), it cannot be edited from the repo.\n- For that out-of-repo case: record it in the results artifact (target/dbt_migration_results.json)\n  as manual-required with the issue_id, the invocation location if known, and the suggested command\n  change, then prompt the user.\n- This change never requires a repo edit to pass `dbt parse`; it is advisory / out-of-repo only."
+      },
+      "_path": "kb/core/1_6_001.yaml"
+    },
+    {
+      "issue_id": "1_6_002",
+      "sort_order": 4020,
+      "change": "Breaking contract changes on unversioned models now warn instead of error",
+      "action": "Add --warn-error (or version the models) to retain the previous hard-error behavior on breaking contract changes",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Unversioned models with a breaking schema/contract change warn via warn_or_error() instead of erroring; CI that relied on the error to block may now pass silently",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan schema YAML (`models/**/*.yml`, `models/**/*.yaml`) for models declaring `contract:` with\n  `enforced: true` that do NOT declare a `version:` / `versions:` block (i.e. unversioned).\n- Those unversioned enforced-contract models are the ones whose breaking contract changes now only\n  warn.\n- Also detect reliance on the old error behavior: grep CI/scripts for `dbt build` / `dbt run`\n  invocations that lack `--warn-error` or `--warn-error-options`.\n- Those flags are what previously turned the contract breakage into a hard failure.\n- This is a behavior/policy change; `dbt parse` stays clean either way, so detection is about intent,\n  not parse errors.",
+        "fixing": "- Preferred: preserve strict behavior by adding `--warn-error` (or a scoped `--warn-error-options`\n  targeting contract deprecations) to the relevant dbt invocation.\n- If that invocation is defined outside the repo (dbt platform job command, orchestration tool), it\n  cannot be edited here: record it in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the suggested flag, and prompt the user.\n- Alternative in-repo fix: add a `version:` to the affected models \u2014 versioning makes breaking\n  contract changes error again.\n- But versioning reshapes ref() resolution and downstream references, so only do it when the user\n  explicitly wants versioned models; note that trade-off in the results report rather than silently\n  versioning.\n- No edit is required for `dbt parse` to succeed."
+      },
+      "_path": "kb/core/1_6_002.yaml"
+    },
+    {
+      "issue_id": "1_6_003",
+      "sort_order": 4030,
+      "change": "New warning for contracted models with bare numeric columns (no precision/scale)",
+      "action": "Add explicit precision and scale to numeric column data_types in enforced contracts (e.g. numeric(38,3))",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with 'data_type: numeric' (or 'decimal') and no precision/scale in an enforced contract now emit a warning at parse time in 1.7",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- In schema YAML (`models/**/*.yml`, `models/**/*.yaml`), find models with `contract:`\n  `enforced: true` and columns whose `data_type` is a bare numeric type with no precision/scale.\n- Match the data_type value (case-insensitive) against `^(numeric|decimal|number)$` (no parentheses).\n- Types that already include `(p,s)` like `numeric(38,3)` are fine and must be left alone.\n- Only columns inside enforced-contract models trigger the warning; bare numeric on non-contracted\n  models is not affected.",
+        "fixing": "- For each flagged column, replace the bare type with an explicit precision/scale, e.g.\n  `data_type: numeric` -> `data_type: numeric(38,3)`.\n- Choose precision/scale from evidence in this order:\n- (1) an existing cast in the model SQL (e.g. `cast(x as numeric(18,2))`) \u2014 match it;\n- (2) the warehouse's documented default for unqualified numeric if the model is already built\n  (Snowflake NUMBER default is (38,0); Redshift/Postgres NUMERIC default is (38,0));\n- (3) if unknown, use a safe wide default `numeric(38,6)` and note the assumption in the results\n  report.\n- Preserve YAML quoting/style.\n- After editing, run `dbt parse`; if it fails, the likely cause is a mismatched type name for the\n  adapter (e.g. Snowflake prefers `number(38,3)`) \u2014 retry with the adapter-native spelling.\n- If the correct precision genuinely cannot be determined, leave the column and record it in the\n  results artifact (target/dbt_migration_results.json) as manual-required for the user to confirm."
+      },
+      "_path": "kb/core/1_6_003.yaml"
+    },
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_6_spark.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_6_spark.json
@@ -1,0 +1,612 @@
+{
+  "from_version": "1.6",
+  "warehouse": "spark",
+  "target_version": "1.12",
+  "count": 27,
+  "issues": [
+    {
+      "issue_id": "1_6_011",
+      "sort_order": 4005,
+      "change": "dbt clean errors when clean-targets include source paths or paths outside the project",
+      "action": "Remove source paths (e.g. models/, macros/) and any path outside the project directory from clean-targets in dbt_project.yml",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "dbt clean now raises an error instead of silently deleting the wrong directories when clean-targets references source paths or paths outside the project root",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Read dbt_project.yml's clean-targets list.\n- Flag any entry that resolves (relative to the project root) to a configured source path\n  (model-paths, seed-paths, macro-paths, etc.) or that resolves outside the project directory\n  (e.g. ../shared, /absolute/path).",
+        "fixing": "- Remove the offending entries from clean-targets, keeping only build/output directories\n  (e.g. target, dbt_packages, logs).\n- Re-run dbt clean to confirm it no longer errors."
+      },
+      "_path": "kb/core/1_6_011.yaml"
+    },
+    {
+      "issue_id": "1_6_001",
+      "sort_order": 4010,
+      "change": "New warning when --state and --target point to the same directory",
+      "action": "Fix --state/--target configuration so they reference distinct directories",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "WarnStateTargetEqual raised (informational) for previously silent misconfiguration; fatal under --warn-error",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- This is a runtime CLI/job configuration issue, not a repo-source issue, so `dbt parse` cannot\n  surface it. Detect by scanning invocation sites, not models.\n- Grep the repo for `--state` and `--target` / `--target-path` in shell scripts, Makefiles, and\n  `scripts/**/*.sh`.\n- Also grep CI configs: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `tox.ini`.\n- Check `dbt_project.yml` for a `target-path:` key (deprecated since 1.5 but may still be present).\n- Check for `DBT_STATE` / `DBT_TARGET_PATH` env vars in CI.\n- Flag any invocation where `--state` and `--target`/`--target-path` resolve to the same directory\n  (commonly both set to `target/`).\n- Note the value is frequently supplied outside the repo (dbt platform job definitions,\n  orchestration tools), which parse cannot see.",
+        "fixing": "- Point `--state` at a directory separate from the run's `--target` \u2014 e.g. keep run output in\n  `target/` and the comparison manifest in a distinct dir such as `state/` or `prod-artifacts/`.\n- Concretely, in the offending script/CI step change the duplicated paths so a command like\n  `dbt build --state ./state --target-path ./target` uses different dirs, and populate the state\n  artifacts there.\n- If the same-directory usage lives outside the repo (a dbt platform job command, an orchestration\n  tool), it cannot be edited from the repo.\n- For that out-of-repo case: record it in the results artifact (target/dbt_migration_results.json)\n  as manual-required with the issue_id, the invocation location if known, and the suggested command\n  change, then prompt the user.\n- This change never requires a repo edit to pass `dbt parse`; it is advisory / out-of-repo only."
+      },
+      "_path": "kb/core/1_6_001.yaml"
+    },
+    {
+      "issue_id": "1_6_002",
+      "sort_order": 4020,
+      "change": "Breaking contract changes on unversioned models now warn instead of error",
+      "action": "Add --warn-error (or version the models) to retain the previous hard-error behavior on breaking contract changes",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Unversioned models with a breaking schema/contract change warn via warn_or_error() instead of erroring; CI that relied on the error to block may now pass silently",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Scan schema YAML (`models/**/*.yml`, `models/**/*.yaml`) for models declaring `contract:` with\n  `enforced: true` that do NOT declare a `version:` / `versions:` block (i.e. unversioned).\n- Those unversioned enforced-contract models are the ones whose breaking contract changes now only\n  warn.\n- Also detect reliance on the old error behavior: grep CI/scripts for `dbt build` / `dbt run`\n  invocations that lack `--warn-error` or `--warn-error-options`.\n- Those flags are what previously turned the contract breakage into a hard failure.\n- This is a behavior/policy change; `dbt parse` stays clean either way, so detection is about intent,\n  not parse errors.",
+        "fixing": "- Preferred: preserve strict behavior by adding `--warn-error` (or a scoped `--warn-error-options`\n  targeting contract deprecations) to the relevant dbt invocation.\n- If that invocation is defined outside the repo (dbt platform job command, orchestration tool), it\n  cannot be edited here: record it in the results artifact (target/dbt_migration_results.json) as\n  manual-required with the suggested flag, and prompt the user.\n- Alternative in-repo fix: add a `version:` to the affected models \u2014 versioning makes breaking\n  contract changes error again.\n- But versioning reshapes ref() resolution and downstream references, so only do it when the user\n  explicitly wants versioned models; note that trade-off in the results report rather than silently\n  versioning.\n- No edit is required for `dbt parse` to succeed."
+      },
+      "_path": "kb/core/1_6_002.yaml"
+    },
+    {
+      "issue_id": "1_6_003",
+      "sort_order": 4030,
+      "change": "New warning for contracted models with bare numeric columns (no precision/scale)",
+      "action": "Add explicit precision and scale to numeric column data_types in enforced contracts (e.g. numeric(38,3))",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with 'data_type: numeric' (or 'decimal') and no precision/scale in an enforced contract now emit a warning at parse time in 1.7",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "human",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- In schema YAML (`models/**/*.yml`, `models/**/*.yaml`), find models with `contract:`\n  `enforced: true` and columns whose `data_type` is a bare numeric type with no precision/scale.\n- Match the data_type value (case-insensitive) against `^(numeric|decimal|number)$` (no parentheses).\n- Types that already include `(p,s)` like `numeric(38,3)` are fine and must be left alone.\n- Only columns inside enforced-contract models trigger the warning; bare numeric on non-contracted\n  models is not affected.",
+        "fixing": "- For each flagged column, replace the bare type with an explicit precision/scale, e.g.\n  `data_type: numeric` -> `data_type: numeric(38,3)`.\n- Choose precision/scale from evidence in this order:\n- (1) an existing cast in the model SQL (e.g. `cast(x as numeric(18,2))`) \u2014 match it;\n- (2) the warehouse's documented default for unqualified numeric if the model is already built\n  (Snowflake NUMBER default is (38,0); Redshift/Postgres NUMERIC default is (38,0));\n- (3) if unknown, use a safe wide default `numeric(38,6)` and note the assumption in the results\n  report.\n- Preserve YAML quoting/style.\n- After editing, run `dbt parse`; if it fails, the likely cause is a mismatched type name for the\n  adapter (e.g. Snowflake prefers `number(38,3)`) \u2014 retry with the adapter-native spelling.\n- If the correct precision genuinely cannot be determined, leave the column and record it in the\n  results artifact (target/dbt_migration_results.json) as manual-required for the user to confirm."
+      },
+      "_path": "kb/core/1_6_003.yaml"
+    },
+    {
+      "issue_id": "1_6_010",
+      "sort_order": 4100,
+      "change": "server_side_parameters values coerced to strings",
+      "action": "Review server_side_parameters that use non-string values; they are now str()-coerced (e.g. True -> \"True\")",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "spark",
+      "impact": "server_side_parameters is now typed Dict[str, str] with str() coercion; non-string values are converted, so booleans/ints render as their Python str form (True -> \"True\" with a capital T, 1 -> \"1\")",
+      "from_version": "1.6",
+      "to_version": "1.7",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep for `server_side_parameters` in `profiles.yml` (`outputs.<target>`), `dbt_project.yml`,\n  model config() blocks, and schema YAML `config:` blocks.\n- Inspect the mapped values: flag any value that is not already a quoted string \u2014 YAML bare\n  `true`/`false` (parsed as booleans), bare integers/floats, or Jinja expressions producing\n  non-strings.\n- String values are unaffected.",
+        "fixing": "- This is a behavior change with no parse impact.\n- For each non-string value, decide the intended wire value and make it an explicit string so the\n  coercion is predictable.\n- Example: if Spark expects lowercase `true`, write `'true'` as a quoted string rather than YAML\n  boolean `true` (which str()-coerces to `\"True\"` with a capital T and may be rejected by Spark).\n- Edit the value in place (quote it / normalize case) and record in the results report.\n- Where the config lives in `profiles.yml` outside the repo, record the recommendation in the\n  results artifact (target/dbt_migration_results.json) as manual-required instead.\n- If unsure of the exact string Spark expects for a given parameter, leave it and flag it for the\n  user rather than guessing.\n- Real effect is validated in the warehouse build-green layer."
+      },
+      "_path": "kb/spark/1_6_010.yaml"
+    },
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_7_bigquery.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_7_bigquery.json
@@ -1,0 +1,512 @@
+{
+  "from_version": "1.7",
+  "warehouse": "bigquery",
+  "target_version": "1.12",
+  "count": 22,
+  "issues": [
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_7_core.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_7_core.json
@@ -1,0 +1,512 @@
+{
+  "from_version": "1.7",
+  "warehouse": "core",
+  "target_version": "1.12",
+  "count": 22,
+  "issues": [
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_7_databricks.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_7_databricks.json
@@ -1,0 +1,512 @@
+{
+  "from_version": "1.7",
+  "warehouse": "databricks",
+  "target_version": "1.12",
+  "count": 22,
+  "issues": [
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_7_redshift.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_7_redshift.json
@@ -1,0 +1,532 @@
+{
+  "from_version": "1.7",
+  "warehouse": "redshift",
+  "target_version": "1.12",
+  "count": 23,
+  "issues": [
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_004",
+      "sort_order": 5040,
+      "change": "Redshift catalog query macros restructured and split into multiple files",
+      "action": "Update custom overrides of redshift__get_base_catalog / catalog macros to match the new 1.8 structure",
+      "category": "Behavior",
+      "component": "adapter",
+      "adapter_type": "redshift",
+      "impact": "Custom overrides of redshift__get_catalog / redshift__get_base_catalog (and related catalog SQL) may break or silently diverge because the macro was split across a catalog/ directory in dbt-redshift 1.8",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant if the project (or an installed package) overrides Redshift catalog macros.\n- Grep macros/**/*.sql and packages' macros for definitions named `redshift__get_catalog`,\n  `redshift__get_base_catalog`, `redshift__get_catalog_relations`, or any\n  `{% macro redshift__...catalog...%}`.\n- If no such override exists, the change is not present (docs generate keeps working on the\n  built-in macros).\n- If an override exists, it likely mirrors the old single-file catalog.sql shape and will not\n  align with the 1.8 split.",
+        "fixing": "- If an override is found, compare it against the dbt-redshift 1.8 catalog macros (now under an\n  adapter catalog/ directory, split into base-catalog and relations pieces).\n- Re-implement the override on the new macro seams: typically split a monolithic\n  `redshift__get_catalog` override into `redshift__get_base_catalog` plus the relation-scoped\n  variant, matching the new signatures.\n- Invisible to `dbt parse` (catalog macros only compile when catalog generation runs), so parse\n  cannot validate correctness.\n- After adjusting, note that `dbt docs generate` against a warehouse is the real check (harness\n  build-green layer, not in-skill).\n- If the override's intent is unclear or reproducing the split is risky, record a manual-actions\n  entry pointing at the overriding macro and the dbt-redshift 1.8 catalog macro source."
+      },
+      "_path": "kb/redshift/1_7_004.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_7_snowflake.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_7_snowflake.json
@@ -1,0 +1,512 @@
+{
+  "from_version": "1.7",
+  "warehouse": "snowflake",
+  "target_version": "1.12",
+  "count": 22,
+  "issues": [
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_7_spark.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_7_spark.json
@@ -1,0 +1,512 @@
+{
+  "from_version": "1.7",
+  "warehouse": "spark",
+  "target_version": "1.12",
+  "count": 22,
+  "issues": [
+    {
+      "issue_id": "1_7_001",
+      "sort_order": 5010,
+      "change": "--dry-run flag removed from dbt deps --add-package; use dbt deps --lock instead",
+      "action": "Replace `dbt deps --add-package ... --dry-run` invocations with `dbt deps --lock`",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Commands using `dbt deps --add-package <pkg> --dry-run` will error in 1.8 (unknown option --dry-run)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep the repo for `--dry-run` alongside `dbt deps`. Pattern: `dbt\\s+deps[^\\n]*--dry-run`\n  and `--add-package[^\\n]*--dry-run`.\n- Most common locations: shell scripts, Makefiles, CI YAML (.github/workflows/*.yml,\n  .gitlab-ci.yml, azure-pipelines.yml), Dockerfiles, tox.ini, pre-commit configs, docs/READMEs.\n- PRIMARY RISK IS OUT OF REPO: the same command may live in dbt platform job definitions,\n  orchestration tools (Airflow/Dagster/cron), or a developer's shell history \u2014 not scannable\n  from the repo.",
+        "fixing": "- For every in-repo occurrence, rewrite `dbt deps --add-package <pkg>@<ver> --dry-run` to\n  `dbt deps --lock` (resolves and writes package-lock.yml without installing).\n- If the intent was only to preview resolution, `dbt deps --lock` is the direct replacement.\n- `dbt deps` does not affect `dbt parse`, so no parse retry loop applies here.\n- ALWAYS add a manual-actions entry: issue_id, the fact that `--dry-run` on\n  `dbt deps --add-package` now errors, and the instruction to audit all scheduled/CI job\n  commands for `dbt deps ... --dry-run` and switch them to `dbt deps --lock`."
+      },
+      "_path": "kb/core/1_7_001.yaml"
+    },
+    {
+      "issue_id": "1_7_002",
+      "sort_order": 5020,
+      "change": "Primary key constraint on multiple columns or at both column and model level now throws ParsingError",
+      "action": "Fix constraint definitions to specify the primary key in exactly one place",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Models with duplicate/ambiguous primary_key constraint definitions fail to parse in 1.8 (ParsingError)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Only relevant to models with `contract: {enforced: true}` (or constraints blocks).\n- Scan model YAML (models/**/*.yml, *.yaml) and in-file `{{ config(...) }}` blocks for a\n  primary key declared more than once.\n- Failure shape 1: a model-level `constraints:` entry of `type: primary_key` listing multiple\n  columns AND a column also carrying `constraints: [{type: primary_key}]`.\n- Failure shape 2: more than one column each carrying a `type: primary_key` column-level\n  constraint.\n- Cues: search YAML for `type: primary_key` and count occurrences per model; also check for a\n  model-level `constraints:` list with `- type: primary_key` combined with any column-level one.\n- Composite PKs must be expressed once, at the model level, with `columns: [a, b]`.",
+        "fixing": "- Consolidate to a single primary key declaration per model.\n- If a composite key is intended, remove the per-column `type: primary_key` constraints and\n  declare one model-level constraint:\n    constraints:\n      - type: primary_key\n        columns: [col_a, col_b]\n- If a single-column PK is intended, keep exactly one declaration (column-level OR a model-level\n  single-column entry) and delete the duplicate.\n- Preserve any accompanying constraints (not_null, foreign_key) unchanged.\n- After editing, run `dbt parse`; if it still raises a primary-key ParsingError, re-read the\n  error's node name and ensure only one primary_key exists across column- and model-level.\n- If the intended key is ambiguous (e.g. two different single-column PKs on one model), do not\n  guess \u2014 record a manual-actions entry with the model name and the competing declarations."
+      },
+      "_path": "kb/core/1_7_002.yaml"
+    },
+    {
+      "issue_id": "1_7_003",
+      "sort_order": 5030,
+      "change": "Spaces in resource names produce deprecation warning (SpacesInResourceNameDeprecation)",
+      "action": "Rename resources to remove spaces and rewrite all ref()/source() calls that reference them",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "SpacesInResourceNameDeprecation is raised at parse time in 1.8 for any model/seed/snapshot/source/test/exposure/metric whose name contains a space; treated as an error under --warn-error and slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "agentic",
+      "out_of_repo_risk": true,
+      "environment_change": false,
+      "context": {
+        "detection": "- Two sources of resource names to scan.\n- FILE NAMES: any `models/**/*.sql`, `models/**/*.py`, `seeds/**/*.csv`, `snapshots/**/*.sql`,\n  `analyses/**/*.sql`, or `macros/**/*.sql` whose filename stem contains a space \u2014 the\n  model/seed/snapshot name defaults to the filename. Glob for basenames matching `* *`.\n- EXPLICIT NAMES in YAML: in models/**/*.yml and *.yaml, any `name:` value under models:,\n  seeds:, snapshots:, sources: (both the source `name:` and each table `name:`), exposures:,\n  metrics:, and named singular/data tests. Regex: `^\\s*name:\\s+.*\\S \\S`.\n- `alias:` need NOT change (aliases may contain spaces if quoted) \u2014 the deprecation targets the\n  resource NAME.\n- Build a map of {old_name -> new_name} for every offending resource before editing anything.",
+        "fixing": "- For each offending resource, choose a new name by replacing spaces with underscores\n  (e.g. `customer orders` -> `customer_orders`), keeping it unique. Then apply ALL of:\n- (a) Rename the file if the name came from the filename:\n    git mv 'models/customer orders.sql' models/customer_orders.sql\n- (b) Update the `name:` (and matching properties block) in YAML.\n- (c) Rewrite EVERY reference across the repo \u2014 `ref('customer orders')` ->\n  `ref('customer_orders')`, and for source tables `source('src', 'my table')` ->\n  `source('src', 'my_table')` \u2014 covering single- and double-quote forms in .sql/.py models and\n  in `--select`/YAML selectors inside the repo.\n- Example before: `select * from {{ ref('customer orders') }}`\n- Example after:  `select * from {{ ref('customer_orders') }}`\n- You MUST rewrite refs in the same pass as the rename, or `dbt parse` fails with an unresolved\n  ref.\n- After edits run `dbt parse`; if it fails with 'depends on a node named X which was not found',\n  a ref still points at the old name \u2014 grep the repo for the old name and fix the stragglers.\n- OUT-OF-REPO RISK: names are also referenced by dbt platform job `--select` clauses,\n  `selectors.yml` consumed by CI, BI tools, and dbt Mesh cross-project refs\n  (`ref('project', 'name')`). These cannot be rewritten from this repo.\n- For every renamed resource, add a manual-actions entry listing old_name -> new_name and\n  telling the user to update job selectors, downstream mesh refs, and BI tool references.\n- If a name cannot be safely changed because too many external consumers depend on it, leave it\n  and record a manual-required entry instead."
+      },
+      "_path": "kb/core/1_7_003.yaml"
+    },
+    {
+      "issue_id": "1_7_008",
+      "sort_order": 5080,
+      "change": "require_explicit_package_overrides_for_builtin_materializations defaults to True",
+      "action": "Set the flag to false in dbt_project.yml flags: to keep old behavior, or update packages that override built-in materializations",
+      "category": "Breaking",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Installed packages can no longer silently override built-in materializations (table/view/incremental); built-in takes precedence",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml `flags:` for\n  require_explicit_package_overrides_for_builtin_materializations.\n- Check installed packages (dbt_packages/, packages.yml) for materialization overrides of\n  table/view/incremental.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets the flag explicitly). Review the diff.\n- Manual fallback: add `require_explicit_package_overrides_for_builtin_materializations: false`\n  under `flags:` to preserve old behavior, or update the offending package.\n- Parse-detectable via the deprecation/warning; confirm clean on 1.8."
+      },
+      "_path": "kb/core/1_7_008.yaml"
+    },
+    {
+      "issue_id": "1_7_009",
+      "sort_order": 5090,
+      "change": "tests config deprecated in favor of data_tests",
+      "action": "Rename `tests:` to `data_tests:` in dbt_project.yml and schema YAML files",
+      "category": "Deprecated",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "`tests:` key emits a deprecation warning in 1.8; still works but slated for removal",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Grep dbt_project.yml for a top-level `tests:` block.\n- Grep models/**/*.yml for `tests:` keys (both model-level and column-level).",
+        "fixing": "- Handled by `dbt-autofix deprecations` (renames `tests:` -> `data_tests:`).\n- Review the diff and confirm every occurrence was renamed (leave the test list contents\n  unchanged).\n- Manual fallback: rename any occurrence autofix missed.\n- Verify with `dbt parse --warn-error` (no deprecation)."
+      },
+      "_path": "kb/core/1_7_009.yaml"
+    },
+    {
+      "issue_id": "1_7_010",
+      "sort_order": 5100,
+      "change": "dbt source freshness now runs on-run-start / on-run-end hooks",
+      "action": "Set source_freshness_run_project_hooks to False if project hooks should not run during freshness checks",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "on-run-start/on-run-end hooks now execute during `dbt source freshness` (previously skipped)",
+      "from_version": "1.7",
+      "to_version": "1.8",
+      "automation_type": "deterministic",
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Check dbt_project.yml for on-run-start/on-run-end hooks.\n- Check whether source_freshness_run_project_hooks is set under `flags:`.",
+        "fixing": "- Handled by `dbt-autofix deprecations` (sets source_freshness_run_project_hooks explicitly).\n  Review the diff.\n- Manual fallback: add `source_freshness_run_project_hooks: false` under `flags:` if hooks should\n  NOT run during freshness (e.g. they mutate the warehouse).\n- Behavior change; validate hook side-effects in the build-green layer."
+      },
+      "_path": "kb/core/1_7_010.yaml"
+    },
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_8_bigquery.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_8_bigquery.json
@@ -1,0 +1,392 @@
+{
+  "from_version": "1.8",
+  "warehouse": "bigquery",
+  "target_version": "1.12",
+  "count": 16,
+  "issues": [
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_8_core.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_8_core.json
@@ -1,0 +1,392 @@
+{
+  "from_version": "1.8",
+  "warehouse": "core",
+  "target_version": "1.12",
+  "count": 16,
+  "issues": [
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_8_databricks.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_8_databricks.json
@@ -1,0 +1,392 @@
+{
+  "from_version": "1.8",
+  "warehouse": "databricks",
+  "target_version": "1.12",
+  "count": 16,
+  "issues": [
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_8_redshift.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_8_redshift.json
@@ -1,0 +1,392 @@
+{
+  "from_version": "1.8",
+  "warehouse": "redshift",
+  "target_version": "1.12",
+  "count": 16,
+  "issues": [
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_8_snowflake.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_8_snowflake.json
@@ -1,0 +1,392 @@
+{
+  "from_version": "1.8",
+  "warehouse": "snowflake",
+  "target_version": "1.12",
+  "count": 16,
+  "issues": [
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_8_spark.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_8_spark.json
@@ -1,0 +1,392 @@
+{
+  "from_version": "1.8",
+  "warehouse": "spark",
+  "target_version": "1.12",
+  "count": 16,
+  "issues": [
+    {
+      "issue_id": "1_8_001",
+      "sort_order": 6001,
+      "change": "on-run-start hook failure now skips all downstream nodes instead of continuing",
+      "action": "Set flags.skip_nodes_if_on_run_start_fails: false to keep the old behavior, or make on-run-start hooks reliable.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A failing on-run-start hook aborts the whole run's nodes rather than letting them execute. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "skip_nodes_if_on_run_start_fails",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines `on-run-start` hooks.\n- Check dbt_project.yml for a non-empty `on-run-start:` list.\n- No on-run-start hooks -> the gated behavior cannot occur -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_001`. No project code changes.\nOnly pin it when on-run-start hooks exist."
+      },
+      "_path": "kb/core/1_8_001.yaml"
+    },
+    {
+      "issue_id": "1_8_002",
+      "sort_order": 6002,
+      "change": "state:modified compares more unrendered config values, changing which nodes are selected",
+      "action": "Set flags.state_modified_compare_more_unrendered_values: false to keep the old comparison.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Slim CI / state:modified selection can pick a different node set, changing what gets built. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "state_modified_compare_more_unrendered_values",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project relies on `state:modified` selection.\n- Look for state comparison in-repo: a `selectors.yml` using `state:modified`,\n  or CI config / job commands in the repo passing `--select state:modified`.\n- If nothing in the repo uses state:modified, this cannot be confirmed from the\n  repo alone -> skipped-not-present, and mention it in the report so the user can\n  decide (their CI may use it out of repo).",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_002`. No project code changes.\nOnly pin it when the repo shows state:modified usage."
+      },
+      "_path": "kb/core/1_8_002.yaml"
+    },
+    {
+      "issue_id": "1_8_003",
+      "sort_order": 6003,
+      "change": "custom microbatch strategies must use batched execution",
+      "action": "Set flags.require_batched_execution_for_custom_microbatch_strategy: false to keep the old behavior, or adopt batched execution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A custom microbatch incremental strategy that is not batch-aware behaves differently or errors. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_batched_execution_for_custom_microbatch_strategy",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines a CUSTOM microbatch incremental strategy.\n- Check macros/ for a macro named `get_incremental_microbatch_sql` or a\n  materialization/strategy override handling `microbatch`, and models configured\n  with `incremental_strategy: microbatch`.\n- Built-in microbatch usage alone is NOT affected -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_003`. No project code changes.\nOnly pin it when a custom microbatch strategy macro exists."
+      },
+      "_path": "kb/core/1_8_003.yaml"
+    },
+    {
+      "issue_id": "1_8_004",
+      "sort_order": 6004,
+      "change": "cumulative metric type params must be nested under type_params",
+      "action": "Set flags.require_nested_cumulative_type_params: false to keep accepting the flat shape, or nest the params.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Semantic-layer cumulative metrics using the flat param shape fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.8",
+      "to_version": "1.9",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_nested_cumulative_type_params",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines cumulative metrics using the FLAT param\n  shape (window/grain_to_date directly under the metric rather than nested under\n  `type_params`).\n- Grep metric YAML for `type: cumulative`, then check whether its params are\n  nested under `type_params:`.\n- Already nested, or no cumulative metrics -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_8_004`. No project code changes.\nOnly pin it when a flat-shaped cumulative metric exists."
+      },
+      "_path": "kb/core/1_8_004.yaml"
+    },
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_9_bigquery.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_9_bigquery.json
@@ -1,0 +1,296 @@
+{
+  "from_version": "1.9",
+  "warehouse": "bigquery",
+  "target_version": "1.12",
+  "count": 12,
+  "issues": [
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_9_core.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_9_core.json
@@ -1,0 +1,296 @@
+{
+  "from_version": "1.9",
+  "warehouse": "core",
+  "target_version": "1.12",
+  "count": 12,
+  "issues": [
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_9_databricks.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_9_databricks.json
@@ -1,0 +1,296 @@
+{
+  "from_version": "1.9",
+  "warehouse": "databricks",
+  "target_version": "1.12",
+  "count": 12,
+  "issues": [
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_9_redshift.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_9_redshift.json
@@ -1,0 +1,296 @@
+{
+  "from_version": "1.9",
+  "warehouse": "redshift",
+  "target_version": "1.12",
+  "count": 12,
+  "issues": [
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_9_snowflake.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_9_snowflake.json
@@ -1,0 +1,296 @@
+{
+  "from_version": "1.9",
+  "warehouse": "snowflake",
+  "target_version": "1.12",
+  "count": 12,
+  "issues": [
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}

--- a/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_9_spark.json
+++ b/skills/dbt-migration/skills/upgrading-dbt-core/references/kb_1_9_spark.json
@@ -1,0 +1,296 @@
+{
+  "from_version": "1.9",
+  "warehouse": "spark",
+  "target_version": "1.12",
+  "count": 12,
+  "issues": [
+    {
+      "issue_id": "1_9_001",
+      "sort_order": 7001,
+      "change": "macro arguments are validated against their declared signatures",
+      "action": "Set flags.validate_macro_args: false to keep validation off, or correct the macro argument declarations.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Macros whose calls do not match their documented arguments now warn or error at parse time. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "validate_macro_args",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has macros whose call sites disagree with their\n  declared arguments (the thing validation would now reject).\n- Check macros/ for documented `arguments:` in YAML that do not match the macro\n  signature, or calls passing unexpected/missing args.\n- The reliable check: run the parse gate; if it reports a macro-argument\n  validation error/warning, the behavior is exhibited.\n- Parse clean with the flag unset -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_001`. No project code changes.\nPrefer pinning only when the parse gate actually flags a macro-argument problem."
+      },
+      "_path": "kb/core/1_9_001.yaml"
+    },
+    {
+      "issue_id": "1_9_002",
+      "sort_order": 7002,
+      "change": "every warning must be handled when warn_error / warn_error_options is set",
+      "action": "Set flags.require_all_warnings_handled_by_warn_error: false to keep the old partial handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects using warn_error_options can start failing on warnings that were previously not escalated. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_all_warnings_handled_by_warn_error",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project sets `warn_error` or `warn_error_options`\n  (dbt_project.yml `flags:`, profiles.yml, or CI job commands in the repo).\n- Neither set -> the stricter handling changes nothing -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_002`. No project code changes.\nOnly pin it when warn_error / warn_error_options is actually configured."
+      },
+      "_path": "kb/core/1_9_002.yaml"
+    },
+    {
+      "issue_id": "1_9_003",
+      "sort_order": 7003,
+      "change": "generic test arguments must be declared under an `arguments:` property",
+      "action": "Set flags.require_generic_test_arguments_property: false to keep accepting the old inline shape, or move test args under `arguments:`.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Generic tests passing args inline (not under `arguments:`) fail validation. This flag defaults to True in 1.12, so leaving it unset silently adopts the new behavior.",
+      "from_version": "1.9",
+      "to_version": "1.10",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_generic_test_arguments_property",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if generic tests pass arguments inline instead of under an\n  `arguments:` property.\n- Grep models/**/*.yml (and any tests/ YAML) for generic tests with sibling keys\n  next to the test name that are not `arguments:` (e.g. `accepted_values:` with\n  `values:` inline).\n- All generic test args already under `arguments:`, or no parameterized generic\n  tests -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_9_003`. No project code changes.\nOnly pin it when inline generic-test arguments are present."
+      },
+      "_path": "kb/core/1_9_003.yaml"
+    },
+    {
+      "issue_id": "1_10_001",
+      "sort_order": 8001,
+      "change": "resource names must be unique within a project",
+      "action": "Set flags.require_unique_project_resource_names: false to keep allowing duplicates, or rename the colliding resources.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Projects with two resources sharing a name across paths start erroring at parse time. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_unique_project_resource_names",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has DUPLICATE resource names within itself.\n- List model/seed/snapshot/test file stems and look for the same name declared\n  more than once across different paths.\n- All names unique -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_001`. No project code changes.\nOnly pin it when an actual duplicate resource name exists."
+      },
+      "_path": "kb/core/1_10_001.yaml"
+    },
+    {
+      "issue_id": "1_10_002",
+      "sort_order": 8002,
+      "change": "ref() resolves against the node's own package before the root project",
+      "action": "Set flags.require_ref_searches_node_package_before_root: false to keep root-first resolution.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "In projects with packages that shadow root model names, ref() can resolve to a different node. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.10",
+      "to_version": "1.11",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_ref_searches_node_package_before_root",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if an installed package defines a model name that ALSO exists in\n  the root project (the shadowing case where resolution order changes).\n- Check packages.yml/dependencies.yml for packages, then compare package model\n  names against root model names (dbt_packages/ if installed).\n- No packages, or no name collision -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_10_002`. No project code changes.\nOnly pin it when a package/root model name collision exists."
+      },
+      "_path": "kb/core/1_10_002.yaml"
+    },
+    {
+      "issue_id": "1_11_001",
+      "sort_order": 9001,
+      "change": "generate_schema_name must return a valid, non-empty schema name",
+      "action": "Set flags.require_valid_schema_from_generate_schema_name: false to keep the lax behavior, or fix the macro.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "A generate_schema_name override returning None/empty now errors instead of silently falling back. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_valid_schema_from_generate_schema_name",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project overrides `generate_schema_name` (or\n  `generate_schema_name_for_env`) in macros/.\n- Inspect the override for a path that can return None/empty (e.g. a missing\n  `{% else %}` branch, or returning `custom_schema_name` unguarded).\n- No override, or the override always returns a non-empty schema ->\n  skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_001`. No project code changes.\nOnly pin it when a generate_schema_name override can return empty."
+      },
+      "_path": "kb/core/1_11_001.yaml"
+    },
+    {
+      "issue_id": "1_11_002",
+      "sort_order": 9002,
+      "change": "sql_header must be declared in test configs to take effect",
+      "action": "Set flags.require_sql_header_in_test_configs: false to keep the old handling.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Tests relying on an implicitly inherited sql_header may lose it. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_sql_header_in_test_configs",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if tests rely on a `sql_header` they do not declare themselves\n  (i.e. inherited from a model/project-level config).\n- Grep for `sql_header` in dbt_project.yml, model configs, and test configs; the\n  issue is present when a test needs it but only a non-test config sets it.\n- No sql_header anywhere, or tests declare their own -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_002`. No project code changes.\nOnly pin it when a test depends on an inherited sql_header."
+      },
+      "_path": "kb/core/1_11_002.yaml"
+    },
+    {
+      "issue_id": "1_11_003",
+      "sort_order": 9003,
+      "change": "analyses use corrected fully-qualified names",
+      "action": "Set flags.require_corrected_analysis_fqns: false to keep the previous FQNs.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Selection and documentation paths for analyses change, affecting --select on analyses. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_corrected_analysis_fqns",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project has an analyses/ directory with content AND\n  something selects analyses by FQN (selectors.yml or in-repo job commands).\n- Empty/absent analyses/ -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_003`. No project code changes.\nOnly pin it when analyses exist and are selected by FQN."
+      },
+      "_path": "kb/core/1_11_003.yaml"
+    },
+    {
+      "issue_id": "1_11_004",
+      "sort_order": 9004,
+      "change": "source and semantic model names may not contain spaces",
+      "action": "Set flags.require_source_and_semantic_model_names_without_spaces: false to keep allowing spaces, or rename them.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Sources/semantic models with spaces in their names start erroring rather than warning. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "require_source_and_semantic_model_names_without_spaces",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if a SOURCE or SEMANTIC MODEL name contains a space.\n- Grep source/semantic model YAML for `- name:` values containing a space.\n  (Model names with spaces are a different, pre-1.8 issue \u2014 not this one.)\n- No spaces in source/semantic model names -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_004`. No project code changes.\nOnly pin it when a source/semantic model name actually contains a space."
+      },
+      "_path": "kb/core/1_11_004.yaml"
+    },
+    {
+      "issue_id": "1_11_005",
+      "sort_order": 9005,
+      "change": "Jinja-suffixed file extensions (e.g. .sql.jinja) are recognized",
+      "action": "Leave flags.allow_jinja_file_extensions: false to keep the previous file discovery.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Enabling it changes which files dbt picks up as models; leaving it false preserves current discovery. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "allow_jinja_file_extensions",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- This flag ENABLES new file-extension discovery; it defaults to false, so the\n  project's current behavior is already the legacy one.\n- Only relevant if the project has files with a `.jinja`-style suffix it expects\n  dbt to pick up.\n- No such files -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_005` only if the project has\nJinja-suffixed files and you need to lock the current discovery behavior."
+      },
+      "_path": "kb/core/1_11_005.yaml"
+    },
+    {
+      "issue_id": "1_11_006",
+      "sort_order": 9006,
+      "change": "versioned models get a `latest` version pointer by default",
+      "action": "Leave flags.latest_version_pointer_enabled_by_default: false to keep explicit-only version pointers.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "For versioned models, ref() without a version can resolve differently. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "latest_version_pointer_enabled_by_default",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project uses MODEL VERSIONS (`versions:` in model YAML)\n  and has `ref()` calls to a versioned model without an explicit version.\n- No versioned models -> the pointer default cannot matter -> skipped-not-present.",
+        "fixing": "Pin the flag via `tools.py set-flag --issue-id 1_11_006`. No project code changes.\nOnly pin it when versioned models exist and are ref'd without a version."
+      },
+      "_path": "kb/core/1_11_006.yaml"
+    },
+    {
+      "issue_id": "1_11_007",
+      "sort_order": 9007,
+      "change": "v2 catalog integration replaces the previous catalog behavior (all adapters)",
+      "action": "Leave flags.use_catalogs_v2: false to keep the previous catalog behavior.",
+      "category": "Behavior",
+      "component": "core",
+      "adapter_type": null,
+      "impact": "Catalog/metadata resolution changes across adapters; leaving it false preserves current behavior. This flag still defaults to False in 1.12; pinning it makes that explicit and survives a future flip.",
+      "from_version": "1.11",
+      "to_version": "1.12",
+      "automation_type": "behavior_flag",
+      "behavior_flag": {
+        "name": "use_catalogs_v2",
+        "set_to": false
+      },
+      "out_of_repo_risk": false,
+      "environment_change": false,
+      "context": {
+        "detection": "- Applies only if the project defines catalog configuration (e.g. a `catalogs:`\n  block or catalog-related model configs) whose resolution v2 would change.\n- Defaults to false, so a project with no catalog config already has the legacy\n  behavior -> skipped-not-present (pinning would be pure noise).",
+        "fixing": "Normally skipped-not-present: false is already the default and the legacy\nbehavior. Pin via `tools.py set-flag --issue-id 1_11_007` only if the project has\ncatalog configuration whose behavior you need to lock."
+      },
+      "_path": "kb/core/1_11_007.yaml"
+    }
+  ]
+}


### PR DESCRIPTION
resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

Part 2 of 3 in a stack (see #153 for the overview). Builds on #149 — the
`kb/` move.

Adds the bundle-regeneration workflow and its output, together so they
land in sync:

- `.github/workflows/upgrading-dbt-core-kb.yml` regenerates
  `references/kb_<version>_<adapter>.json` from `kb/` on every PR touching
  `kb/`, `references/`, or `scripts/`, and pushes the result back to the
  PR branch — so the two can never drift apart from here on.
- `references/kb_<version>_<adapter>.json`: one bundle per (starting
  version × adapter) the `kb/` corpus covers, produced by
  `tools.py collect-all` against the relocated `kb/` directory. 100%
  generated; nothing here is hand-edited. To verify, re-run the generator
  against `kb/` and diff — it should reproduce these files exactly.
- `pyproject.toml`: package-data now includes these compiled bundles (the
  `kb/` source they're generated from doesn't need to ship).

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-agent-skills/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-agent-skills/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
