### PR TITLE
evals: mandatory model + MCP isolation, accurate run metadata, single review page

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -54,9 +54,12 @@ uv run skill-eval run --all --parallel --workers 8    # custom worker count (def
 # Verbose mode (shows tool calls and skill invocations)
 uv run skill-eval run <scenario-name> --verbose       # or -v
 
-# Review transcripts in browser (opens HTML files)
+# Review a run: generates review.html (one sortable table, links to each
+# transcript + output, cost/tokens/duration/subagent use per skill set) and
+# opens that single page
 uv run skill-eval review              # latest run
 uv run skill-eval review <run-id>     # specific run
+uv run skill-eval review --tabs       # old behavior: open every transcript in its own tab
 
 # Grade outputs from a run (creates grades.yaml for manual review)
 uv run skill-eval grade <run-id>
@@ -433,7 +436,7 @@ Stall detection helps catch runs that get stuck waiting for tool approval when u
 1. **Create a scenario** - `skill-eval new <name>` scaffolds the directory structure
 2. **Configure skill sets** - Edit `skill-sets.yaml` to specify skills, MCP servers, and tool permissions
 3. **Run evaluation** - `skill-eval run <scenario>` executes Claude with each configuration
-4. **Review transcripts** - `skill-eval review` opens HTML transcripts in browser
+4. **Review transcripts** - `skill-eval review` opens a single index page with links, cost/token/subagent metrics, and a sortable table (use `--tabs` for the old one-tab-per-transcript behavior)
 5. **Grade outputs** - `skill-eval grade <run-id>` (manual) or `--auto` (Claude-graded)
 6. **Generate report** - `skill-eval report <run-id>` shows comparison summary
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -359,11 +359,18 @@ skills_invoked:
   - debugging-dbt-errors
 skills_available:
   - debugging-dbt-errors
+skills_available_other:
+  - some-globally-installed-plugin-skill
 tools_used:
   - Read
   - Edit
   - Glob
   - Skill
+tool_call_count: 12
+subagents_used: false
+subagent_count: 0
+subagent_tools_used: []
+subagent_tool_call_count: 0
 mcp_servers: []
 model: claude-opus-4-5-20251101
 duration_ms: 31476
@@ -372,6 +379,33 @@ total_cost_usd: 0.1425935
 input_tokens: 125241
 output_tokens: 1177
 ```
+
+`skills_available` is scoped to only the skills this set's `skills:` list actually added — it's what
+grading and reporting use for skill-usage percentages. `claude` may also report other skills that happen
+to be installed globally (plugins, marketplace skills) that have nothing to do with the scenario; those
+are recorded separately as `skills_available_other` for visibility but excluded from grading.
+
+#### Subagents
+
+When Claude uses the `Task` tool, the spawned subagent's own turns stream inline as a "sidechain"
+alongside the main conversation. These fields keep that separate from the main thread:
+
+- `output.md` / `output_text` only ever contains the main thread's own text — a subagent's narration
+  never leaks into what gets graded as "the answer".
+- `tools_used` / `tool_call_count` count only main-thread tool calls. `subagent_tools_used` /
+  `subagent_tool_call_count` cover everything called from inside subagents.
+- `skills_invoked` is **not** split — a Skill invoked from inside a subagent still counts as the skill
+  having been used for this task.
+- `subagents_used` / `subagent_count` flag whether (and how many times) a set delegated to a subagent
+  at all, since that changes how to read the other numbers below.
+
+`duration_ms` and `total_cost_usd`/token counts come straight from `claude`'s own `result` message and
+are **not** split — `duration_ms` is wall-clock time for the whole process, so it inherently includes
+however long any subagents took. Whether `total_cost_usd`/token counts include subagent API calls wasn't
+verified here (the raw per-message `usage` fields don't reconcile cleanly enough to derive it
+independently — see `subagent_tool_call_count` as the closest available proxy for "how much subagent
+work happened"). `num_turns` empirically only counts main-thread turns, not subagent turns, but this is
+observed behavior, not documented by `claude` itself.
 
 ### changes/
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -102,10 +102,12 @@ Define skill combinations, MCP servers, tool permissions, and prompt variations:
 sets:
   # Baseline with no skills
   - name: no-skills
+    model: sonnet
     skills: []
 
   # With specific allowed tools (safer than allowing all)
   - name: restricted-tools
+    model: sonnet
     skills:
       - skills/debugging-dbt-errors
     allowed_tools:
@@ -118,6 +120,7 @@ sets:
 
   # With MCP server
   - name: with-mcp
+    model: sonnet
     skills:
       - skills/troubleshooting-dbt-job-errors
     mcp_servers:
@@ -135,12 +138,14 @@ sets:
 
   # Allow all tools (uses --dangerously-skip-permissions)
   - name: all-tools
+    model: sonnet
     skills:
       - skills/fetching-dbt-docs
     # No allowed_tools = allows everything
 
   # With extra instructions appended to the prompt
   - name: with-skill-hint
+    model: sonnet
     skills:
       - skills/debugging-dbt-errors
     extra_prompt: Check if any skill can help with this task.
@@ -148,6 +153,57 @@ sets:
       - Read
       - Glob
       - Skill
+
+  # Comparing a stronger model on the same setup
+  - name: with-mcp-opus
+    model: opus
+    skills:
+      - skills/troubleshooting-dbt-job-errors
+    mcp_servers:
+      dbt:
+        command: uvx
+        args:
+          - --env-file
+          - .env
+          - dbt-mcp@latest
+    allowed_tools:
+      - Read
+      - Glob
+      - mcp__dbt__*
+      - Skill
+```
+
+### Model
+
+`model` is **required** on every set — `skill-eval` raises an error if it's missing, rather than silently
+falling back to whatever the `claude` CLI's built-in default happens to be. This keeps runs reproducible
+and cost/latency comparable across skill sets and across time.
+
+Pass an alias (`sonnet`, `opus`, `fable`) or a full model ID, exactly as accepted by `claude --model`:
+
+```yaml
+sets:
+  - name: baseline
+    model: sonnet
+    skills: []
+```
+
+### MCP Isolation (`strict_mcp_config`)
+
+By default, every run adds `--strict-mcp-config` to the `claude` invocation, so only the MCP servers
+declared in that set's `mcp_servers` are available — MCP servers configured in Claude Desktop, your
+user-level `~/.claude.json`, or a project's `.mcp.json` are ignored. Without this, runs can silently pick
+up unrelated MCP servers from your local machine (extra tools, auth prompts, noisy `mcp_servers` metadata)
+that have nothing to do with the scenario and won't be present on another machine or in CI.
+
+Set `strict_mcp_config: false` on a set to opt out and allow those external MCP servers to load:
+
+```yaml
+sets:
+  - name: with-desktop-mcp-servers
+    model: sonnet
+    strict_mcp_config: false
+    skills: []
 ```
 
 ### Skills
@@ -238,12 +294,14 @@ Append additional instructions to the base prompt for specific skill sets:
 sets:
   # Baseline - just the prompt.txt content
   - name: no-hint
+    model: sonnet
     skills:
       - skills/debugging-dbt-errors
     allowed_tools: [Read, Glob, Skill]
 
   # With hint - prompt.txt + extra_prompt
   - name: with-hint
+    model: sonnet
     skills:
       - skills/debugging-dbt-errors
     extra_prompt: Check if any skill can help with this task.
@@ -271,6 +329,7 @@ Run commands before Claude starts (e.g., installing skills via CLI):
 ```yaml
 sets:
   - name: with-remote-skill
+    model: sonnet
     setup:
       - npx skills add https://github.com/dbt-labs/dbt-agent-skills -a claude-code -y
     skills: []
@@ -379,10 +438,12 @@ Output grades include:
 # Does the skill help Claude solve the problem better?
 sets:
   - name: without-skill
+    model: sonnet
     skills: []
     allowed_tools: [Read, Glob, Grep, Edit, Bash(dbt:*)]
 
   - name: with-skill
+    model: sonnet
     skills:
       - skills/debugging-dbt-errors
     allowed_tools: [Read, Glob, Grep, Edit, Bash(dbt:*), Skill]
@@ -394,11 +455,13 @@ sets:
 # Does the MCP server provide better results?
 sets:
   - name: skill-only
+    model: sonnet
     skills:
       - skills/troubleshooting-dbt-job-errors
     allowed_tools: [Read, Glob, Grep, Skill]
 
   - name: skill-plus-mcp
+    model: sonnet
     skills:
       - skills/troubleshooting-dbt-job-errors
     mcp_servers:
@@ -414,11 +477,13 @@ sets:
 # Compare a local skill against a remote version
 sets:
   - name: local-skill
+    model: sonnet
     skills:
       - skills/debugging-dbt-errors
     allowed_tools: [Read, Glob, Grep, Edit, Skill]
 
   - name: remote-skill
+    model: sonnet
     skills:
       # GitHub blob URL - automatically converted to raw
       - https://github.com/org/repo/blob/main/skills/debugging-dbt-errors/SKILL.md

--- a/evals/scenarios/dbt-docs-arguments/skill-sets.yaml
+++ b/evals/scenarios/dbt-docs-arguments/skill-sets.yaml
@@ -1,7 +1,9 @@
 sets:
   - name: no-skills
+    model: sonnet
     skills: []
 
   - name: dbt-docs-baseline
+    model: sonnet
     skills:
       - skills/dbt/skills/fetching-dbt-docs

--- a/evals/scenarios/dbt-docs-unit-test-fixtures/skill-sets.yaml
+++ b/evals/scenarios/dbt-docs-unit-test-fixtures/skill-sets.yaml
@@ -1,7 +1,9 @@
 sets:
   - name: no-skills
+    model: sonnet
     skills: []
 
   - name: dbt-docs-baseline
+    model: sonnet
     skills:
       - skills/dbt/skills/fetching-dbt-docs

--- a/evals/scenarios/dbt-job-failure/skill-sets.yaml
+++ b/evals/scenarios/dbt-job-failure/skill-sets.yaml
@@ -1,6 +1,7 @@
 sets:
   # Baseline: No MCP, no skills - limited to reading local files
   - name: no-skills
+    model: sonnet
     skills: []
     allowed_tools:
       - Read
@@ -25,6 +26,7 @@ sets:
 
   # Full setup: skill + MCP server
   - name: with-skill-and-mcp
+    model: sonnet
     skills:
       # - skills/dbt/skills/troubleshooting-dbt-job-errors
     mcp_servers:

--- a/evals/scenarios/dbt-unit-test-format-choice/skill-sets.yaml
+++ b/evals/scenarios/dbt-unit-test-format-choice/skill-sets.yaml
@@ -1,7 +1,9 @@
 sets:
   - name: no-skills
+    model: sonnet
     skills: []
 
   - name: add-unit-test-skill
+    model: sonnet
     skills:
       - skills/dbt/skills/adding-dbt-unit-test

--- a/evals/scenarios/example-yaml-error/skill-sets.yaml
+++ b/evals/scenarios/example-yaml-error/skill-sets.yaml
@@ -1,5 +1,6 @@
 sets:
   - name: no-skills-but-tools
+    model: sonnet
     skills: []
     allowed_tools:
         - Read
@@ -9,6 +10,7 @@ sets:
         - Bash(dbt:*)
 
   - name: no-skills-just-edit-tool
+    model: sonnet
     skills: []
     allowed_tools:
         - Read

--- a/evals/scenarios/fusion-migration-triage-basic/skill-sets.yaml
+++ b/evals/scenarios/fusion-migration-triage-basic/skill-sets.yaml
@@ -1,5 +1,6 @@
 sets:
   - name: no-skills
+    model: sonnet
     skills: []
     allowed_tools:
       - Read
@@ -7,6 +8,7 @@ sets:
       - Grep
 
   - name: with-triage-skill
+    model: sonnet
     skills:
       - skills/dbt-migration/skills/migrating-dbt-core-to-fusion
     allowed_tools:

--- a/evals/scenarios/fusion-migration-triage-blocked/skill-sets.yaml
+++ b/evals/scenarios/fusion-migration-triage-blocked/skill-sets.yaml
@@ -1,5 +1,6 @@
 sets:
   - name: no-skills
+    model: sonnet
     skills: []
     allowed_tools:
       - Read
@@ -7,6 +8,7 @@ sets:
       - Grep
 
   - name: with-triage-skill
+    model: sonnet
     skills:
       - skills/dbt-migration/skills/migrating-dbt-core-to-fusion
     allowed_tools:

--- a/evals/scenarios/fusion-triage-cat-a-static-analysis/skill-sets.yaml
+++ b/evals/scenarios/fusion-triage-cat-a-static-analysis/skill-sets.yaml
@@ -1,5 +1,6 @@
 sets:
   - name: no-skills
+    model: sonnet
     skills: []
     allowed_tools:
       - Read
@@ -7,6 +8,7 @@ sets:
       - Grep
 
   - name: with-triage-skill
+    model: sonnet
     skills:
       - skills/dbt-migration/skills/migrating-dbt-core-to-fusion
     allowed_tools:

--- a/evals/scenarios/fusion-triage-cat-b-dict-meta-get/skill-sets.yaml
+++ b/evals/scenarios/fusion-triage-cat-b-dict-meta-get/skill-sets.yaml
@@ -1,5 +1,6 @@
 sets:
   - name: no-skills
+    model: sonnet
     skills: []
     allowed_tools:
       - Read
@@ -7,6 +8,7 @@ sets:
       - Grep
 
   - name: with-triage-skill
+    model: sonnet
     skills:
       - skills/dbt-migration/skills/migrating-dbt-core-to-fusion
     allowed_tools:

--- a/evals/scenarios/fusion-triage-cat-b-unexpected-config/skill-sets.yaml
+++ b/evals/scenarios/fusion-triage-cat-b-unexpected-config/skill-sets.yaml
@@ -1,5 +1,6 @@
 sets:
   - name: no-skills
+    model: sonnet
     skills: []
     allowed_tools:
       - Read
@@ -7,6 +8,7 @@ sets:
       - Grep
 
   - name: with-triage-skill
+    model: sonnet
     skills:
       - skills/dbt-migration/skills/migrating-dbt-core-to-fusion
     allowed_tools:

--- a/evals/scenarios/fusion-triage-cat-b-unused-schema/skill-sets.yaml
+++ b/evals/scenarios/fusion-triage-cat-b-unused-schema/skill-sets.yaml
@@ -1,5 +1,6 @@
 sets:
   - name: no-skills
+    model: sonnet
     skills: []
     allowed_tools:
       - Read
@@ -7,6 +8,7 @@ sets:
       - Grep
 
   - name: with-triage-skill
+    model: sonnet
     skills:
       - skills/dbt-migration/skills/migrating-dbt-core-to-fusion
     allowed_tools:

--- a/evals/scenarios/fusion-triage-cat-b-yaml-syntax/skill-sets.yaml
+++ b/evals/scenarios/fusion-triage-cat-b-yaml-syntax/skill-sets.yaml
@@ -1,5 +1,6 @@
 sets:
   - name: no-skills
+    model: sonnet
     skills: []
     allowed_tools:
       - Read
@@ -7,6 +8,7 @@ sets:
       - Grep
 
   - name: with-triage-skill
+    model: sonnet
     skills:
       - skills/dbt-migration/skills/migrating-dbt-core-to-fusion
     allowed_tools:

--- a/evals/scenarios/fusion-triage-cat-c-hardcoded-fqn/skill-sets.yaml
+++ b/evals/scenarios/fusion-triage-cat-c-hardcoded-fqn/skill-sets.yaml
@@ -1,5 +1,6 @@
 sets:
   - name: no-skills
+    model: sonnet
     skills: []
     allowed_tools:
       - Read
@@ -7,6 +8,7 @@ sets:
       - Grep
 
   - name: with-triage-skill
+    model: sonnet
     skills:
       - skills/dbt-migration/skills/migrating-dbt-core-to-fusion
     allowed_tools:

--- a/evals/scenarios/semantic-layer-inline-latest-spec/skill-sets.yaml
+++ b/evals/scenarios/semantic-layer-inline-latest-spec/skill-sets.yaml
@@ -1,11 +1,13 @@
 sets:
   - name: pre-fix-6cd21ea
+    model: sonnet
     skills:
       - https://github.com/dbt-labs/dbt-agent-skills/blob/6cd21ea97bd81decf5eb5b48b54bccea8d8fcbc2/skills/dbt/skills/building-dbt-semantic-layer/SKILL.md
     allowed_tools:
       - Skill
 
   - name: working-tree
+    model: sonnet
     skills:
       - skills/dbt/skills/building-dbt-semantic-layer/SKILL.md
     allowed_tools:

--- a/evals/scenarios/semantic-layer-inline-legacy-spec/skill-sets.yaml
+++ b/evals/scenarios/semantic-layer-inline-legacy-spec/skill-sets.yaml
@@ -1,11 +1,13 @@
 sets:
   - name: pre-fix-6cd21ea
+    model: sonnet
     skills:
       - https://github.com/dbt-labs/dbt-agent-skills/blob/6cd21ea97bd81decf5eb5b48b54bccea8d8fcbc2/skills/dbt/skills/building-dbt-semantic-layer/SKILL.md
     allowed_tools:
       - Skill
 
   - name: working-tree
+    model: sonnet
     skills:
       - skills/dbt/skills/building-dbt-semantic-layer/SKILL.md
     allowed_tools:

--- a/evals/src/skill_eval/cli.py
+++ b/evals/src/skill_eval/cli.py
@@ -359,7 +359,7 @@ def grade(
     run_dir = find_run(runs_dir, run_id, latest=latest)
 
     if auto:
-        typer.echo(f"Auto-grading run: {run_id}")
+        typer.echo(f"Auto-grading run: {run_dir.name}")
         typer.echo()
 
         # Count scenarios and skill sets for progress
@@ -419,7 +419,7 @@ def grade(
         save_grades(run_dir, grades)
         grades_file = run_dir / "grades.yaml"
         typer.echo(f"\nGrades saved to: {grades_file}")
-        typer.echo(f"Run: uv run skill-eval report {run_id}")
+        typer.echo(f"Run: uv run skill-eval report {run_dir.name}")
     else:
         grades_file = init_grades_file(run_dir)
 
@@ -436,7 +436,7 @@ def grade(
                 typer.echo(f"    {skill_set_dir.name}/output.md")
 
         typer.echo(f"\nEdit {grades_file} to record your grades.")
-        typer.echo(f"Then run: uv run skill-eval report {run_id}")
+        typer.echo(f"Then run: uv run skill-eval report {run_dir.name}")
 
 
 @app.command()

--- a/evals/src/skill_eval/cli.py
+++ b/evals/src/skill_eval/cli.py
@@ -467,9 +467,12 @@ def review(
     run_id: Optional[str] = typer.Argument(None, help="Run ID (full or partial). Defaults to latest run."),
     latest: bool = typer.Option(False, "--latest", "-l", help="Use latest run without prompting"),
     base_dir: Optional[Path] = typer.Option(None, "--base-dir", "-d", help="Evals root directory (default: auto-detected)"),
+    tabs: bool = typer.Option(False, "--tabs", help="Open every transcript in its own browser tab instead of the index page"),
 ) -> None:
-    """Open HTML transcripts in browser for review."""
+    """Open a review index page (or every transcript tab with --tabs)."""
     import webbrowser
+
+    from skill_eval.reporter import save_review_html
 
     evals_dir = _get_evals_dir(base_dir)
     runs_dir = evals_dir / "runs"
@@ -483,13 +486,17 @@ def review(
         typer.echo(f"Error: No transcripts found in {run_dir}", err=True)
         raise typer.Exit(1)
 
-    typer.echo(f"Opening {len(transcripts)} transcript(s)...")
+    if tabs:
+        typer.echo(f"Opening {len(transcripts)} transcript(s)...")
+        for transcript in sorted(transcripts):
+            rel_path = transcript.relative_to(run_dir)
+            typer.echo(f"  {rel_path}")
+            webbrowser.open(f"file://{transcript}")
+        return
 
-    for transcript in sorted(transcripts):
-        # Show which transcript we're opening
-        rel_path = transcript.relative_to(run_dir)
-        typer.echo(f"  {rel_path}")
-        webbrowser.open(f"file://{transcript}")
+    review_file = save_review_html(run_dir)
+    typer.echo(f"Review index: {review_file}")
+    webbrowser.open(f"file://{review_file}")
 
 
 @app.command()

--- a/evals/src/skill_eval/cli.py
+++ b/evals/src/skill_eval/cli.py
@@ -479,14 +479,14 @@ def review(
 
     run_dir = find_run(runs_dir, run_id, latest=latest)
 
-    # Find all transcript index.html files
-    transcripts = list(run_dir.glob("**/transcript/index.html"))
-
-    if not transcripts:
-        typer.echo(f"Error: No transcripts found in {run_dir}", err=True)
-        raise typer.Exit(1)
-
     if tabs:
+        # Find all transcript index.html files
+        transcripts = list(run_dir.glob("**/transcript/index.html"))
+
+        if not transcripts:
+            typer.echo(f"Error: No transcripts found in {run_dir}", err=True)
+            raise typer.Exit(1)
+
         typer.echo(f"Opening {len(transcripts)} transcript(s)...")
         for transcript in sorted(transcripts):
             rel_path = transcript.relative_to(run_dir)
@@ -494,6 +494,9 @@ def review(
             webbrowser.open(f"file://{transcript}")
         return
 
+    # The index page doesn't need transcripts to be useful — it can still
+    # show cost/tokens/duration/etc. from metadata.yaml even if transcript
+    # generation failed or was disabled for a run.
     review_file = save_review_html(run_dir)
     typer.echo(f"Review index: {review_file}")
     webbrowser.open(f"file://{review_file}")

--- a/evals/src/skill_eval/grader.py
+++ b/evals/src/skill_eval/grader.py
@@ -273,12 +273,18 @@ def init_grades_file(run_dir: Path) -> Path:
 
 
 def load_grades(run_dir: Path) -> dict:
-    """Load grades from a run directory."""
+    """Load grades from a run directory.
+
+    Returns {} if grades.yaml is missing, empty, or doesn't parse to a
+    mapping (e.g. hand-edited/corrupted), so callers can rely on the
+    declared `dict` return type without their own guard.
+    """
     grades_file = run_dir / "grades.yaml"
     if not grades_file.exists():
         return {}
     with grades_file.open() as f:
-        return yaml.safe_load(f)
+        loaded = yaml.safe_load(f)
+    return loaded if isinstance(loaded, dict) else {}
 
 
 def save_grades(run_dir: Path, grades: dict) -> None:

--- a/evals/src/skill_eval/models.py
+++ b/evals/src/skill_eval/models.py
@@ -63,6 +63,11 @@ def load_scenario(scenario_dir: Path) -> Scenario:
     with skill_sets_file.open() as f:
         data = yaml.safe_load(f)
 
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"skill-sets.yaml in '{name}' is empty or not a mapping with a 'sets' list."
+        )
+
     skill_sets = []
     for s in data.get("sets", []):
         if not s.get("model"):

--- a/evals/src/skill_eval/models.py
+++ b/evals/src/skill_eval/models.py
@@ -78,6 +78,8 @@ def load_scenario(scenario_dir: Path) -> Scenario:
             raise ValueError(
                 f"skill-sets.yaml in '{name}' has a set entry that isn't a mapping: {s!r}"
             )
+        if not s.get("name"):
+            raise ValueError(f"skill-sets.yaml in '{name}' has a set entry missing a 'name'.")
         if not s.get("model"):
             raise ValueError(
                 f"skill-sets.yaml in '{name}' is missing a required 'model' field "

--- a/evals/src/skill_eval/models.py
+++ b/evals/src/skill_eval/models.py
@@ -27,11 +27,15 @@ class SkillSet:
     """A combination of skills and MCP servers to test."""
 
     name: str
+    model: str
     skills: list[str] = field(default_factory=list)
     mcp_servers: dict = field(default_factory=dict)  # MCP server config (mcpServers format)
     allowed_tools: list[str] = field(default_factory=list)  # If empty, allows all tools
     extra_prompt: str = ""  # Additional text appended to the base prompt
     setup: list[str] = field(default_factory=list)  # Commands to run before Claude
+    # If True (default), only MCP servers from this set's mcp_servers are used —
+    # Claude Desktop / user / project MCP config is ignored. Set to False to opt out.
+    strict_mcp_config: bool = True
 
 
 @dataclass
@@ -59,17 +63,26 @@ def load_scenario(scenario_dir: Path) -> Scenario:
     with skill_sets_file.open() as f:
         data = yaml.safe_load(f)
 
-    skill_sets = [
-        SkillSet(
-            name=s["name"],
-            skills=s.get("skills", []),
-            mcp_servers=s.get("mcp_servers", {}),
-            allowed_tools=s.get("allowed_tools", []),
-            extra_prompt=s.get("extra_prompt", ""),
-            setup=s.get("setup", []),
+    skill_sets = []
+    for s in data.get("sets", []):
+        if not s.get("model"):
+            raise ValueError(
+                f"skill-sets.yaml in '{name}' is missing a required 'model' field "
+                f"for set '{s.get('name', '?')}'. Every set must declare a model "
+                "(e.g. `model: sonnet`) so runs are reproducible."
+            )
+        skill_sets.append(
+            SkillSet(
+                name=s["name"],
+                model=s["model"],
+                skills=s.get("skills", []),
+                mcp_servers=s.get("mcp_servers", {}),
+                allowed_tools=s.get("allowed_tools", []),
+                extra_prompt=s.get("extra_prompt", ""),
+                setup=s.get("setup", []),
+                strict_mcp_config=s.get("strict_mcp_config", True),
+            )
         )
-        for s in data.get("sets", [])
-    ]
 
     description = ""
     scenario_md = scenario_dir / "scenario.md"

--- a/evals/src/skill_eval/models.py
+++ b/evals/src/skill_eval/models.py
@@ -68,8 +68,16 @@ def load_scenario(scenario_dir: Path) -> Scenario:
             f"skill-sets.yaml in '{name}' is empty or not a mapping with a 'sets' list."
         )
 
+    sets = data.get("sets", [])
+    if not isinstance(sets, list):
+        raise ValueError(f"skill-sets.yaml in '{name}' has a 'sets' key that isn't a list.")
+
     skill_sets = []
-    for s in data.get("sets", []):
+    for s in sets:
+        if not isinstance(s, dict):
+            raise ValueError(
+                f"skill-sets.yaml in '{name}' has a set entry that isn't a mapping: {s!r}"
+            )
         if not s.get("model"):
             raise ValueError(
                 f"skill-sets.yaml in '{name}' is missing a required 'model' field "

--- a/evals/src/skill_eval/reporter.py
+++ b/evals/src/skill_eval/reporter.py
@@ -347,6 +347,10 @@ _REVIEW_CSS = """
 """
 
 _REVIEW_SORT_JS = """
+  const sortValue = (td) => {
+    const nested = td.querySelector("[data-sort]");
+    return nested ? nested.dataset.sort : td.innerText;
+  };
   document.querySelectorAll("th[data-idx]").forEach((th) => {
     th.addEventListener("click", () => {
       const idx = Number(th.dataset.idx);
@@ -356,8 +360,8 @@ _REVIEW_SORT_JS = """
       const rows = Array.from(tbody.querySelectorAll("tr"));
       const asc = th.dataset.dir !== "asc";
       rows.sort((a, b) => {
-        let x = a.children[idx].dataset.sort ?? a.children[idx].innerText;
-        let y = b.children[idx].dataset.sort ?? b.children[idx].innerText;
+        let x = sortValue(a.children[idx]);
+        let y = sortValue(b.children[idx]);
         if (numeric) { x = parseFloat(x) || 0; y = parseFloat(y) || 0; }
         return asc ? (x > y ? 1 : x < y ? -1 : 0) : (x < y ? 1 : x > y ? -1 : 0);
       });

--- a/evals/src/skill_eval/reporter.py
+++ b/evals/src/skill_eval/reporter.py
@@ -274,6 +274,18 @@ def save_report(run_dir: Path, reports_dir: Path) -> Path:
     return report_file
 
 
+def _safe_number(value: object, default: float | None = None) -> float | None:
+    """Coerce a metadata/grades value to a plain number, or `default` if it isn't one.
+
+    metadata.yaml and grades.yaml can be hand-edited or corrupted; a non-numeric
+    value here must not reach an f-string meant to hold a number (data-sort
+    attributes, HTML attribute text) unescaped.
+    """
+    if isinstance(value, bool):
+        return default
+    return value if isinstance(value, (int, float)) else default
+
+
 def _format_duration(duration_ms: int | float | None) -> str:
     """Format milliseconds as e.g. '1m 05s' or '3.2s'."""
     if duration_ms is None:
@@ -290,7 +302,7 @@ def _format_cost(cost: float | None) -> str:
     return "-" if cost is None else f"${cost:.4f}"
 
 
-def _format_tokens(n: int | None) -> str:
+def _format_tokens(n: int | float | None) -> str:
     """Format a token count with thousands separators."""
     return "-" if n is None else f"{n:,}"
 
@@ -422,7 +434,7 @@ def generate_review_html(run_dir: Path) -> str:
             status_html = '<span class="unknown">?</span>'
             status_sort = "1"
 
-        score = grade.get("score") if grade else None
+        score = _safe_number(grade.get("score")) if grade else None
         score_html = f"{score}/5" if score is not None else "-"
 
         skills_available = m.get("skills_available", [])
@@ -436,10 +448,11 @@ def generate_review_html(run_dir: Path) -> str:
             ", ".join(s.get("name", "?") if isinstance(s, dict) else str(s) for s in mcp_servers) or "-"
         )
 
-        subagent_count = m.get("subagent_count", 0)
+        subagent_count = _safe_number(m.get("subagent_count", 0), default=0)
         if m.get("subagents_used"):
             subagent_tools = ", ".join(m.get("subagent_tools_used", []))
-            subagent_title = f'title="{html_lib.escape(subagent_tools)} ({m.get("subagent_tool_call_count", 0)} calls)"'
+            subagent_call_count = _safe_number(m.get("subagent_tool_call_count", 0), default=0)
+            subagent_title = f'title="{html_lib.escape(subagent_tools)} ({subagent_call_count} calls)"'
             subagent_html = f'<span {subagent_title}>{subagent_count}</span>'
         else:
             subagent_html = "-"
@@ -451,24 +464,29 @@ def generate_review_html(run_dir: Path) -> str:
             links.append(f'<a href="{html_lib.escape(row["output_rel"])}">output</a>')
         links_html = " &middot; ".join(links) if links else "-"
 
-        duration_ms = m.get("duration_ms")
-        cost = m.get("total_cost_usd")
+        duration_ms = _safe_number(m.get("duration_ms"))
+        cost = _safe_number(m.get("total_cost_usd"))
+        num_turns = _safe_number(m.get("num_turns"))
+        tool_call_count = _safe_number(m.get("tool_call_count", 0), default=0)
+
+        model_name = m.get("model")
+        model_text = html_lib.escape(str(model_name)) if model_name else "-"
 
         cells = [
             html_lib.escape(row["scenario"]),
             html_lib.escape(row["skill_set"]),
-            html_lib.escape(m.get("model") or "-"),
+            model_text,
             f'<span data-sort="{status_sort}">{status_html}</span>',
             f'<span data-sort="{score if score is not None else -1}">{score_html}</span>',
             f'<span data-sort="{duration_ms or 0}">{_format_duration(duration_ms)}</span>',
-            m.get("num_turns") if m.get("num_turns") is not None else "-",
-            m.get("tool_call_count", 0),
+            num_turns if num_turns is not None else "-",
+            tool_call_count,
             len(tools_used),
             f'<span data-sort="{subagent_count}">{subagent_html}</span>',
             f'<span data-sort="{skills_sort}">{skills_html}</span>',
             html_lib.escape(mcp_names),
             f'<span data-sort="{cost or 0}">{_format_cost(cost)}</span>',
-            f"{_format_tokens(m.get('input_tokens'))} / {_format_tokens(m.get('output_tokens'))}",
+            f"{_format_tokens(_safe_number(m.get('input_tokens')))} / {_format_tokens(_safe_number(m.get('output_tokens')))}",
             links_html,
         ]
         classes = ["", "", "", "center", "center", "right", "right", "right", "right", "right", "right", "", "right", "right", ""]

--- a/evals/src/skill_eval/reporter.py
+++ b/evals/src/skill_eval/reporter.py
@@ -308,7 +308,8 @@ def collect_review_rows(run_dir: Path) -> list[dict]:
             metadata_file = skill_set_dir / "metadata.yaml"
             metadata: dict = {}
             if metadata_file.exists():
-                metadata = yaml.safe_load(metadata_file.read_text()) or {}
+                loaded = yaml.safe_load(metadata_file.read_text())
+                metadata = loaded if isinstance(loaded, dict) else {}
 
             transcript = skill_set_dir / "transcript" / "index.html"
             output_md = skill_set_dir / "output.md"

--- a/evals/src/skill_eval/reporter.py
+++ b/evals/src/skill_eval/reporter.py
@@ -1,8 +1,10 @@
 """Report generation for skill evaluation."""
 
+import html as html_lib
 from collections import Counter, defaultdict
 from pathlib import Path
 
+import yaml
 from rich.console import Console
 from rich.table import Table
 
@@ -270,3 +272,230 @@ def save_report(run_dir: Path, reports_dir: Path) -> Path:
     report_file = reports_dir / f"{run_dir.name}.md"
     report_file.write_text(report)
     return report_file
+
+
+def _format_duration(duration_ms: int | float | None) -> str:
+    """Format milliseconds as e.g. '1m 05s' or '3.2s'."""
+    if duration_ms is None:
+        return "-"
+    seconds = duration_ms / 1000
+    minutes, seconds = divmod(seconds, 60)
+    if minutes:
+        return f"{int(minutes)}m {seconds:02.0f}s"
+    return f"{seconds:.1f}s"
+
+
+def _format_cost(cost: float | None) -> str:
+    """Format a USD cost, e.g. '$0.1426'."""
+    return "-" if cost is None else f"${cost:.4f}"
+
+
+def _format_tokens(n: int | None) -> str:
+    """Format a token count with thousands separators."""
+    return "-" if n is None else f"{n:,}"
+
+
+def collect_review_rows(run_dir: Path) -> list[dict]:
+    """Gather per (scenario, skill_set) run data for the review index page."""
+    grades = load_grades(run_dir).get("results", {})
+
+    rows = []
+    for scenario_dir in sorted(p for p in run_dir.iterdir() if p.is_dir()):
+        scenario_name = scenario_dir.name
+        for skill_set_dir in sorted(p for p in scenario_dir.iterdir() if p.is_dir()):
+            skill_set_name = skill_set_dir.name
+
+            metadata_file = skill_set_dir / "metadata.yaml"
+            metadata: dict = {}
+            if metadata_file.exists():
+                metadata = yaml.safe_load(metadata_file.read_text()) or {}
+
+            transcript = skill_set_dir / "transcript" / "index.html"
+            output_md = skill_set_dir / "output.md"
+
+            rows.append(
+                {
+                    "scenario": scenario_name,
+                    "skill_set": skill_set_name,
+                    "metadata": metadata,
+                    "transcript_rel": transcript.relative_to(run_dir).as_posix() if transcript.exists() else None,
+                    "output_rel": output_md.relative_to(run_dir).as_posix() if output_md.exists() else None,
+                    "grade": grades.get(scenario_name, {}).get(skill_set_name),
+                }
+            )
+    return rows
+
+
+_REVIEW_CSS = """
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+         margin: 2rem; color: #1c1e21; background: #fff; }
+  h1 { font-size: 1.3rem; margin-bottom: 0.2rem; }
+  .subtitle { color: #666; margin-top: 0; margin-bottom: 1.2rem; }
+  table { border-collapse: collapse; width: 100%; font-size: 0.85rem; }
+  th, td { padding: 0.4rem 0.6rem; border-bottom: 1px solid #e3e5e8; text-align: left; white-space: nowrap; }
+  th { position: sticky; top: 0; background: #f5f6f8; cursor: pointer; user-select: none; }
+  th:hover { background: #ebedf0; }
+  th.sorted::after { content: " \\25BE"; }
+  tbody tr:hover { background: #f9fafb; }
+  td.right, th.right { text-align: right; }
+  td.center, th.center { text-align: center; }
+  .ok { color: #16794c; font-weight: bold; }
+  .fail { color: #c0392b; font-weight: bold; }
+  .unknown { color: #999; }
+  a { color: #0b5cff; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+"""
+
+_REVIEW_SORT_JS = """
+  document.querySelectorAll("th[data-idx]").forEach((th) => {
+    th.addEventListener("click", () => {
+      const idx = Number(th.dataset.idx);
+      const numeric = th.dataset.numeric === "1";
+      const table = th.closest("table");
+      const tbody = table.querySelector("tbody");
+      const rows = Array.from(tbody.querySelectorAll("tr"));
+      const asc = th.dataset.dir !== "asc";
+      rows.sort((a, b) => {
+        let x = a.children[idx].dataset.sort ?? a.children[idx].innerText;
+        let y = b.children[idx].dataset.sort ?? b.children[idx].innerText;
+        if (numeric) { x = parseFloat(x) || 0; y = parseFloat(y) || 0; }
+        return asc ? (x > y ? 1 : x < y ? -1 : 0) : (x < y ? 1 : x > y ? -1 : 0);
+      });
+      rows.forEach((row) => tbody.appendChild(row));
+      table.querySelectorAll("th").forEach((h) => { h.classList.remove("sorted"); h.dataset.dir = ""; });
+      th.classList.add("sorted");
+      th.dataset.dir = asc ? "asc" : "desc";
+    });
+  });
+"""
+
+
+def generate_review_html(run_dir: Path) -> str:
+    """Generate a single HTML page indexing every run with links + key metrics.
+
+    Replaces opening one browser tab per transcript: one page, one table,
+    sortable by clicking column headers, with links out to each transcript
+    and raw output.
+    """
+    rows = collect_review_rows(run_dir)
+
+    columns = [
+        ("Scenario", False),
+        ("Skill Set", False),
+        ("Model", False),
+        ("Result", False),
+        ("Score", True),
+        ("Duration", True),
+        ("Turns", True),
+        ("Tool calls", True),
+        ("Distinct tools", True),
+        ("Subagents", True),
+        ("Skills", True),
+        ("MCP servers", False),
+        ("Cost", True),
+        ("Tokens (in/out)", True),
+        ("Links", False),
+    ]
+    header_html = "".join(
+        f'<th data-idx="{i}" data-numeric="{"1" if numeric else "0"}">{html_lib.escape(label)}</th>'
+        for i, (label, numeric) in enumerate(columns)
+    )
+
+    body_rows = []
+    for row in rows:
+        m = row["metadata"]
+        grade = row["grade"]
+
+        success = m.get("success")
+        if success:
+            status_html = '<span class="ok">&#10003;</span>'
+            status_sort = "2"
+        elif success is False:
+            status_html = '<span class="fail">&#10007;</span>'
+            status_sort = "0"
+        else:
+            status_html = '<span class="unknown">?</span>'
+            status_sort = "1"
+
+        score = grade.get("score") if grade else None
+        score_html = f"{score}/5" if score is not None else "-"
+
+        skills_available = m.get("skills_available", [])
+        skills_invoked = m.get("skills_invoked", [])
+        skills_html = f"{len(skills_invoked)}/{len(skills_available)}" if skills_available else "-"
+        skills_sort = len(skills_invoked) / len(skills_available) if skills_available else -1
+
+        tools_used = m.get("tools_used", [])
+        mcp_servers = m.get("mcp_servers", [])
+        mcp_names = (
+            ", ".join(s.get("name", "?") if isinstance(s, dict) else str(s) for s in mcp_servers) or "-"
+        )
+
+        subagent_count = m.get("subagent_count", 0)
+        if m.get("subagents_used"):
+            subagent_tools = ", ".join(m.get("subagent_tools_used", []))
+            subagent_title = f'title="{html_lib.escape(subagent_tools)} ({m.get("subagent_tool_call_count", 0)} calls)"'
+            subagent_html = f'<span {subagent_title}>{subagent_count}</span>'
+        else:
+            subagent_html = "-"
+
+        links = []
+        if row["transcript_rel"]:
+            links.append(f'<a href="{html_lib.escape(row["transcript_rel"])}">transcript</a>')
+        if row["output_rel"]:
+            links.append(f'<a href="{html_lib.escape(row["output_rel"])}">output</a>')
+        links_html = " &middot; ".join(links) if links else "-"
+
+        duration_ms = m.get("duration_ms")
+        cost = m.get("total_cost_usd")
+
+        cells = [
+            html_lib.escape(row["scenario"]),
+            html_lib.escape(row["skill_set"]),
+            html_lib.escape(m.get("model") or "-"),
+            f'<span data-sort="{status_sort}">{status_html}</span>',
+            f'<span data-sort="{score if score is not None else -1}">{score_html}</span>',
+            f'<span data-sort="{duration_ms or 0}">{_format_duration(duration_ms)}</span>',
+            m.get("num_turns") if m.get("num_turns") is not None else "-",
+            m.get("tool_call_count", 0),
+            len(tools_used),
+            f'<span data-sort="{subagent_count}">{subagent_html}</span>',
+            f'<span data-sort="{skills_sort}">{skills_html}</span>',
+            html_lib.escape(mcp_names),
+            f'<span data-sort="{cost or 0}">{_format_cost(cost)}</span>',
+            f"{_format_tokens(m.get('input_tokens'))} / {_format_tokens(m.get('output_tokens'))}",
+            links_html,
+        ]
+        classes = ["", "", "", "center", "center", "right", "right", "right", "right", "right", "right", "", "right", "right", ""]
+        cells_html = "".join(
+            f'<td class="{cls}">{val}</td>' if cls else f"<td>{val}</td>"
+            for cls, val in zip(classes, cells)
+        )
+        body_rows.append(f"<tr>{cells_html}</tr>")
+
+    run_name = html_lib.escape(run_dir.name)
+    return f"""<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Eval Review: {run_name}</title>
+<style>{_REVIEW_CSS}</style>
+</head>
+<body>
+<h1>Eval Review: {run_name}</h1>
+<p class="subtitle">{len(rows)} run(s) &middot; click a column header to sort</p>
+<table>
+<thead><tr>{header_html}</tr></thead>
+<tbody>{"".join(body_rows)}</tbody>
+</table>
+<script>{_REVIEW_SORT_JS}</script>
+</body>
+</html>
+"""
+
+
+def save_review_html(run_dir: Path) -> Path:
+    """Generate and save the review index page inside the run directory."""
+    review_file = run_dir / "review.html"
+    review_file.write_text(generate_review_html(run_dir))
+    return review_file

--- a/evals/src/skill_eval/runner.py
+++ b/evals/src/skill_eval/runner.py
@@ -659,7 +659,6 @@ class Runner:
             skills=skill_set.skills,
             mcp_servers=skill_set.mcp_servers if skill_set.mcp_servers else None,
         )
-        configured_skill_names = self._configured_skill_names(env_dir / ".claude" / "skills")
 
         # Load .env vars for setup commands and Claude
         dot_env_vars: dict[str, str] = {}
@@ -718,8 +717,12 @@ class Runner:
         (output_dir / "raw.jsonl").write_text(raw_json)
 
         # Scope skills_available down to skills this eval actually configured
-        # (skill_set.skills) — `claude` also reports globally installed
-        # plugin/marketplace skills, which aren't part of what's being tested.
+        # (skill_set.skills, plus anything a setup command installed) —
+        # `claude` also reports globally installed plugin/marketplace skills,
+        # which aren't part of what's being tested. Computed now rather than
+        # right after prepare_environment so it also picks up skills a setup
+        # command (e.g. `npx skills add ... -a claude-code`) installed.
+        configured_skill_names = self._configured_skill_names(env_dir / ".claude" / "skills")
         reported_available = parsed.get("skills_available", [])
         eval_skills_available = [s for s in reported_available if s in configured_skill_names]
         other_skills_available = [s for s in reported_available if s not in configured_skill_names]

--- a/evals/src/skill_eval/runner.py
+++ b/evals/src/skill_eval/runner.py
@@ -205,6 +205,30 @@ class Runner:
             dest.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy(src, dest)
 
+    def _configured_skill_names(self, skills_dir: Path) -> list[str]:
+        """Names of skills copied into skills_dir for this eval (from SKILL.md frontmatter).
+
+        Falls back to the containing folder's name if a SKILL.md has no `name`
+        in its frontmatter or isn't parseable. This is what the eval actually
+        added — used to filter out unrelated skills/plugins (e.g. globally
+        installed ones) that `claude` may also report as available.
+        """
+        names = []
+        for skill_md in sorted(skills_dir.glob("*/SKILL.md")):
+            name = skill_md.parent.name
+            text = skill_md.read_text()
+            if text.startswith("---"):
+                end = text.find("\n---", 3)
+                if end != -1:
+                    try:
+                        frontmatter = yaml.safe_load(text[3:end])
+                        if isinstance(frontmatter, dict) and frontmatter.get("name"):
+                            name = frontmatter["name"]
+                    except yaml.YAMLError:
+                        pass
+            names.append(name)
+        return names
+
     def _generate_transcript(
         self, env_dir: Path, output_dir: Path, scenario_name: str, skill_set_name: str, log=None
     ) -> None:
@@ -319,12 +343,29 @@ class Runner:
     def _parse_json_output(self, json_str: str) -> dict:
         """Parse NDJSON (newline-delimited JSON) output from Claude stream-json format.
 
-        Returns dict with: output_text, skills_invoked, tools_used, and run metadata.
+        A `Task` tool call spawns a subagent whose own turns are streamed inline
+        as assistant/user messages with `parent_tool_use_id` set (a "sidechain").
+        Those are kept separate from the main thread's counters below:
+
+        - `output_text` is built only from main-thread text, so a subagent's own
+          narration never ends up in output.md and gets graded as the answer.
+        - `tools_used`/`tool_call_count` count main-thread tool calls only;
+          `subagent_tools_used`/`subagent_tool_call_count` cover sidechain calls.
+        - `skills_invoked` is deliberately NOT split — a Skill invoked from
+          inside a subagent still means the skill was used for this task.
+
+        Returns dict with: output_text, skills_invoked, tools_used, subagent
+        usage, and run metadata.
         """
         result = {
             "output_text": "",
             "skills_invoked": [],
             "tools_used": [],
+            "tool_call_count": 0,
+            "subagents_used": False,
+            "subagent_count": 0,
+            "subagent_tools_used": [],
+            "subagent_tool_call_count": 0,
             # From init message
             "model": None,
             "skills_available": [],
@@ -340,6 +381,10 @@ class Runner:
         text_parts = []
         skills_invoked = []
         tools_used = set()
+        tool_call_count = 0
+        subagent_tools_used = set()
+        subagent_tool_call_count = 0
+        subagent_count = 0
 
         # Parse each line as separate JSON (NDJSON format)
         for line in json_str.strip().split("\n"):
@@ -361,17 +406,24 @@ class Runner:
 
             # Extract text and tool usage from assistant messages
             if msg.get("type") == "assistant":
+                is_subagent = bool(msg.get("parent_tool_use_id"))
                 for content in msg.get("message", {}).get("content", []):
                     if isinstance(content, dict):
                         if content.get("type") == "text":
                             text = content.get("text", "").strip()
-                            if text:
+                            if text and not is_subagent:
                                 text_parts.append(text)
                         elif content.get("type") == "tool_use":
                             tool_name = content.get("name", "")
-                            if tool_name:
+                            if tool_name == "Task":
+                                subagent_count += 1
+                            if tool_name and is_subagent:
+                                subagent_tools_used.add(tool_name)
+                                subagent_tool_call_count += 1
+                            elif tool_name:
                                 tools_used.add(tool_name)
-                            # Check if it's a Skill invocation
+                                tool_call_count += 1
+                            # Check if it's a Skill invocation (main thread or subagent)
                             if tool_name == "Skill":
                                 skill_input = content.get("input", {})
                                 skill_name = skill_input.get("skill", "")
@@ -389,7 +441,12 @@ class Runner:
 
         result["output_text"] = "\n\n".join(text_parts)
         result["skills_invoked"] = skills_invoked
+        result["subagent_count"] = subagent_count
+        result["subagents_used"] = subagent_count > 0
+        result["subagent_tools_used"] = list(subagent_tools_used)
+        result["subagent_tool_call_count"] = subagent_tool_call_count
         result["tools_used"] = list(tools_used)
+        result["tool_call_count"] = tool_call_count
 
         return result
 
@@ -602,6 +659,7 @@ class Runner:
             skills=skill_set.skills,
             mcp_servers=skill_set.mcp_servers if skill_set.mcp_servers else None,
         )
+        configured_skill_names = self._configured_skill_names(env_dir / ".claude" / "skills")
 
         # Load .env vars for setup commands and Claude
         dot_env_vars: dict[str, str] = {}
@@ -659,12 +717,25 @@ class Runner:
         (output_dir / "output.md").write_text(parsed.get("output_text", ""))
         (output_dir / "raw.jsonl").write_text(raw_json)
 
+        # Scope skills_available down to skills this eval actually configured
+        # (skill_set.skills) — `claude` also reports globally installed
+        # plugin/marketplace skills, which aren't part of what's being tested.
+        reported_available = parsed.get("skills_available", [])
+        eval_skills_available = [s for s in reported_available if s in configured_skill_names]
+        other_skills_available = [s for s in reported_available if s not in configured_skill_names]
+
         # Save metadata
         metadata = {
             "success": success,
             "skills_invoked": parsed.get("skills_invoked", []),
-            "skills_available": parsed.get("skills_available", []),
+            "skills_available": eval_skills_available,
+            "skills_available_other": other_skills_available,
             "tools_used": parsed.get("tools_used", []),
+            "tool_call_count": parsed.get("tool_call_count", 0),
+            "subagents_used": parsed.get("subagents_used", False),
+            "subagent_count": parsed.get("subagent_count", 0),
+            "subagent_tools_used": parsed.get("subagent_tools_used", []),
+            "subagent_tool_call_count": parsed.get("subagent_tool_call_count", 0),
             "mcp_servers": parsed.get("mcp_servers", []),
             "model": parsed.get("model"),
             "duration_ms": parsed.get("duration_ms"),

--- a/evals/src/skill_eval/runner.py
+++ b/evals/src/skill_eval/runner.py
@@ -466,6 +466,8 @@ class Runner:
         prompt: str,
         mcp_config_path: Path | None = None,
         allowed_tools: list[str] | None = None,
+        model: str | None = None,
+        strict_mcp_config: bool = True,
         timeout: int = 600,
         stall_timeout: int = 60,
         ctx_logger=None,
@@ -478,6 +480,10 @@ class Runner:
             prompt: The prompt to send
             mcp_config_path: Optional path to MCP config
             allowed_tools: Optional list of allowed tools
+            model: Model alias or ID to pass via `--model` (e.g. "sonnet", "opus")
+            strict_mcp_config: If True (default), pass --strict-mcp-config so only
+                mcp_config_path's servers are used — Claude Desktop/user/project
+                MCP servers are ignored. Set False to allow those to load too.
             timeout: Maximum total runtime in seconds (default: 600 = 10 min)
             stall_timeout: Kill if no output for this many seconds (default: 60)
             ctx_logger: Optional logger with bound context (scenario, skill_set)
@@ -496,6 +502,12 @@ class Runner:
             "--verbose",
             "--output-format", "stream-json",
         ]
+
+        if model:
+            cmd.extend(["--model", model])
+
+        if strict_mcp_config:
+            cmd.append("--strict-mcp-config")
 
         # Use allowed_tools if specified, otherwise skip all permissions
         if allowed_tools:
@@ -636,6 +648,8 @@ class Runner:
             prompt,
             mcp_config_path,
             skill_set.allowed_tools if skill_set.allowed_tools else None,
+            model=skill_set.model,
+            strict_mcp_config=skill_set.strict_mcp_config,
             ctx_logger=ctx_logger,
             extra_env=dot_env_vars if dot_env_vars else None,
         )

--- a/evals/src/skill_eval/runner.py
+++ b/evals/src/skill_eval/runner.py
@@ -443,9 +443,9 @@ class Runner:
         result["skills_invoked"] = skills_invoked
         result["subagent_count"] = subagent_count
         result["subagents_used"] = subagent_count > 0
-        result["subagent_tools_used"] = list(subagent_tools_used)
+        result["subagent_tools_used"] = sorted(subagent_tools_used)
         result["subagent_tool_call_count"] = subagent_tool_call_count
-        result["tools_used"] = list(tools_used)
+        result["tools_used"] = sorted(tools_used)
         result["tool_call_count"] = tool_call_count
 
         return result

--- a/evals/src/skill_eval/templates/skill-sets.yaml
+++ b/evals/src/skill_eval/templates/skill-sets.yaml
@@ -1,6 +1,11 @@
 sets:
+  # `model` is required on every set (e.g. sonnet, opus, or a full model ID) so
+  # runs are reproducible instead of silently depending on the `claude` CLI's
+  # built-in default.
+
   # Baseline: no skills, read-only tools
   - name: no-skills
+    model: sonnet
     skills: []
     allowed_tools:
       - Read
@@ -9,6 +14,7 @@ sets:
 
   # # With skills and additional tools
   # - name: with-skills
+  #   model: sonnet
   #   skills:
   #     - skills/my-skill
   #   allowed_tools:
@@ -21,6 +27,7 @@ sets:
 
   # # With MCP server
   # - name: with-mcp
+  #   model: sonnet
   #   skills: []
   #   mcp_servers:
   #     dbt:
@@ -37,6 +44,7 @@ sets:
 
   # # With setup commands (run before Claude)
   # - name: with-setup
+  #   model: sonnet
   #   setup:
   #     - npx skills add https://github.com/dbt-labs/dbt-agent-skills -a claude-code -y
   #   skills: []
@@ -48,6 +56,7 @@ sets:
 
   # # Full setup: skill + MCP server
   # - name: with-skill-and-mcp
+  #   model: sonnet
   #   skills:
   #     - skills/my-skill
   #   mcp_servers:
@@ -66,3 +75,20 @@ sets:
   #     - Skill
   #     - mcp__dbt__*
   #   extra_prompt: Check if any skill can help with this task.
+
+  # # Compare a stronger model on the same setup
+  # - name: with-mcp-opus
+  #   model: opus
+  #   skills: []
+  #   mcp_servers:
+  #     dbt:
+  #       command: uvx
+  #       args:
+  #         - --env-file
+  #         - .env
+  #         - dbt-mcp@latest
+  #   allowed_tools:
+  #     - Read
+  #     - Glob
+  #     - Grep
+  #     - mcp__dbt__*

--- a/evals/tests/test_cli_commands.py
+++ b/evals/tests/test_cli_commands.py
@@ -319,8 +319,34 @@ class TestReportCommand:
 class TestReviewCommand:
     """Tests for the 'review' command."""
 
-    def test_review_finds_transcripts(self, tmp_path: Path, monkeypatch: MagicMock) -> None:
-        """review command finds and reports transcript files."""
+    def test_review_generates_index_page(self, tmp_path: Path, monkeypatch: MagicMock) -> None:
+        """review command generates a single review.html index and opens it."""
+        monkeypatch.chdir(tmp_path)
+
+        # Create scenarios dir so find_evals_root can locate evals root
+        (tmp_path / "scenarios").mkdir()
+
+        runs_dir = tmp_path / "runs"
+        run_dir = runs_dir / "2024-01-15-120000"
+        skill_set_dir = run_dir / "test-scenario" / "skill-set-1"
+        transcript_dir = skill_set_dir / "transcript"
+        transcript_dir.mkdir(parents=True)
+        (transcript_dir / "index.html").write_text("<html></html>")
+
+        with patch("skill_eval.cli.is_interactive", return_value=False):
+            with patch("webbrowser.open") as mock_open:
+                result = runner.invoke(app, ["review"])
+
+        assert result.exit_code == 0
+        review_file = run_dir / "review.html"
+        assert "Review index:" in result.output
+        assert review_file.exists()
+        assert "test-scenario" in review_file.read_text()
+        assert "skill-set-1" in review_file.read_text()
+        mock_open.assert_called_once_with(f"file://{review_file}")
+
+    def test_review_tabs_flag_opens_each_transcript(self, tmp_path: Path, monkeypatch: MagicMock) -> None:
+        """review --tabs opens each transcript individually, like the old default."""
         monkeypatch.chdir(tmp_path)
 
         # Create scenarios dir so find_evals_root can locate evals root
@@ -334,7 +360,7 @@ class TestReviewCommand:
 
         with patch("skill_eval.cli.is_interactive", return_value=False):
             with patch("webbrowser.open") as mock_open:
-                result = runner.invoke(app, ["review"])
+                result = runner.invoke(app, ["review", "--tabs"])
 
         assert result.exit_code == 0
         assert "Opening 1 transcript" in result.output
@@ -541,7 +567,8 @@ class TestBaseDirOption:
             result = runner.invoke(app, ["review", "--base-dir", str(custom_dir)])
 
         assert result.exit_code == 0
-        assert "Opening 1 transcript" in result.output
+        assert "Review index:" in result.output
+        assert (run_dir / "review.html").exists()
 
 
 class TestVersionFlag:

--- a/evals/tests/test_cli_commands.py
+++ b/evals/tests/test_cli_commands.py
@@ -38,7 +38,7 @@ class TestRunCommand:
         scenario_dir.mkdir(parents=True)
         (scenario_dir / "prompt.txt").write_text("Do something")
         (scenario_dir / "skill-sets.yaml").write_text(
-            yaml.dump({"sets": [{"name": "baseline", "skills": []}]})
+            yaml.dump({"sets": [{"name": "baseline", "model": "sonnet", "skills": []}]})
         )
 
         # Mock the runner to avoid actually running Claude
@@ -63,7 +63,7 @@ class TestRunCommand:
         scenario_dir.mkdir(parents=True)
         (scenario_dir / "prompt.txt").write_text("Do something")
         (scenario_dir / "skill-sets.yaml").write_text(
-            yaml.dump({"sets": [{"name": "baseline", "skills": []}]})
+            yaml.dump({"sets": [{"name": "baseline", "model": "sonnet", "skills": []}]})
         )
 
         with patch("skill_eval.runner.Runner") as MockRunner:
@@ -86,7 +86,7 @@ class TestRunCommand:
         scenario_dir.mkdir(parents=True)
         (scenario_dir / "prompt.txt").write_text("Do something")
         (scenario_dir / "skill-sets.yaml").write_text(
-            yaml.dump({"sets": [{"name": "set1"}, {"name": "set2"}]})
+            yaml.dump({"sets": [{"name": "set1", "model": "sonnet"}, {"name": "set2", "model": "sonnet"}]})
         )
 
         with patch("skill_eval.runner.Runner") as MockRunner:
@@ -108,7 +108,7 @@ class TestRunCommand:
             d = scenarios_dir / name
             d.mkdir(parents=True)
             (d / "prompt.txt").write_text("Do something")
-            (d / "skill-sets.yaml").write_text(yaml.dump({"sets": [{"name": "baseline"}]}))
+            (d / "skill-sets.yaml").write_text(yaml.dump({"sets": [{"name": "baseline", "model": "sonnet"}]}))
 
         with patch("skill_eval.runner.Runner") as MockRunner:
             mock_runner = MockRunner.return_value
@@ -389,7 +389,7 @@ class TestRootDiscovery:
         scenario_dir.mkdir(parents=True)
         (scenario_dir / "prompt.txt").write_text("Do something")
         (scenario_dir / "skill-sets.yaml").write_text(
-            yaml.dump({"sets": [{"name": "baseline", "skills": []}]})
+            yaml.dump({"sets": [{"name": "baseline", "model": "sonnet", "skills": []}]})
         )
 
         monkeypatch.chdir(tmp_path)
@@ -513,7 +513,7 @@ class TestBaseDirOption:
         scenario_dir.mkdir(parents=True)
         (scenario_dir / "prompt.txt").write_text("Do something")
         (scenario_dir / "skill-sets.yaml").write_text(
-            yaml.dump({"sets": [{"name": "baseline", "skills": []}]})
+            yaml.dump({"sets": [{"name": "baseline", "model": "sonnet", "skills": []}]})
         )
         monkeypatch.chdir(tmp_path)
 

--- a/evals/tests/test_cli_commands.py
+++ b/evals/tests/test_cli_commands.py
@@ -398,8 +398,8 @@ class TestReviewCommand:
         assert "Opening 1 transcript" in result.output
         mock_open.assert_called_once()
 
-    def test_review_no_transcripts_errors(self, tmp_path: Path, monkeypatch: MagicMock) -> None:
-        """review command errors when no transcripts found."""
+    def test_review_tabs_no_transcripts_errors(self, tmp_path: Path, monkeypatch: MagicMock) -> None:
+        """review --tabs errors when no transcripts found."""
         monkeypatch.chdir(tmp_path)
 
         # Create scenarios dir so find_evals_root can locate evals root
@@ -410,10 +410,34 @@ class TestReviewCommand:
         run_dir.mkdir(parents=True)
 
         with patch("skill_eval.cli.is_interactive", return_value=False):
-            result = runner.invoke(app, ["review"])
+            result = runner.invoke(app, ["review", "--tabs"])
 
         assert result.exit_code == 1
         assert "No transcripts found" in result.output
+
+    def test_review_generates_index_without_transcripts(self, tmp_path: Path, monkeypatch: MagicMock) -> None:
+        """review (default) still generates an index page when transcripts are missing."""
+        monkeypatch.chdir(tmp_path)
+
+        # Create scenarios dir so find_evals_root can locate evals root
+        (tmp_path / "scenarios").mkdir()
+
+        runs_dir = tmp_path / "runs"
+        run_dir = runs_dir / "2024-01-15-120000"
+        skill_set_dir = run_dir / "test-scenario" / "skill-set-1"
+        skill_set_dir.mkdir(parents=True)
+        (skill_set_dir / "metadata.yaml").write_text(yaml.dump({"success": True}))
+        # No transcript/index.html - e.g. transcript generation failed or was disabled
+
+        with patch("skill_eval.cli.is_interactive", return_value=False):
+            with patch("webbrowser.open") as mock_open:
+                result = runner.invoke(app, ["review"])
+
+        assert result.exit_code == 0
+        review_file = run_dir / "review.html"
+        assert review_file.exists()
+        assert "test-scenario" in review_file.read_text()
+        mock_open.assert_called_once_with(f"file://{review_file}")
 
     def test_review_latest_flag(self, tmp_path: Path, monkeypatch: MagicMock) -> None:
         """review --latest uses most recent run."""

--- a/evals/tests/test_cli_commands.py
+++ b/evals/tests/test_cli_commands.py
@@ -215,6 +215,38 @@ class TestGradeCommand:
         mock_grader.assert_called_once()
         assert (run_dir / "grades.yaml").exists()
 
+    def test_grade_auto_without_run_id_echoes_resolved_run_name(
+        self, tmp_path: Path, monkeypatch: MagicMock
+    ) -> None:
+        """grade --auto with no run_id echoes the resolved run name, not 'None'."""
+        monkeypatch.chdir(tmp_path)
+
+        scenarios_dir = tmp_path / "scenarios"
+        scenario_dir = scenarios_dir / "test-scenario"
+        scenario_dir.mkdir(parents=True)
+        (scenario_dir / "scenario.md").write_text("# Test")
+        (scenario_dir / "prompt.txt").write_text("Do something")
+
+        runs_dir = tmp_path / "runs"
+        run_dir = runs_dir / "2024-01-15-120000"
+        skill_set_dir = run_dir / "test-scenario" / "skill-set-1"
+        skill_set_dir.mkdir(parents=True)
+        (skill_set_dir / "output.md").write_text("I did the thing")
+        (skill_set_dir / "metadata.yaml").write_text(
+            yaml.dump({"skills_available": ["skill-a"], "skills_invoked": ["skill-a"]})
+        )
+
+        with patch("skill_eval.grader.call_claude_grader") as mock_grader:
+            mock_grader.return_value = "success: true\nscore: 4\ntool_usage: appropriate\nnotes: Good"
+
+            with patch("skill_eval.cli.is_interactive", return_value=False):
+                result = runner.invoke(app, ["grade", "--auto"])
+
+        assert result.exit_code == 0
+        assert "Auto-grading run: 2024-01-15-120000" in result.output
+        assert "Run: uv run skill-eval report 2024-01-15-120000" in result.output
+        assert "None" not in result.output
+
     def test_grade_auto_computes_skill_usage(self, tmp_path: Path, monkeypatch: MagicMock) -> None:
         """grade --auto computes skill usage from metadata."""
         monkeypatch.chdir(tmp_path)

--- a/evals/tests/test_grader.py
+++ b/evals/tests/test_grader.py
@@ -10,6 +10,7 @@ from skill_eval.grader import (
     build_grading_prompt,
     call_claude_grader,
     compute_skill_usage,
+    load_grades,
     parse_grade_response,
 )
 from skill_eval.models import Grade
@@ -318,3 +319,30 @@ def test_compute_skill_usage_handles_extra_invocations() -> None:
 
     assert invoked == ["skill-a", "skill-external"]
     assert pct == 100.0  # 1/1 available skill was used
+
+
+def test_load_grades_returns_empty_dict_when_missing(tmp_path: Path) -> None:
+    """load_grades returns {} when grades.yaml doesn't exist."""
+    assert load_grades(tmp_path) == {}
+
+
+def test_load_grades_returns_empty_dict_for_empty_file(tmp_path: Path) -> None:
+    """An empty grades.yaml (parses to None) doesn't crash load_grades."""
+    (tmp_path / "grades.yaml").write_text("")
+
+    assert load_grades(tmp_path) == {}
+
+
+def test_load_grades_returns_empty_dict_for_non_mapping_yaml(tmp_path: Path) -> None:
+    """A grades.yaml that parses to a list, not a mapping, doesn't crash load_grades."""
+    (tmp_path / "grades.yaml").write_text("- oops\n- not\n- a\n- mapping\n")
+
+    assert load_grades(tmp_path) == {}
+
+
+def test_load_grades_returns_valid_grades(tmp_path: Path) -> None:
+    """A well-formed grades.yaml is returned as-is."""
+    grades = {"graded_at": "2026-01-01", "grader": "human", "results": {"a": {"b": {"success": True}}}}
+    (tmp_path / "grades.yaml").write_text(yaml.dump(grades))
+
+    assert load_grades(tmp_path) == grades

--- a/evals/tests/test_models.py
+++ b/evals/tests/test_models.py
@@ -105,6 +105,18 @@ def test_load_scenario_rejects_non_mapping_set_entry(tmp_path: Path) -> None:
         load_scenario(scenario_dir)
 
 
+def test_load_scenario_rejects_set_entry_missing_name(tmp_path: Path) -> None:
+    """A set entry without a 'name' raises a clear ValueError, not a KeyError."""
+    scenario_dir = tmp_path / "test-scenario"
+    scenario_dir.mkdir()
+    (scenario_dir / "scenario.md").write_text("# Test")
+    (scenario_dir / "prompt.txt").write_text("Fix the bug")
+    (scenario_dir / "skill-sets.yaml").write_text("sets:\n  - model: sonnet\n    skills: []\n")
+
+    with pytest.raises(ValueError, match="test-scenario"):
+        load_scenario(scenario_dir)
+
+
 def test_load_scenario_strict_mcp_config_defaults_true(tmp_path: Path) -> None:
     """strict_mcp_config defaults to True when omitted from skill-sets.yaml."""
     scenario_dir = tmp_path / "test-scenario"

--- a/evals/tests/test_models.py
+++ b/evals/tests/test_models.py
@@ -57,6 +57,30 @@ sets:
         load_scenario(scenario_dir)
 
 
+def test_load_scenario_rejects_empty_skill_sets_yaml(tmp_path: Path) -> None:
+    """An empty or non-mapping skill-sets.yaml raises a clear ValueError, not AttributeError."""
+    scenario_dir = tmp_path / "test-scenario"
+    scenario_dir.mkdir()
+    (scenario_dir / "scenario.md").write_text("# Test")
+    (scenario_dir / "prompt.txt").write_text("Fix the bug")
+    (scenario_dir / "skill-sets.yaml").write_text("")
+
+    with pytest.raises(ValueError, match="test-scenario"):
+        load_scenario(scenario_dir)
+
+
+def test_load_scenario_rejects_non_mapping_skill_sets_yaml(tmp_path: Path) -> None:
+    """A skill-sets.yaml that's a list (not a mapping) raises a clear ValueError."""
+    scenario_dir = tmp_path / "test-scenario"
+    scenario_dir.mkdir()
+    (scenario_dir / "scenario.md").write_text("# Test")
+    (scenario_dir / "prompt.txt").write_text("Fix the bug")
+    (scenario_dir / "skill-sets.yaml").write_text("- just\n- a\n- list\n")
+
+    with pytest.raises(ValueError, match="test-scenario"):
+        load_scenario(scenario_dir)
+
+
 def test_load_scenario_strict_mcp_config_defaults_true(tmp_path: Path) -> None:
     """strict_mcp_config defaults to True when omitted from skill-sets.yaml."""
     scenario_dir = tmp_path / "test-scenario"

--- a/evals/tests/test_models.py
+++ b/evals/tests/test_models.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from skill_eval.models import load_scenario
 
 
@@ -15,8 +17,10 @@ def test_load_scenario_parses_skill_sets(tmp_path: Path) -> None:
         """
 sets:
   - name: no-skills
+    model: sonnet
     skills: []
   - name: with-debug
+    model: sonnet
     skills:
       - debugging-dbt-errors/baseline.md
 """
@@ -31,6 +35,51 @@ sets:
     assert scenario.skill_sets[0].skills == []
     assert scenario.skill_sets[1].name == "with-debug"
     assert scenario.skill_sets[1].skills == ["debugging-dbt-errors/baseline.md"]
+    assert scenario.skill_sets[0].model == "sonnet"
+    assert scenario.skill_sets[1].model == "sonnet"
+
+
+def test_load_scenario_requires_model(tmp_path: Path) -> None:
+    """Loading a skill-sets.yaml without a model field raises a clear error."""
+    scenario_dir = tmp_path / "test-scenario"
+    scenario_dir.mkdir()
+    (scenario_dir / "scenario.md").write_text("# Test")
+    (scenario_dir / "prompt.txt").write_text("Fix the bug")
+    (scenario_dir / "skill-sets.yaml").write_text(
+        """
+sets:
+  - name: no-model
+    skills: []
+"""
+    )
+
+    with pytest.raises(ValueError, match="no-model.*model"):
+        load_scenario(scenario_dir)
+
+
+def test_load_scenario_strict_mcp_config_defaults_true(tmp_path: Path) -> None:
+    """strict_mcp_config defaults to True when omitted from skill-sets.yaml."""
+    scenario_dir = tmp_path / "test-scenario"
+    scenario_dir.mkdir()
+    (scenario_dir / "scenario.md").write_text("# Test")
+    (scenario_dir / "prompt.txt").write_text("Fix the bug")
+    (scenario_dir / "skill-sets.yaml").write_text(
+        """
+sets:
+  - name: default
+    model: sonnet
+    skills: []
+  - name: opted-out
+    model: sonnet
+    skills: []
+    strict_mcp_config: false
+"""
+    )
+
+    scenario = load_scenario(scenario_dir)
+
+    assert scenario.skill_sets[0].strict_mcp_config is True
+    assert scenario.skill_sets[1].strict_mcp_config is False
 
 
 def test_load_scenario_parses_mcp_servers(tmp_path: Path) -> None:
@@ -43,6 +92,7 @@ def test_load_scenario_parses_mcp_servers(tmp_path: Path) -> None:
         """
 sets:
   - name: with-mcp
+    model: sonnet
     skills: []
     mcp_servers:
       dbt:
@@ -74,6 +124,7 @@ def test_load_scenario_parses_allowed_tools(tmp_path: Path) -> None:
         """
 sets:
   - name: restricted
+    model: sonnet
     skills: []
     allowed_tools:
       - Read
@@ -99,8 +150,10 @@ def test_load_scenario_parses_extra_prompt(tmp_path: Path) -> None:
         """
 sets:
   - name: no-extra
+    model: sonnet
     skills: []
   - name: with-extra
+    model: sonnet
     skills: []
     extra_prompt: Check if any skill can help with this task.
 """
@@ -122,8 +175,10 @@ def test_load_scenario_parses_setup_commands(tmp_path: Path) -> None:
         """
 sets:
   - name: no-setup
+    model: sonnet
     skills: []
   - name: with-setup
+    model: sonnet
     setup:
       - npx @anthropic-ai/claude-code-skills add https://example.com/skill
       - echo "ready"
@@ -150,6 +205,7 @@ def test_load_scenario_parses_multiline_extra_prompt(tmp_path: Path) -> None:
         """
 sets:
   - name: with-multiline
+    model: sonnet
     skills: []
     extra_prompt: |
       Before starting:

--- a/evals/tests/test_models.py
+++ b/evals/tests/test_models.py
@@ -81,6 +81,30 @@ def test_load_scenario_rejects_non_mapping_skill_sets_yaml(tmp_path: Path) -> No
         load_scenario(scenario_dir)
 
 
+def test_load_scenario_rejects_non_list_sets_key(tmp_path: Path) -> None:
+    """A 'sets' key that isn't a list (e.g. a mapping) raises a clear ValueError."""
+    scenario_dir = tmp_path / "test-scenario"
+    scenario_dir.mkdir()
+    (scenario_dir / "scenario.md").write_text("# Test")
+    (scenario_dir / "prompt.txt").write_text("Fix the bug")
+    (scenario_dir / "skill-sets.yaml").write_text("sets:\n  foo: bar\n")
+
+    with pytest.raises(ValueError, match="test-scenario"):
+        load_scenario(scenario_dir)
+
+
+def test_load_scenario_rejects_non_mapping_set_entry(tmp_path: Path) -> None:
+    """A set entry that isn't a mapping (e.g. a bare string) raises a clear ValueError."""
+    scenario_dir = tmp_path / "test-scenario"
+    scenario_dir.mkdir()
+    (scenario_dir / "scenario.md").write_text("# Test")
+    (scenario_dir / "prompt.txt").write_text("Fix the bug")
+    (scenario_dir / "skill-sets.yaml").write_text("sets:\n  - just-a-string\n")
+
+    with pytest.raises(ValueError, match="test-scenario"):
+        load_scenario(scenario_dir)
+
+
 def test_load_scenario_strict_mcp_config_defaults_true(tmp_path: Path) -> None:
     """strict_mcp_config defaults to True when omitted from skill-sets.yaml."""
     scenario_dir = tmp_path / "test-scenario"

--- a/evals/tests/test_reporter.py
+++ b/evals/tests/test_reporter.py
@@ -160,6 +160,19 @@ def test_collect_review_rows_reads_metadata_and_links(tmp_path: Path) -> None:
     assert row["grade"] is None  # No grades.yaml in this run
 
 
+def test_collect_review_rows_handles_non_mapping_metadata(tmp_path: Path) -> None:
+    """A corrupt/partial metadata.yaml that parses to a non-mapping doesn't crash review."""
+    run_dir = tmp_path / "runs" / "2026-01-01-000000"
+    skill_set_dir = run_dir / "my-scenario" / "with-mcp"
+    skill_set_dir.mkdir(parents=True)
+    # e.g. a truncated write leaving only a YAML list behind
+    (skill_set_dir / "metadata.yaml").write_text("- oops\n- not\n- a\n- mapping\n")
+
+    rows = collect_review_rows(run_dir)
+
+    assert rows[0]["metadata"] == {}
+
+
 def test_collect_review_rows_attaches_grade_when_present(tmp_path: Path) -> None:
     """collect_review_rows pulls in the score from grades.yaml if it exists."""
     run_dir = _make_run(tmp_path)

--- a/evals/tests/test_reporter.py
+++ b/evals/tests/test_reporter.py
@@ -9,6 +9,7 @@ from skill_eval.reporter import (
     _format_cost,
     _format_duration,
     _format_tokens,
+    _safe_number,
     collect_review_rows,
     generate_review_html,
 )
@@ -241,3 +242,43 @@ def test_generate_review_html_sort_js_reads_nested_data_sort(tmp_path: Path) -> 
     assert 'nested = td.querySelector("[data-sort]")' in html
     # The old broken pattern must be gone
     assert "a.children[idx].dataset.sort" not in html
+
+
+def test_safe_number() -> None:
+    assert _safe_number(3) == 3
+    assert _safe_number(3.5) == 3.5
+    assert _safe_number(None) is None
+    assert _safe_number("3") is None  # strings aren't coerced, just defaulted
+    assert _safe_number(True) is None  # bools aren't numbers here
+    assert _safe_number("oops", default=0) == 0
+
+
+def test_generate_review_html_handles_corrupted_numeric_metadata(tmp_path: Path) -> None:
+    """Non-numeric values in hand-edited metadata.yaml/grades.yaml don't crash
+    the page or break out of an HTML attribute unescaped."""
+    run_dir = _make_run(tmp_path)
+    metadata_file = run_dir / "my-scenario" / "with-mcp" / "metadata.yaml"
+    metadata = yaml.safe_load(metadata_file.read_text())
+    metadata["num_turns"] = '"><script>alert(1)</script>'
+    metadata["tool_call_count"] = "not-a-number"
+    metadata["duration_ms"] = "not-a-number"
+    metadata["total_cost_usd"] = "not-a-number"
+    metadata["input_tokens"] = "not-a-number"
+    metadata["output_tokens"] = "not-a-number"
+    metadata["model"] = ["not", "a", "string"]
+    metadata["subagents_used"] = True
+    metadata["subagent_count"] = "not-a-number"
+    metadata["subagent_tool_call_count"] = '"><img src=x>'
+    metadata["subagent_tools_used"] = ["Read"]
+    metadata_file.write_text(yaml.dump(metadata))
+
+    grades = {"results": {"my-scenario": {"with-mcp": {"success": True, "score": '"><script>'}}}}
+    (run_dir / "grades.yaml").write_text(yaml.dump(grades))
+
+    html = generate_review_html(run_dir)  # must not raise
+
+    # The payloads themselves must not appear unescaped (the page's own
+    # legitimate <script> tag for sorting is fine and expected).
+    assert '"><script>alert(1)</script>' not in html
+    assert '"><img src=x>' not in html
+    assert '"><script>' not in html

--- a/evals/tests/test_reporter.py
+++ b/evals/tests/test_reporter.py
@@ -1,6 +1,17 @@
 """Tests for skill_eval reporter."""
 
-from skill_eval.reporter import _compute_skill_set_stats
+from pathlib import Path
+
+import yaml
+
+from skill_eval.reporter import (
+    _compute_skill_set_stats,
+    _format_cost,
+    _format_duration,
+    _format_tokens,
+    collect_review_rows,
+    generate_review_html,
+)
 
 
 def test_compute_skill_set_stats_aggregates_across_scenarios() -> None:
@@ -88,3 +99,114 @@ def test_compute_skill_set_stats_handles_empty_results() -> None:
     stats = _compute_skill_set_stats({})
 
     assert stats == {}
+
+
+def test_format_duration() -> None:
+    assert _format_duration(None) == "-"
+    assert _format_duration(3200) == "3.2s"
+    assert _format_duration(65000) == "1m 05s"
+
+
+def test_format_cost() -> None:
+    assert _format_cost(None) == "-"
+    assert _format_cost(0.1426) == "$0.1426"
+
+
+def test_format_tokens() -> None:
+    assert _format_tokens(None) == "-"
+    assert _format_tokens(125241) == "125,241"
+
+
+def _make_run(tmp_path: Path) -> Path:
+    run_dir = tmp_path / "runs" / "2026-01-01-000000"
+    skill_set_dir = run_dir / "my-scenario" / "with-mcp"
+    skill_set_dir.mkdir(parents=True)
+    metadata = {
+        "success": True,
+        "skills_invoked": ["my-skill"],
+        "skills_available": ["my-skill"],
+        "skills_available_other": ["design-sync"],
+        "tools_used": ["Read", "mcp__dbt__list_projects"],
+        "tool_call_count": 5,
+        "mcp_servers": [{"name": "dbt", "status": "connected"}],
+        "model": "claude-sonnet-5",
+        "duration_ms": 52856,
+        "num_turns": 8,
+        "total_cost_usd": 0.2031766,
+        "input_tokens": 267958,
+        "output_tokens": 3130,
+    }
+    (skill_set_dir / "metadata.yaml").write_text(yaml.dump(metadata))
+    (skill_set_dir / "output.md").write_text("Some output")
+    transcript_dir = skill_set_dir / "transcript"
+    transcript_dir.mkdir()
+    (transcript_dir / "index.html").write_text("<html></html>")
+    return run_dir
+
+
+def test_collect_review_rows_reads_metadata_and_links(tmp_path: Path) -> None:
+    """collect_review_rows gathers metadata and relative links per skill set."""
+    run_dir = _make_run(tmp_path)
+
+    rows = collect_review_rows(run_dir)
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["scenario"] == "my-scenario"
+    assert row["skill_set"] == "with-mcp"
+    assert row["metadata"]["total_cost_usd"] == 0.2031766
+    assert row["transcript_rel"] == "my-scenario/with-mcp/transcript/index.html"
+    assert row["output_rel"] == "my-scenario/with-mcp/output.md"
+    assert row["grade"] is None  # No grades.yaml in this run
+
+
+def test_collect_review_rows_attaches_grade_when_present(tmp_path: Path) -> None:
+    """collect_review_rows pulls in the score from grades.yaml if it exists."""
+    run_dir = _make_run(tmp_path)
+    grades = {"results": {"my-scenario": {"with-mcp": {"success": True, "score": 4}}}}
+    (run_dir / "grades.yaml").write_text(yaml.dump(grades))
+
+    rows = collect_review_rows(run_dir)
+
+    assert rows[0]["grade"]["score"] == 4
+
+
+def test_generate_review_html_includes_key_metrics_and_links(tmp_path: Path) -> None:
+    """The generated review page surfaces cost, tool calls, and transcript links."""
+    run_dir = _make_run(tmp_path)
+
+    html = generate_review_html(run_dir)
+
+    assert "my-scenario" in html
+    assert "with-mcp" in html
+    assert "$0.2032" in html
+    assert ">5<" in html  # tool_call_count
+    assert 'href="my-scenario/with-mcp/transcript/index.html"' in html
+    assert "design-sync" not in html  # skills_available_other isn't shown as if configured
+
+
+def test_generate_review_html_flags_subagent_usage(tmp_path: Path) -> None:
+    """The review page shows a subagent count when a set used the Task tool."""
+    run_dir = _make_run(tmp_path)
+    metadata_file = run_dir / "my-scenario" / "with-mcp" / "metadata.yaml"
+    metadata = yaml.safe_load(metadata_file.read_text())
+    metadata["subagents_used"] = True
+    metadata["subagent_count"] = 2
+    metadata["subagent_tool_call_count"] = 30
+    metadata["subagent_tools_used"] = ["Read", "Glob"]
+    metadata_file.write_text(yaml.dump(metadata))
+
+    html = generate_review_html(run_dir)
+
+    assert ">2<" in html
+    assert "Read, Glob" in html
+    assert "30 calls" in html
+
+
+def test_generate_review_html_shows_dash_when_no_subagents(tmp_path: Path) -> None:
+    """Sets that never spawned a subagent show a dash, not a false zero-count row."""
+    run_dir = _make_run(tmp_path)
+
+    html = generate_review_html(run_dir)
+
+    assert "<th data-idx=\"9\" data-numeric=\"1\">Subagents</th>" in html

--- a/evals/tests/test_reporter.py
+++ b/evals/tests/test_reporter.py
@@ -210,3 +210,21 @@ def test_generate_review_html_shows_dash_when_no_subagents(tmp_path: Path) -> No
     html = generate_review_html(run_dir)
 
     assert "<th data-idx=\"9\" data-numeric=\"1\">Subagents</th>" in html
+
+
+def test_generate_review_html_sort_js_reads_nested_data_sort(tmp_path: Path) -> None:
+    """Sort JS must read data-sort from the nested <span>, not the <td> itself.
+
+    Numeric columns (Duration, Cost, Score, Subagents, Skills) put their raw
+    sortable value on a nested <span data-sort="...">, since the <td> holds
+    formatted display text. The click handler has to look there, not just at
+    the <td>'s own (nonexistent) dataset.
+    """
+    run_dir = _make_run(tmp_path)
+
+    html = generate_review_html(run_dir)
+
+    assert "sortValue(a.children[idx])" in html
+    assert 'nested = td.querySelector("[data-sort]")' in html
+    # The old broken pattern must be gone
+    assert "a.children[idx].dataset.sort" not in html

--- a/evals/tests/test_runner.py
+++ b/evals/tests/test_runner.py
@@ -326,6 +326,60 @@ def test_run_scenario_scopes_skills_available_to_configured_skills(tmp_path: Pat
     assert metadata["skills_available_other"] == ["design-sync", "verify"]
 
 
+def test_run_scenario_scopes_skills_installed_by_setup_command(tmp_path: Path) -> None:
+    """A skill installed by a setup command (not skill_set.skills) still counts as configured."""
+    from skill_eval.models import Scenario, SkillSet
+
+    evals_dir = tmp_path / "evals"
+    evals_dir.mkdir()
+    (evals_dir / "runs").mkdir()
+
+    scenario_dir = tmp_path / "scenarios" / "test"
+    scenario_dir.mkdir(parents=True)
+
+    scenario = Scenario(name="test-scenario", path=scenario_dir, prompt="Fix the bug", skill_sets=[])
+    # No `skills:` entries - this skill only shows up via the setup command,
+    # mirroring `npx skills add <url> -a claude-code` installing into
+    # .claude/skills after prepare_environment has already run.
+    skill_set = SkillSet(
+        name="with-setup-skill",
+        model="sonnet",
+        skills=[],
+        setup=[
+            "mkdir -p .claude/skills/setup-installed-skill && "
+            "printf -- '---\\nname: setup-installed-skill\\ndescription: test\\n---\\n\\nBody' "
+            "> .claude/skills/setup-installed-skill/SKILL.md"
+        ],
+    )
+
+    runner = Runner(evals_dir=evals_dir)
+    run_dir = runner.create_run_dir()
+
+    def mock_run_claude(env_dir, prompt, mcp_config_path, allowed_tools, model=None, strict_mcp_config=True, ctx_logger=None, extra_env=None):
+        return (
+            {
+                "output_text": "Done",
+                "skills_invoked": ["setup-installed-skill"],
+                "tools_used": [],
+                "skills_available": ["setup-installed-skill", "design-sync"],
+            },
+            True,
+            None,
+            "",
+        )
+
+    with patch.object(runner, "run_claude", side_effect=mock_run_claude):
+        result = runner.run_scenario(scenario, skill_set, run_dir)
+
+    assert result.success is True
+
+    import yaml
+
+    metadata = yaml.safe_load((run_dir / "test-scenario" / "with-setup-skill" / "metadata.yaml").read_text())
+    assert metadata["skills_available"] == ["setup-installed-skill"]
+    assert metadata["skills_available_other"] == ["design-sync"]
+
+
 def test_runner_is_url_detection(tmp_path: Path) -> None:
     """Runner correctly identifies HTTP(S) URLs."""
     evals_dir = tmp_path / "evals"

--- a/evals/tests/test_runner.py
+++ b/evals/tests/test_runner.py
@@ -131,6 +131,68 @@ def test_parse_json_output_extracts_metadata(tmp_path: Path) -> None:
     assert result["output_tokens"] == 100
     assert "Read" in result["tools_used"]
     assert "I found the issue." in result["output_text"]
+    assert result["tool_call_count"] == 1
+    assert result["subagents_used"] is False
+    assert result["subagent_count"] == 0
+
+
+def test_parse_json_output_separates_subagent_activity(tmp_path: Path) -> None:
+    """Subagent (sidechain) text/tools are kept out of the main-thread counters."""
+    evals_dir = tmp_path / "evals"
+    evals_dir.mkdir()
+    runner = Runner(evals_dir=evals_dir)
+
+    ndjson = """{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Task","input":{"subagent_type":"Explore"}}]},"parent_tool_use_id":null}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Exploring the repo..."}]},"parent_tool_use_id":"toolu_task1"}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{}}]},"parent_tool_use_id":"toolu_task1"}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Grep","input":{}}]},"parent_tool_use_id":"toolu_task1"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Here is the final answer."}]},"parent_tool_use_id":null}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{}}]},"parent_tool_use_id":null}"""
+
+    result = runner._parse_json_output(ndjson)
+
+    # Main-thread output only - no subagent narration leaking into output.md
+    assert result["output_text"] == "Here is the final answer."
+
+    # Main-thread tool counters exclude the subagent's calls
+    assert result["tool_call_count"] == 2  # Task + Read (main thread)
+    assert sorted(result["tools_used"]) == ["Read", "Task"]
+
+    # Subagent activity tracked separately
+    assert result["subagents_used"] is True
+    assert result["subagent_count"] == 1
+    assert result["subagent_tool_call_count"] == 2  # Read + Grep (sidechain)
+    assert sorted(result["subagent_tools_used"]) == ["Grep", "Read"]
+
+
+def test_parse_json_output_merges_skills_invoked_across_subagents(tmp_path: Path) -> None:
+    """A Skill invoked by a subagent still counts as invoked for grading."""
+    evals_dir = tmp_path / "evals"
+    evals_dir.mkdir()
+    runner = Runner(evals_dir=evals_dir)
+
+    ndjson = """{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Task","input":{}}]},"parent_tool_use_id":null}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Skill","input":{"skill":"debugging-dbt-errors"}}]},"parent_tool_use_id":"toolu_task1"}"""
+
+    result = runner._parse_json_output(ndjson)
+
+    assert result["skills_invoked"] == ["debugging-dbt-errors"]
+
+
+def test_parse_json_output_counts_repeated_tool_calls(tmp_path: Path) -> None:
+    """tool_call_count counts every call, not just distinct tool names."""
+    evals_dir = tmp_path / "evals"
+    evals_dir.mkdir()
+    runner = Runner(evals_dir=evals_dir)
+
+    ndjson = """{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Grep","input":{}}]}}"""
+
+    result = runner._parse_json_output(ndjson)
+
+    assert result["tool_call_count"] == 3
+    assert sorted(result["tools_used"]) == ["Grep", "Read"]
 
 
 def test_parse_json_output_handles_empty_input(tmp_path: Path) -> None:
@@ -177,6 +239,91 @@ def test_runner_prepares_environment_with_folder_path(tmp_path: Path) -> None:
     # Supporting files are also copied
     assert (skill_dest / "helper.sh").exists()
     assert "helper" in (skill_dest / "helper.sh").read_text()
+
+
+def test_configured_skill_names_uses_frontmatter_name(tmp_path: Path) -> None:
+    """_configured_skill_names reads the `name` field from SKILL.md frontmatter."""
+    evals_dir = tmp_path / "evals"
+    evals_dir.mkdir()
+    runner = Runner(evals_dir=evals_dir)
+
+    skills_dir = tmp_path / "skills"
+    skill_folder = skills_dir / "on-disk-folder-name"
+    skill_folder.mkdir(parents=True)
+    (skill_folder / "SKILL.md").write_text(
+        "---\nname: real-frontmatter-name\ndescription: test\n---\n\nBody"
+    )
+
+    assert runner._configured_skill_names(skills_dir) == ["real-frontmatter-name"]
+
+
+def test_configured_skill_names_falls_back_to_folder_name(tmp_path: Path) -> None:
+    """_configured_skill_names falls back to the folder name without frontmatter."""
+    evals_dir = tmp_path / "evals"
+    evals_dir.mkdir()
+    runner = Runner(evals_dir=evals_dir)
+
+    skills_dir = tmp_path / "skills"
+    skill_folder = skills_dir / "no-frontmatter-skill"
+    skill_folder.mkdir(parents=True)
+    (skill_folder / "SKILL.md").write_text("Just a body, no frontmatter")
+
+    assert runner._configured_skill_names(skills_dir) == ["no-frontmatter-skill"]
+
+
+def test_configured_skill_names_handles_missing_dir(tmp_path: Path) -> None:
+    """_configured_skill_names returns [] when the skills dir doesn't exist."""
+    evals_dir = tmp_path / "evals"
+    evals_dir.mkdir()
+    runner = Runner(evals_dir=evals_dir)
+
+    assert runner._configured_skill_names(tmp_path / "does-not-exist") == []
+
+
+def test_run_scenario_scopes_skills_available_to_configured_skills(tmp_path: Path) -> None:
+    """metadata.yaml's skills_available only includes skills this eval added."""
+    from skill_eval.models import Scenario, SkillSet
+
+    evals_dir = tmp_path / "evals"
+    evals_dir.mkdir()
+    (evals_dir / "runs").mkdir()
+
+    # skill lives in repo_dir (evals_dir.parent), same layout as other skill-copy tests
+    repo_dir = evals_dir.parent
+    skill_dir = repo_dir / "skills" / "my-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: my-skill\ndescription: test\n---\n\nBody")
+
+    scenario_dir = tmp_path / "scenarios" / "test"
+    scenario_dir.mkdir(parents=True)
+
+    scenario = Scenario(name="test-scenario", path=scenario_dir, prompt="Fix the bug", skill_sets=[])
+    skill_set = SkillSet(name="with-skill", model="sonnet", skills=["skills/my-skill"])
+
+    runner = Runner(evals_dir=evals_dir)
+    run_dir = runner.create_run_dir()
+
+    def mock_run_claude(env_dir, prompt, mcp_config_path, allowed_tools, model=None, strict_mcp_config=True, ctx_logger=None, extra_env=None):
+        return (
+            {
+                "output_text": "Done",
+                "skills_invoked": ["my-skill"],
+                "tools_used": [],
+                "skills_available": ["my-skill", "design-sync", "verify"],
+            },
+            True,
+            None,
+            "",
+        )
+
+    with patch.object(runner, "run_claude", side_effect=mock_run_claude):
+        runner.run_scenario(scenario, skill_set, run_dir)
+
+    import yaml
+
+    metadata = yaml.safe_load((run_dir / "test-scenario" / "with-skill" / "metadata.yaml").read_text())
+    assert metadata["skills_available"] == ["my-skill"]
+    assert metadata["skills_available_other"] == ["design-sync", "verify"]
 
 
 def test_runner_is_url_detection(tmp_path: Path) -> None:

--- a/evals/tests/test_runner.py
+++ b/evals/tests/test_runner.py
@@ -549,8 +549,8 @@ def test_run_parallel_executes_all_tasks(tmp_path: Path) -> None:
         skill_sets=[],
     )
 
-    skill_set1 = SkillSet(name="skill-set-1", skills=[])
-    skill_set2 = SkillSet(name="skill-set-2", skills=[])
+    skill_set1 = SkillSet(name="skill-set-1", model="sonnet", skills=[])
+    skill_set2 = SkillSet(name="skill-set-2", model="sonnet", skills=[])
 
     tasks = [
         RunTask(scenario=scenario1, skill_set=skill_set1, run_dir=run_dir),
@@ -602,7 +602,7 @@ def test_run_parallel_calls_progress_callback(tmp_path: Path) -> None:
     )
 
     tasks = [
-        RunTask(scenario=scenario, skill_set=SkillSet(name=f"set-{i}", skills=[]), run_dir=run_dir)
+        RunTask(scenario=scenario, skill_set=SkillSet(name=f"set-{i}", model="sonnet", skills=[]), run_dir=run_dir)
         for i in range(3)
     ]
 
@@ -647,8 +647,8 @@ def test_run_parallel_handles_task_failure(tmp_path: Path) -> None:
     )
 
     tasks = [
-        RunTask(scenario=scenario, skill_set=SkillSet(name="success", skills=[]), run_dir=run_dir),
-        RunTask(scenario=scenario, skill_set=SkillSet(name="failure", skills=[]), run_dir=run_dir),
+        RunTask(scenario=scenario, skill_set=SkillSet(name="success", model="sonnet", skills=[]), run_dir=run_dir),
+        RunTask(scenario=scenario, skill_set=SkillSet(name="failure", model="sonnet", skills=[]), run_dir=run_dir),
     ]
 
     def mock_run_scenario(scenario, skill_set, run_dir):
@@ -698,7 +698,7 @@ def test_run_parallel_respects_max_workers(tmp_path: Path) -> None:
     )
 
     tasks = [
-        RunTask(scenario=scenario, skill_set=SkillSet(name=f"set-{i}", skills=[]), run_dir=run_dir)
+        RunTask(scenario=scenario, skill_set=SkillSet(name=f"set-{i}", model="sonnet", skills=[]), run_dir=run_dir)
         for i in range(6)
     ]
 
@@ -907,6 +907,7 @@ def test_run_scenario_appends_extra_prompt(tmp_path: Path) -> None:
 
     skill_set = SkillSet(
         name="with-extra",
+        model="sonnet",
         skills=[],
         extra_prompt="Check if any skill can help.",
     )
@@ -916,7 +917,7 @@ def test_run_scenario_appends_extra_prompt(tmp_path: Path) -> None:
 
     captured_prompt = None
 
-    def mock_run_claude(env_dir, prompt, mcp_config_path, allowed_tools, ctx_logger=None, extra_env=None):
+    def mock_run_claude(env_dir, prompt, mcp_config_path, allowed_tools, model=None, strict_mcp_config=True, ctx_logger=None, extra_env=None):
         nonlocal captured_prompt
         captured_prompt = prompt
         return {"output_text": "Done", "skills_invoked": [], "tools_used": []}, True, None, ""
@@ -947,6 +948,7 @@ def test_run_scenario_no_extra_prompt_unchanged(tmp_path: Path) -> None:
 
     skill_set = SkillSet(
         name="no-extra",
+        model="sonnet",
         skills=[],
         # No extra_prompt set (defaults to "")
     )
@@ -956,7 +958,7 @@ def test_run_scenario_no_extra_prompt_unchanged(tmp_path: Path) -> None:
 
     captured_prompt = None
 
-    def mock_run_claude(env_dir, prompt, mcp_config_path, allowed_tools, ctx_logger=None, extra_env=None):
+    def mock_run_claude(env_dir, prompt, mcp_config_path, allowed_tools, model=None, strict_mcp_config=True, ctx_logger=None, extra_env=None):
         nonlocal captured_prompt
         captured_prompt = prompt
         return {"output_text": "Done", "skills_invoked": [], "tools_used": []}, True, None, ""
@@ -999,6 +1001,171 @@ def test_run_claude_normal_completion(tmp_path: Path) -> None:
 
     assert success is True
     assert error is None
+
+
+def test_run_claude_passes_model_flag(tmp_path: Path) -> None:
+    """run_claude includes --model <model> in the claude command when given."""
+    import io
+
+    evals_dir = tmp_path / "evals"
+    evals_dir.mkdir()
+    env_dir = tmp_path / "env"
+    env_dir.mkdir()
+    (env_dir / ".claude").mkdir()
+
+    runner = Runner(evals_dir=evals_dir)
+
+    mock_proc = MagicMock()
+    mock_proc.poll.side_effect = [None, 0]
+    mock_proc.returncode = 0
+    mock_proc.stdout = io.StringIO('{"type":"result","result":"done"}\n')
+    mock_proc.stderr = io.StringIO("")
+
+    with patch.object(runner_module.subprocess, "Popen", return_value=mock_proc) as mock_popen:
+        with patch.object(runner_module.select, "select", return_value=([mock_proc.stdout], [], [])):
+            runner.run_claude(env_dir, "test prompt", model="sonnet", timeout=10, stall_timeout=5)
+
+    cmd = mock_popen.call_args.args[0]
+    assert "--model" in cmd
+    assert cmd[cmd.index("--model") + 1] == "sonnet"
+
+
+def test_run_claude_omits_model_flag_when_not_given(tmp_path: Path) -> None:
+    """run_claude does not add --model when no model is passed."""
+    import io
+
+    evals_dir = tmp_path / "evals"
+    evals_dir.mkdir()
+    env_dir = tmp_path / "env"
+    env_dir.mkdir()
+    (env_dir / ".claude").mkdir()
+
+    runner = Runner(evals_dir=evals_dir)
+
+    mock_proc = MagicMock()
+    mock_proc.poll.side_effect = [None, 0]
+    mock_proc.returncode = 0
+    mock_proc.stdout = io.StringIO('{"type":"result","result":"done"}\n')
+    mock_proc.stderr = io.StringIO("")
+
+    with patch.object(runner_module.subprocess, "Popen", return_value=mock_proc) as mock_popen:
+        with patch.object(runner_module.select, "select", return_value=([mock_proc.stdout], [], [])):
+            runner.run_claude(env_dir, "test prompt", timeout=10, stall_timeout=5)
+
+    cmd = mock_popen.call_args.args[0]
+    assert "--model" not in cmd
+
+
+def test_run_claude_adds_strict_mcp_config_by_default(tmp_path: Path) -> None:
+    """run_claude adds --strict-mcp-config unless explicitly disabled."""
+    import io
+
+    evals_dir = tmp_path / "evals"
+    evals_dir.mkdir()
+    env_dir = tmp_path / "env"
+    env_dir.mkdir()
+    (env_dir / ".claude").mkdir()
+
+    runner = Runner(evals_dir=evals_dir)
+
+    mock_proc = MagicMock()
+    mock_proc.poll.side_effect = [None, 0]
+    mock_proc.returncode = 0
+    mock_proc.stdout = io.StringIO('{"type":"result","result":"done"}\n')
+    mock_proc.stderr = io.StringIO("")
+
+    with patch.object(runner_module.subprocess, "Popen", return_value=mock_proc) as mock_popen:
+        with patch.object(runner_module.select, "select", return_value=([mock_proc.stdout], [], [])):
+            runner.run_claude(env_dir, "test prompt", timeout=10, stall_timeout=5)
+
+    cmd = mock_popen.call_args.args[0]
+    assert "--strict-mcp-config" in cmd
+
+
+def test_run_claude_can_disable_strict_mcp_config(tmp_path: Path) -> None:
+    """run_claude omits --strict-mcp-config when strict_mcp_config=False."""
+    import io
+
+    evals_dir = tmp_path / "evals"
+    evals_dir.mkdir()
+    env_dir = tmp_path / "env"
+    env_dir.mkdir()
+    (env_dir / ".claude").mkdir()
+
+    runner = Runner(evals_dir=evals_dir)
+
+    mock_proc = MagicMock()
+    mock_proc.poll.side_effect = [None, 0]
+    mock_proc.returncode = 0
+    mock_proc.stdout = io.StringIO('{"type":"result","result":"done"}\n')
+    mock_proc.stderr = io.StringIO("")
+
+    with patch.object(runner_module.subprocess, "Popen", return_value=mock_proc) as mock_popen:
+        with patch.object(runner_module.select, "select", return_value=([mock_proc.stdout], [], [])):
+            runner.run_claude(env_dir, "test prompt", strict_mcp_config=False, timeout=10, stall_timeout=5)
+
+    cmd = mock_popen.call_args.args[0]
+    assert "--strict-mcp-config" not in cmd
+
+
+def test_run_scenario_passes_skill_set_model_to_run_claude(tmp_path: Path) -> None:
+    """run_scenario forwards skill_set.model to run_claude."""
+    from skill_eval.models import Scenario, SkillSet
+
+    evals_dir = tmp_path / "evals"
+    evals_dir.mkdir()
+    (evals_dir / "runs").mkdir()
+
+    scenario_dir = tmp_path / "scenarios" / "test"
+    scenario_dir.mkdir(parents=True)
+
+    scenario = Scenario(name="test-scenario", path=scenario_dir, prompt="Fix the bug", skill_sets=[])
+    skill_set = SkillSet(name="opus-set", model="opus", skills=[])
+
+    runner = Runner(evals_dir=evals_dir)
+    run_dir = runner.create_run_dir()
+
+    captured_model = None
+
+    def mock_run_claude(env_dir, prompt, mcp_config_path, allowed_tools, model=None, strict_mcp_config=True, ctx_logger=None, extra_env=None):
+        nonlocal captured_model
+        captured_model = model
+        return {"output_text": "Done", "skills_invoked": [], "tools_used": []}, True, None, ""
+
+    with patch.object(runner, "run_claude", side_effect=mock_run_claude):
+        runner.run_scenario(scenario, skill_set, run_dir)
+
+    assert captured_model == "opus"
+
+
+def test_run_scenario_passes_skill_set_strict_mcp_config_to_run_claude(tmp_path: Path) -> None:
+    """run_scenario forwards skill_set.strict_mcp_config to run_claude."""
+    from skill_eval.models import Scenario, SkillSet
+
+    evals_dir = tmp_path / "evals"
+    evals_dir.mkdir()
+    (evals_dir / "runs").mkdir()
+
+    scenario_dir = tmp_path / "scenarios" / "test"
+    scenario_dir.mkdir(parents=True)
+
+    scenario = Scenario(name="test-scenario", path=scenario_dir, prompt="Fix the bug", skill_sets=[])
+    skill_set = SkillSet(name="opt-out", model="sonnet", skills=[], strict_mcp_config=False)
+
+    runner = Runner(evals_dir=evals_dir)
+    run_dir = runner.create_run_dir()
+
+    captured_strict = None
+
+    def mock_run_claude(env_dir, prompt, mcp_config_path, allowed_tools, model=None, strict_mcp_config=True, ctx_logger=None, extra_env=None):
+        nonlocal captured_strict
+        captured_strict = strict_mcp_config
+        return {"output_text": "Done", "skills_invoked": [], "tools_used": []}, True, None, ""
+
+    with patch.object(runner, "run_claude", side_effect=mock_run_claude):
+        runner.run_scenario(scenario, skill_set, run_dir)
+
+    assert captured_strict is False
 
 
 def test_run_claude_total_timeout(tmp_path: Path) -> None:
@@ -1146,6 +1313,7 @@ def test_setup_commands_run_in_env_dir(tmp_path: Path) -> None:
 
     skill_set = SkillSet(
         name="with-setup",
+        model="sonnet",
         skills=[],
         setup=["echo $MY_VAR > setup_output.txt"],
     )
@@ -1153,7 +1321,7 @@ def test_setup_commands_run_in_env_dir(tmp_path: Path) -> None:
     runner = Runner(evals_dir=evals_dir)
     run_dir = runner.create_run_dir()
 
-    def mock_run_claude(env_dir, prompt, mcp_config_path, allowed_tools, ctx_logger=None, extra_env=None):
+    def mock_run_claude(env_dir, prompt, mcp_config_path, allowed_tools, model=None, strict_mcp_config=True, ctx_logger=None, extra_env=None):
         # Verify setup command ran and created the file
         output_file = env_dir / "setup_output.txt"
         assert output_file.exists()
@@ -1186,6 +1354,7 @@ def test_setup_command_failure_stops_run(tmp_path: Path) -> None:
 
     skill_set = SkillSet(
         name="bad-setup",
+        model="sonnet",
         skills=[],
         setup=["exit 1"],
     )

--- a/evals/tests/test_runner.py
+++ b/evals/tests/test_runner.py
@@ -195,6 +195,25 @@ def test_parse_json_output_counts_repeated_tool_calls(tmp_path: Path) -> None:
     assert sorted(result["tools_used"]) == ["Grep", "Read"]
 
 
+def test_parse_json_output_returns_tools_used_in_sorted_order(tmp_path: Path) -> None:
+    """tools_used/subagent_tools_used are sorted for stable metadata.yaml output."""
+    evals_dir = tmp_path / "evals"
+    evals_dir.mkdir()
+    runner = Runner(evals_dir=evals_dir)
+
+    ndjson = """{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Write","input":{}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Grep","input":{}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{}}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Task","input":{}}]},"parent_tool_use_id":null}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{}}]},"parent_tool_use_id":"toolu_task1"}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{}}]},"parent_tool_use_id":"toolu_task1"}"""
+
+    result = runner._parse_json_output(ndjson)
+
+    assert result["tools_used"] == ["Grep", "Read", "Task", "Write"]
+    assert result["subagent_tools_used"] == ["Bash", "Read"]
+
+
 def test_parse_json_output_handles_empty_input(tmp_path: Path) -> None:
     """NDJSON parser handles empty input gracefully."""
     evals_dir = tmp_path / "evals"


### PR DESCRIPTION
## Summary

Four independent fixes/features to the `evals/` skill-eval tool, all found while running real A/B comparisons against the Internal Analytics dbt Cloud project:

- **Require an explicit `model` per skill-set, default to `--strict-mcp-config`.** Runs previously fell back to whatever the `claude` CLI's built-in default model was (silently ran on Opus instead of the configured Sonnet), and could pick up unrelated MCP servers from Claude Desktop/`~/.claude.json`/project config. `model` is now required and validated at load time; `--strict-mcp-config` is on by default (opt out with `strict_mcp_config: false`). Backfills `model: sonnet` into the scenarios already tracked in this repo.
- **Make run metadata reflect what actually happened.** `skills_available` was including globally-installed plugin/marketplace skills that have nothing to do with the eval, inflating skill-usage percentages — now scoped to the skills the set's own `skills:` list added (`skills_available_other` keeps the rest for visibility). `tool_call_count` now counts every call, not just distinct tool names. Subagent (`Task` tool) activity — which previously got merged into the main thread's counters, including subagent narration leaking into `output.md` and getting graded as the main answer — is now tracked separately (`subagents_used`, `subagent_count`, `subagent_tools_used`, `subagent_tool_call_count`).
- **Single sortable review page instead of one tab per transcript.** `skill-eval review` now generates `review.html` in the run directory — one sortable table with model/result/score/duration/turns/tool calls/subagents/skills/MCP servers/cost/tokens plus links to each transcript and output — and opens that one page. `--tabs` preserves the old per-transcript behavior.
- **Fix `grade` command printing `None`.** `grade --auto` (and the manual-grade hint) echoed the raw `run_id` argument, which is `None` when resolved via `--latest`/interactively rather than passed explicitly.

## Test plan

- [x] `uv run pytest` passes at each commit in isolation (182 tests at HEAD)
- [x] `uv run ty check src/` clean
- [x] Verified end-to-end against a real dbt Cloud project: `--model`/`--strict-mcp-config` land correctly in the `claude` invocation, `mcp_servers` metadata is now scoped to just the configured server, `skills_available` no longer lists unrelated global skills, subagent split correctly isolates a real subagent's tool calls from the main thread, and the generated `review.html` renders cost/tokens/subagent columns correctly against real run data